### PR TITLE
Use old fashioned tag code

### DIFF
--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -2,6 +2,6 @@ require 'webpacker/source'
 
 module Webpacker::Helper
   def javascript_pack_tag(name, **options)
-    tag.script src: Webpacker::Source.new(name).path, **options
+    tag('script', src: Webpacker::Source.new(name).path, **options)
   end
 end


### PR DESCRIPTION
The new `tag.script` code is not available on `5-0-stable`; it is onl
available on Rails master, which is tracking 5.1.

Discovered this while trying to write a test for this helper method. :)