### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ in the future.
 You can either make use of Webpacker during setup of a new application with `--webpack`
 or you can add the gem and run `bin/rails webpacker:install` in an existing application.
 
-As the version published on rubygems isn't maintained yet, please include the gem directly from GitHub:
+As the rubygems version isn't promised to be kept up to date until the release of Rails 5.1, you may want to include the gem directly from GitHub:
 
 ```ruby
 gem 'webpacker', git: 'https://github.com/rails/webpacker.git', branch: 'master'

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ or you can add the gem and run `bin/rails webpacker:install` in an existing appl
 As the rubygems version isn't promised to be kept up to date until the release of Rails 5.1, you may want to include the gem directly from GitHub:
 
 ```ruby
-gem 'webpacker', git: 'https://github.com/rails/webpacker.git', branch: 'master'
+gem 'webpacker', github: 'rails/webpacker'
 ```
 
 ## Binstubs

--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@ even JavaScript Sprinkles (that all continues to live in app/assets).
 
 It's designed to work with Rails 5.1+ and makes use of the [Yarn](https://yarnpkg.com/) dependency management
 that's been made default from that version forward.
-It's also currently compatible with Rails 5.0 stable but there's absolutely no warranty
-it will still be in the future.
+
+## Installation
+
+Webpacker is currently compatible with Rails 5.0 stable, but there's no guarantee it will still be
+in the future.
+
 You can either make use of Webpacker during setup of a new application with `--webpack`
 or you can add the gem and run `bin/rails webpacker:install` in an existing application.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ it will still be in the future.
 You can either make use of Webpacker during setup of a new application with `--webpack`
 or you can add the gem and run `bin/rails webpacker:install` in an existing application.
 
+As the version published on rubygems isn't maintained yet, please include the gem directly from GitHub:
+
+```ruby
+gem 'webpacker', git: 'https://github.com/rails/webpacker.git', branch: 'master'
+```
 
 ## Binstubs
 


### PR DESCRIPTION
The `webpacker` gem on rubygems is outdated and broken in rails 5.0, so I've updated the README to clarify that. I've also separated the installation instructions into its own section.