### PR TITLE
Can link to sprockets assets using rails-erb-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,7 @@ to your javascript file, then you can use Sprockets' asset helpers:
 var railsImagePath = "<%= helpers.image_path('rails.png') %>";
 ```
 
-This is enabled by the `rails-erb-loader` loader rule in `config/webpack/shared.js`. If you need
-to extend this functionality to work for file extensions besides `.js`, you'll need to edit this
-rule.
+This is enabled by the `rails-erb-loader` loader rule in `config/webpack/shared.js`. 
 
 ## Ready for React
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ will invoke the production configuration, which includes digesting. The `javascr
 method will automatically insert the correct digest when run in production mode. Just like the asset
 pipeline does it.
 
+## Linking to sprockets assets
+
+It's possible to link to assets that have been precompiled by sprockets. Add the `.erb` extension 
+to your javascript file, then you can use Sprockets' asset helpers:
+
+``` 
+// app/javascript/my_pack/example.js.erb
+
+<% helpers = ActionController::Base.helpers %>
+var railsImagePath = "<%= helpers.image_path('rails.png') %>";
+```
+
+This is enabled by the `rails-erb-loader` loader rule in `config/webpack/shared.js`. If you need
+to extend this functionality to work for file extensions besides `.js`, you'll need to edit this
+rule.
 
 ## Ready for React
 
@@ -91,7 +106,8 @@ have them properly compiled automatically.
 
 ## Work left to do
 
-- Make asset pipeline digests readable from webpack, so you can reference images etc
+- Improve process for linking to assets compiled by sprockets - shouldn't need to specify
+` <% helpers = ActionController::Base.helpers %>` at the beginning of each file
 - Consider chunking setup
 - Consider on-demand compiling with digests when digesting=true
 - I'm sure a ton of other shit

--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -29,11 +29,12 @@ module.exports = {
         }
       },
       {
-        test: /\.erb$/,
+        test: /.erb$/,
         enforce: 'pre',
+        exclude: /node_modules/,
         loader: 'rails-erb-loader',
         options: {
-          runner: '../bin/rails runner'
+          runner: 'DISABLE_SPRING=1 ../bin/rails runner'
         }
       },
     ]


### PR DESCRIPTION
Using rails-erb-loader, it's possible to use the sprockets asset helpers. 

It's not ideal to have to specify `helpers = ActionController::Base.helpers` at the beginning of each file, but it's the best simple solution I've thought of so far.

rails-erb-loader also seems to have problems with spring, so I've just disabled it.

I tested this in both development & production modes, and it works with and without sprockets adding digest hashes.