### PR TITLE
Add yarn binstub

### DIFF
--- a/lib/install/bin/yarn.tt
+++ b/lib/install/bin/yarn.tt
@@ -1,0 +1,10 @@
+<%= shebang %>
+VENDOR_PATH = File.expand_path('../vendor', __dir__)
+Dir.chdir(VENDOR_PATH) do
+  begin
+    exec "yarnpkg #{ARGV.join(" ")}"
+  rescue Errno::ENOENT
+    puts "Yarn executable was not detected in the system."
+    puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+  end
+end


### PR DESCRIPTION
I added the yarn binstub because we cannot run `rails webpacker:install` on apps predating Rails 5.1.