### PR TITLE
Set minimize context for production

### DIFF
--- a/lib/install/config/production.js
+++ b/lib/install/config/production.js
@@ -10,6 +10,8 @@ module.exports = merge(config, {
   output: { filename: "[name]-[hash].js" },
 
   plugins: [
-    new webpack.optimize.UglifyJsPlugin(),
+    new webpack.LoaderOptionsPlugin({
+      minimize: true
+    })
   ]
 })


### PR DESCRIPTION
Per the webpack 2 [documentation](https://webpack.js.org/guides/migrating/#uglifyjsplugin-minimize-loaders)

> UglifyJsPlugin no longer switches loaders into minimize mode. The minimize: true setting needs to be passed via loader options in long-term. See loader documentation for relevant options.
>
> The minimize mode for loaders will be removed in webpack 3 or later.

