### PR TITLE
Add rails-erb-loader for ERB support

### DIFF
--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -2,11 +2,12 @@
 
 var path = require('path')
 var glob = require('glob')
+var extname = require('path-complete-extname')
 
 module.exports = {
-  entry: glob.sync(path.join('..', 'app', 'javascript', 'packs', '*.js')).reduce(
+  entry: glob.sync(path.join('..', 'app', 'javascript', 'packs', '*.js*')).reduce(
     function(map, entry) {
-      basename = path.basename(entry, '.js')
+      basename = path.basename(entry, extname(entry))
       map[basename] = entry;
       return map;
     }, {}
@@ -16,15 +17,25 @@ module.exports = {
 
   module: {
     loaders: [
-      { test: /\.coffee$/, loader: "coffee-loader" },
+      { test: /\.coffee(.erb)?$/, loader: "coffee-loader" },
       {
-        test: /\.js$/,
+        test: /\.js(.erb)?$/,
         exclude: /node_modules/,
         loader: 'babel-loader',
         query: {
           presets: ['es2015']
         }
       }
+    ],
+
+    preLoaders: [
+      {
+        test: /\.erb$/,
+        loader: 'rails-erb-loader',
+        query: {
+          runner: '../bin/rails runner'
+        }
+      },
     ]
   },
 

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -13,7 +13,7 @@ append_to_file '.gitignore', <<-EOS
 public/packs/*
 EOS
 
-run './bin/yarn add --dev webpack webpack-merge babel-loader babel-core babel-preset-es2015 coffee-loader coffee-script'
+run './bin/yarn add --dev webpack webpack-merge path-complete-extname babel-loader babel-core babel-preset-es2015 coffee-loader coffee-script rails-erb-loader'
 
 environment \
   "# Make javascript_pack_tag lookup digest hash to enable long-term caching\n" +


### PR DESCRIPTION
This allow to get support for ERB inside of JS files, e.g you can put Ruby code inside of a .js.erb file to be able to access to asset pipeline files:

```js
// app/javascripts/packs/application.js.erb
var imgPath = '<%= ActionController::Base.helpers.asset_path "rails.png" %>';
console.log(imgPath);
```

is compiled to:

```js
var a="/assets/rails-03bb170d74e34a9d3ab9157113c6ab68d2eb4a61a1a7ec5f77e45bc55d9e168e.png";
console.log(a);
```