### PR TITLE
added lib/install/vue/hello_vue.js, rails webpacker:install:vue

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ make any changes for a basic setup out the box. But this is where you do go if y
 more advanced.
 
 The configuration for what Webpack is supposed to compile by default rests on the convention that
-every file in app/javascript/packs/* should be turned into their own output files (or entry points, 
+every file in app/javascript/packs/* should be turned into their own output files (or entry points,
 as Webpack calls it).
 
 Let's say you're building a calendar. Your structure could look like this:
@@ -65,6 +65,10 @@ To use Webpacker with React, just create a new app with `rails new myapp --webpa
 will be added via yarn and changes to the configuration files made. Now you can create JSX files and
 have them properly compiled automatically.
 
+## Ready for Vue
+
+To use Webpacker with React, just create a new app with `rails new myapp --webpack=vue` (or run `rails webpacker:install:vue` on a Rails 5.1 app already setup with webpack), and all the relevant dependencies
+will be added via yarn and changes to the configuration files made. 
 
 ## Work left to do
 

--- a/README.md
+++ b/README.md
@@ -61,14 +61,12 @@ pipeline does it.
 
 ## Ready for React
 
-To use Webpacker with React, just create a new app with `rails new myapp --webpack=react` (or run `rails webpacker:install:react` on a Rails 5.1 app already setup with webpack), and all the relevant dependencies
-will be added via yarn and changes to the configuration files made. Now you can create JSX files and
+To use Webpacker with React, just create a new app with `rails new myapp --webpack=react` (or run `rails webpacker:install:react` on a Rails 5.1 app already setup with webpack), and all the relevant dependencies will be added via yarn and changes to the configuration files made. Now you can create JSX files and
 have them properly compiled automatically.
 
 ## Ready for Vue
 
-To use Webpacker with React, just create a new app with `rails new myapp --webpack=vue` (or run `rails webpacker:install:vue` on a Rails 5.1 app already setup with webpack), and all the relevant dependencies
-will be added via yarn and changes to the configuration files made. 
+To use Webpacker with Vue, just create a new app with `rails new myapp --webpack=vue` (or run `rails webpacker:install:vue` on a Rails 5.1 app already setup with webpack), and all the relevant dependencies will be added via yarn and changes to the configuration files made.
 
 ## Work left to do
 

--- a/lib/install/vue/hello_vue.js
+++ b/lib/install/vue/hello_vue.js
@@ -1,0 +1,16 @@
+// Run this example by adding <%= javascript_pack_tag 'hello_vue' %> to the head of your layout file,
+// like app/views/layouts/application.html.erb. All it does is render <div>Hello Vue</div> at the bottom
+// of the page.
+
+import Vue from 'vue'
+
+document.addEventListener("DOMContentLoaded", e => {
+  document.body.appendChild(document.createElement('hello'))
+  new Vue({
+    el: 'hello',
+    data: { name: "Vue" },
+    render(createElement) {
+      return createElement('div',{},["Hello " + this.name])
+    },
+  });
+})

--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -48,5 +48,34 @@ namespace :webpacker do
 
       exec './bin/yarn add --dev babel-preset-react && ./bin/yarn add react react-dom'
     end
+
+    desc "install everything needed for vue"
+    task :vue do
+      config_path = Rails.root.join('config/webpack/shared.js')
+      config = File.read(config_path)
+
+      if config.include?("presets: ['es2015']")
+        puts "Replacing loader presets to include react in #{config_path}"
+        config.gsub!(/presets: \['es2015'\]/, "presets: ['react', 'es2015']")
+      else
+        puts "Couldn't automatically update loader presets in #{config_path}. Please set presets: ['react', 'es2015']."
+      end
+
+      if config.include?("test: /\\.js$/")
+        puts "Replacing loader test to include jsx in #{config_path}"
+        config.gsub!("test: /\\.js$/", "test: /\\.jsx?$/")
+      else
+        puts "Couldn't automatically update loader test in #{config_path}. Please set test: /\.jsx?$/."
+      end
+
+      File.write config_path, config
+
+      puts "Copying react example to app/javascript/packs/hello_vue.js"
+      FileUtils.copy File.expand_path('../install/vue/hello_vue.js', File.dirname(__FILE__)),
+        Rails.root.join('app/javascript/packs/hello_vue.js')
+
+      exec './bin/yarn add --dev babel-preset-react  && ./bin/yarn add vue vue-loader vuex vue-resource vue-router vue-validator'
+
+    end
   end
 end


### PR DESCRIPTION
First draft. Open for discussion if necessary. 

- `rails webpacker:install:vue` will ship with Vue 2.0 and its arsenal of tools (vuex, vue-router, vue-validator, vue-loader + vue-resource) 
- `vue/hello_vue.js` renders "Hello Vue" at the bottom of the page. `hello_vue.js` did not use Vue's JSX yet. Vue's JSX may require [babel-plugin-transform-vue-jsx](https://github.com/vuejs/babel-plugin-transform-vue-jsx) as a plugin.
```
Vue.component('jsx-example', {
  render (h) { // <-- h must be in scope
    return <div id="foo">bar</div>
  }
})
``` 
- Used the React's presets because I can't find a working Vue's presets. Known presets on Evan You's npm does not work when I do `webpacker:compile`. 

Suggestion, do we wish to change `app/javascript/packs/*.js` to `app/packs/javascript/*js`? Because we may require a `app/packs/templates/*.jsx or *.vue` next time? And IMO a javascript directory at the same level as assets, may be confusing. 

Please let me know your thoughts. 