### PR TITLE
Change the capitalization of tasks description

### DIFF
--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -4,7 +4,7 @@ PACK_DIGESTS_PATH = PACKS_PATH.join('digests.json')
 WEBPACKER_APP_TEMPLATE_PATH = File.expand_path('../install/template.rb', File.dirname(__FILE__))
 
 namespace :webpacker do
-  desc "compile javascript packs using webpack for production with digests"
+  desc "Compile javascript packs using webpack for production with digests"
   task :compile do
     webpack_digests_json = JSON.parse(`WEBPACK_ENV=production ./bin/webpack --json`)['assetsByChunkName'].to_json
 
@@ -15,13 +15,13 @@ namespace :webpacker do
     puts webpack_digests_json
   end
 
-  desc "install webpacker in this application"
+  desc "Install webpacker in this application"
   task :install do
     exec "./bin/rails app:template LOCATION=#{WEBPACKER_APP_TEMPLATE_PATH}"
   end
 
   namespace :install do
-    desc "install everything needed for react"
+    desc "Install everything needed for react"
     task :react do
       config_path = Rails.root.join('config/webpack/shared.js')
       config = File.read(config_path)


### PR DESCRIPTION
```ruby
# bundle exec rails --tasks
#...
rails stats                          # Report code statistics (KLOCs, etc) from the application or engine
rails test                           # Runs all tests in test folder
rails test:db                        # Run tests quickly, but also reset db
rails time:zones[country_or_offset]  # List all time zones, list by two-letter country code (`rails time:zones[US]`), or list by UTC offset (`rails time:zones[-8]`)
rails tmp:clear                      # Clear cache and socket files from tmp/ (narrow w/ tmp:cache:clear, tmp:sockets:clear)
rails tmp:create                     # Creates tmp directories for cache, sockets, and pids
rails webpacker:compile              # compile javascript packs using webpack for production with digests
rails webpacker:install              # install webpacker in this application
rails webpacker:install:react        # install everything needed for react
```

All the tasks have a capitalized description.