### PR TITLE
Add support for webpack-dev-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,21 @@ or you can add the gem and run `bin/rails webpacker:install` in an existing appl
 
 ## Binstubs
 
-Webpacker ships with two binstubs: `./bin/webpack` and `./bin/webpack-watcher`. They're both thin wrappers
-around the standard webpack.js executable, just to ensure that the right configuration
+Webpacker ships with three binstubs: `./bin/webpack`, `./bin/webpack-watcher` and `./bin/webpack-dev-server`.
+They're thin wrappers around the standard webpack.js executable, just to ensure that the right configuration
 file is loaded and the node_modules from vendor are used.
 
 In development, you'll need to run `./bin/webpack-watcher` in a separate terminal from
 `./bin/rails server` to have your `app/javascript/packs/*.js` files compiled as you make changes.
 If you'd rather not have to run the two processes separately by hand, you can use
 [Foreman](http://ddollar.github.io/foreman/).
+
+Alternatively, you can run `./bin/webpack-dev-server`. This will launch a
+[Webpack Dev Server](https://webpack.github.io/docs/webpack-dev-server.html) listening on http://localhost:8080/
+serving your pack files. It will recompile your files as you make changes. You also need to set
+`config.x.webpacker[:dev_server_host]` in your `config/environment/development.rb` to tell Webpacker to load
+your packs from the Webpack Dev Server. This setup allows you to leverage advanced Webpack features, such
+as [Hot Module Replacement](https://webpack.github.io/docs/hot-module-replacement-with-webpack.html).
 
 
 ## Configuration

--- a/lib/install/bin/webpack-dev-server.tt
+++ b/lib/install/bin/webpack-dev-server.tt
@@ -1,0 +1,23 @@
+<%= shebang %>
+
+RAILS_ENV   = ENV['RAILS_ENV'] || 'development'
+WEBPACK_ENV = ENV['WEBPACK_ENV'] || RAILS_ENV
+
+APP_PATH    = File.expand_path('../', __dir__)
+VENDOR_PATH = File.expand_path('../vendor', __dir__)
+
+SET_NODE_PATH  = "NODE_PATH=#{VENDOR_PATH}/node_modules"
+WEBPACKER_BIN    = "./node_modules/.bin/webpack-dev-server"
+WEBPACK_CONFIG = "#{APP_PATH}/config/webpack/#{WEBPACK_ENV}.js"
+
+# Warn the user if the configuration is not set
+RAILS_ENV_CONFIG = File.join("config", "environments", "#{RAILS_ENV}.rb")
+
+# Look into the environment file for a non-commented variable declaration
+unless File.foreach(File.join(APP_PATH, RAILS_ENV_CONFIG)).detect { |line| line.match(/^\s*[^#]*config\.x\.webpacker\[\:dev_server_host\].*=/) }
+  puts "Warning: if you want to use webpack-dev-server, you need to tell Webpacker to serve asset packs from it. Please set config.x.webpacker[:dev_server_host] in #{RAILS_ENV_CONFIG}.\n\n"
+end
+
+Dir.chdir(VENDOR_PATH) do
+  exec "#{SET_NODE_PATH} #{WEBPACKER_BIN} --config #{WEBPACK_CONFIG} --content-base public/packs #{ARGV.join(" ")}"
+end

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -14,9 +14,14 @@ public/packs/*
 /vendor/node_modules/*
 EOS
 
-run './bin/yarn add --dev webpack@beta webpack-merge path-complete-extname babel-loader babel-core babel-preset-latest coffee-loader coffee-script rails-erb-loader'
+run './bin/yarn add --dev webpack@beta webpack-merge webpack-dev-server@beta path-complete-extname babel-loader babel-core babel-preset-latest coffee-loader coffee-script rails-erb-loader'
 
 environment \
   "# Make javascript_pack_tag lookup digest hash to enable long-term caching\n" +
   "  config.x.webpacker[:digesting] = true\n",
   env: 'production'
+
+environment \
+  "# Make javascript_pack_tag load assets from webpack-dev-server.\n" +
+  "  # config.x.webpacker[:dev_server_host] = \"http://localhost:8080\"\n",
+  env: 'development'

--- a/lib/webpacker/source.rb
+++ b/lib/webpacker/source.rb
@@ -8,7 +8,9 @@ class Webpacker::Source
   end
 
   def path
-    if digesting?
+    if config[:dev_server_host].present?
+      "#{config[:dev_server_host]}/#{filename}"
+    elsif config[:digesting]
       "/packs/#{digested_filename}"
     else
       "/packs/#{filename}"
@@ -18,8 +20,8 @@ class Webpacker::Source
   private
     attr_accessor :name
 
-    def digesting?
-      Rails.configuration.x.webpacker[:digesting]
+    def config
+      Rails.configuration.x.webpacker
     end
 
     def digested_filename


### PR DESCRIPTION
As discussed in #52, here is a proposal.
Documentation needs to be done, but I wanted some feedback first.

This is the simplest implementation possible I think. An alternative to install `webpack-dev-server` when installing Webpacker would be to add a check in `bin/webpack-dev-server` and ask the user to add it to `vendor/package.json` and run Yarn.
Another solution would be to not install the binstub, and create a new `webpack::install::dev_server` generator.

Note: this does not enable Hot Module Reloading or anything special, it only serves the packs using `webpack-dev-server` running on port 8080 by default. Adding HMR requires changes to your Webpack config (and changes to your application code / React integration / ... to be really useful) and I would prefer the user or a plugin to do it (I plan to add this to my React integration gem).

Any thoughts ?