### PR TITLE
fix node_modules path

### DIFF
--- a/lib/install/bin/webpack.tt
+++ b/lib/install/bin/webpack.tt
@@ -7,7 +7,7 @@ APP_PATH    = File.expand_path('../', __dir__)
 VENDOR_PATH = File.expand_path('../vendor', __dir__)
 
 SET_NODE_PATH  = "NODE_PATH=#{VENDOR_PATH}/node_modules"
-WEBPACK_BIN    = "./node_modules/webpack/bin/webpack.js"
+WEBPACK_BIN    = "../node_modules/webpack/bin/webpack.js"
 WEBPACK_CONFIG = "#{APP_PATH}/config/webpack/#{WEBPACK_ENV}.js"
 
 Dir.chdir(VENDOR_PATH) do


### PR DESCRIPTION
By default, node packages are installed in the node_modules folder in root project