### PR TITLE
Reflect other changes in configuration after switching to Webpack 2

### DIFF
--- a/lib/install/config/development.js
+++ b/lib/install/config/development.js
@@ -7,9 +7,15 @@ var merge   = require('webpack-merge')
 var config = require('./shared.js')
 
 module.exports = merge(config, {
-  displayErrorDetails: true,
-  outputPathinfo: true,
   devtool: 'sourcemap',
+
+  stats: {
+    errorDetails: true
+  },
+
+  output: {
+    pathinfo: true
+  },
 
   plugins: [
     new webpack.LoaderOptionsPlugin({


### PR DESCRIPTION
After switching to Webpack 2.2, any Rails' Webpack command fails on the following issue:

```
$ bin/webpack
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration has an unknown property 'outputPathinfo'. These properties are valid:
   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry, externals?, loader?, module?, name?, node?, output?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, stats?, target?, watch?, watchOptions? }
   For typos: please correct them.
   For loader options: webpack 2 no longer allows custom properties in configuration.
     Loaders should be updated to allow passing options via loader options in module.rules.
     Until loaders are updated one can use the LoaderOptionsPlugin to pass these options to the loader:
     plugins: [
       new webpack.LoaderOptionsPlugin({
         // test: /\.xxx$/, // may apply this only for some modules
         options: {
           outputPathinfo: ...
         }
       })
     ]
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration has an unknown property 'outputPathinfo'. These properties are valid:
   object { amd?, bail?, cache?, context?, dependencies?, devServer?, devtool?, entry, externals?, loader?, module?, name?, node?, output?, performance?, plugins?, profile?, recordsInputPath?, recordsOutputPath?, recordsPath?, resolve?, resolveLoader?, stats?, target?, watch?, watchOptions? }
   For typos: please correct them.
   For loader options: webpack 2 no longer allows custom properties in configuration.
     Loaders should be updated to allow passing options via loader options in module.rules.
     Until loaders are updated one can use the LoaderOptionsPlugin to pass these options to the loader:
     plugins: [
       new webpack.LoaderOptionsPlugin({
         // test: /\.xxx$/, // may apply this only for some modules
         options: {
           outputPathinfo: ...
         }
       })
     ]
```

Unfortunately, Webpack 2.x has many improvements since Webpack 1.x. The following changes haven't been reflected in PR #27 in `config/development.js`.

- `displayErrorDetails: true` became `stats.errorDetails: true`. See https://webpack.js.org/configuration/stats/#stats
- `outputPathinfo: true` became `output.pathinfo: true`. See https://webpack.js.org/configuration/output/#output-pathinfo

After these changes, any Rails' Webpack command works.

```
$ bin/webpack
Hash: 9c473eec14e1e3000365
Version: webpack 2.2.0-rc.0
Time: 2310ms
             Asset     Size  Chunks             Chunk Names
    hello_react.js   780 kB       0  [emitted]  [big]hello_react
    application.js  3.42 kB       1  [emitted]  application
hello_react.js.map   866 kB       0  [emitted]  hello_react
application.js.map  3.35 kB       1  [emitted]  application
 [177] ../app/javascript/packs/application.js 511 bytes {1} [built]
 [178] ../app/javascript/packs/hello_react.js 2.71 kB {0} [built]
    + 177 hidden modules
```

