### PR TITLE
Update javascript_pack_tag helper

### DIFF
--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -15,6 +15,6 @@ module Webpacker::Helper
   #   <%= javascript_pack_tag 'calendar', 'data-turbolinks-track': 'reload' %> # =>
   #   <script src="/packs/calendar-1016838bab065ae1e314.js" data-turbolinks-track="reload"></script>
   def javascript_pack_tag(name, **options)
-    tag('script', src: Webpacker::Source.new(name).path, **options)
+    content_tag('script', '', src: Webpacker::Source.new(name).path, **options)
   end
 end


### PR DESCRIPTION
With the current implementation of the `javascript_pack_tag` helper I was getting a self closing script tag (tested on Rails `master`).

I was getting HTML parsing errors from my browser (latest Chrome) because self-closing script tag is not really valid HTML 5.
So like the current implementation of `javascript_include_tag` I propose to always use an empty content tag to avoid any compatibility problems.

Thanks!
