### PR TITLE
Require `lodash.keyby` instead of `lodash`

### DIFF
--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -1,11 +1,11 @@
 // Note: You must restart bin/webpack-watcher for changes to take effect
 
-var path = require('path')
-var glob = require('glob')
-var _    = require('lodash')
+var path  = require('path')
+var glob  = require('glob')
+var keyBy = require('lodash.keyby')
 
 module.exports = {
-  entry: _.keyBy(glob.sync(path.join('..', 'app', 'javascript', 'packs', '*.js')),
+  entry: keyBy(glob.sync(path.join('..', 'app', 'javascript', 'packs', '*.js')),
     function(entry) { return path.basename(entry, '.js') }),
 
   output: { filename: '[name].js', path: path.join('..', 'public', 'packs') },


### PR DESCRIPTION
I tried this gem with `rails5.0.1.rc1` , and I got an error when execute `bin/webpack-watcher`:

```
$ » bin/webpack-watcher
todo/config/webpack/shared.js:8
  entry: _.keyBy(glob.sync('../app/javascript/packs/*.js'), function(entry) { return path.basename(entry, '.js') }),
           ^

TypeError: _.keyBy is not a function
    at Object.<anonymous> (todo/config/webpack/shared.js:8:12)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (todo/config/webpack/development.js:7:31)
    at Module._compile (module.js:541:32)
```

The lodash that I installed version is `4.17.2` (latest version for now) and lodash `4.17.2` does not include function `keyBy`.  `keyBy` is exported as an other  [npm package](https://www.npmjs.com/package/lodash.keyby).

So I think we should require `lodash.keyby` in `shared.js` to use `keyBy`.