### PR TITLE
Make use of path.join for cross-platform

### DIFF
--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -5,9 +5,10 @@ var glob = require('glob')
 var _    = require('lodash')
 
 module.exports = {
-  entry: _.keyBy(glob.sync('../app/javascript/packs/*.js'), function(entry) { return path.basename(entry, '.js') }),
+  entry: _.keyBy(glob.sync(path.join('..', 'app', 'javascript', 'packs', '*.js')),
+    function(entry) { return path.basename(entry, '.js') }),
 
-  output: { filename: '[name].js', path: '../public/packs' },
+  output: { filename: '[name].js', path: path.join('..', 'public', 'packs') },
 
   module: {
     loaders: [


### PR DESCRIPTION
Hi :)

We should use `path.join` for cross platform.

Cheers.