### PR TITLE
Save babel-preset-react to devDependencies

### DIFF
--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -34,6 +34,6 @@ namespace :webpacker do
       puts "Couldn't automatically update loader presets in #{config_path}. Please set presets: ['react', 'es2015']."
     end
 
-    exec './bin/yarn add babel-preset-react react react-dom'
+    exec './bin/yarn add --dev babel-preset-react && ./bin/yarn add react react-dom'
   end
 end


### PR DESCRIPTION
Change `babel-preset-react` package dependency from `dependencies` to `devDependencies`.

The generated `package.json` will be as follows:

```json
{
  "name": "webpacker-react",
  "private": true,
  "dependencies": {
    "react": "^15.4.1",
    "react-dom": "^15.4.1"
  },
  "devDependencies": {
    "babel-core": "^6.20.0",
    "babel-loader": "^6.2.9",
    "babel-preset-es2015": "^6.18.0",
    "babel-preset-react": "^6.16.0",
    "coffee-loader": "^0.7.2",
    "coffee-script": "^1.12.1",
    "webpack": "^1.14.0",
    "webpack-merge": "^1.1.1"
  }
}
```