### PR TITLE
Shared configs. Default variables. Fixed task. Cleanup. Composite patch.

### DIFF
--- a/lib/install/config/development.js
+++ b/lib/install/config/development.js
@@ -4,9 +4,9 @@ var path    = require('path')
 var webpack = require('webpack')
 var merge   = require('webpack-merge')
 
-var config = require('./shared.js')
+var sharedConfig = require('./shared.js')
 
-module.exports = merge(config, {
+module.exports = merge(sharedConfig.config, {
   devtool: 'sourcemap',
 
   stats: {

--- a/lib/install/config/production.js
+++ b/lib/install/config/production.js
@@ -7,7 +7,7 @@ var merge   = require('webpack-merge')
 var sharedConfig = require('./shared.js')
 
 module.exports = merge(sharedConfig.config, {
-  output: { filename: "[name]-[hash].js" },
+  output: { filename: '[name]-[hash].js' },
 
   plugins: [
     new webpack.LoaderOptionsPlugin({

--- a/lib/install/config/production.js
+++ b/lib/install/config/production.js
@@ -4,10 +4,10 @@ var path    = require('path')
 var webpack = require('webpack')
 var merge   = require('webpack-merge')
 
-var config = require('./shared.js')
+var sharedConfig = require('./shared.js')
 
-module.exports = merge(config, {
-  output: { filename: '[name]-[hash].js' },
+module.exports = merge(sharedConfig.config, {
+  output: { filename: "[name]-[hash].js" },
 
   plugins: [
     new webpack.LoaderOptionsPlugin({

--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -1,10 +1,16 @@
 // Note: You must restart bin/webpack-watcher for changes to take effect
 
 var path = require('path')
+var process = require('process')
 var glob = require('glob')
 var extname = require('path-complete-extname')
+var distPath = process.env.WEBPACK_DIST_PATH
 
-module.exports = {
+if(distPath === undefined) {
+  distPath = 'packs'
+}
+
+config = {
   entry: glob.sync(path.join('..', 'app', 'javascript', 'packs', '*.js*')).reduce(
     function(map, entry) {
       var basename = path.basename(entry, extname(entry))
@@ -13,7 +19,7 @@ module.exports = {
     }, {}
   ),
 
-  output: { filename: '[name].js', path: path.resolve('..', 'public', 'packs') },
+  output: { filename: '[name].js', path: path.resolve('..', 'public', distPath) },
 
   module: {
     rules: [
@@ -53,4 +59,9 @@ module.exports = {
   resolveLoader: {
     modules: [ path.resolve('../vendor/node_modules') ]
   }
+}
+
+module.exports = {
+  distPath: distPath,
+  config: config
 }

--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -1,17 +1,17 @@
-PACKS_PATH        = Rails.root.join('public/packs')
-PACK_DIGESTS_PATH = PACKS_PATH.join('digests.json')
-
 WEBPACKER_APP_TEMPLATE_PATH = File.expand_path('../install/template.rb', __dir__)
 
 namespace :webpacker do
   desc "Compile javascript packs using webpack for production with digests"
-  task :compile do
+  task :compile => :environment do
     webpack_digests_json = JSON.parse(`WEBPACK_ENV=production ./bin/webpack --json`)['assetsByChunkName'].to_json
 
-    FileUtils.mkdir_p(PACKS_PATH)
-    File.open(PACK_DIGESTS_PATH, 'w+') { |file| file.write webpack_digests_json }
+    digests_path = Rails.application.config.x.webpacker[:digests_path]
+    packs_path = File.dirname(digests_path)
 
-    puts "Compiled digests for all packs in #{PACK_DIGESTS_PATH}: "
+    FileUtils.mkdir_p(packs_path)
+    File.open(digests_path, 'w+') { |file| file.write webpack_digests_json }
+
+    puts "Compiled digests for all packs in #{digests_path}: "
     puts webpack_digests_json
   end
 

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -13,9 +13,10 @@ class Webpacker::Engine < ::Rails::Engine
 
     if app.config.x.webpacker[:digesting]
       app.config.x.webpacker[:digests_path] ||= \
-        Rails.root.join('public', \
-                        app.config.x.webpacker[:packs_dist_path], \
+        Rails.root.join('public',
+                        app.config.x.webpacker[:packs_dist_path],
                         'digests.json')
+
       Webpacker::Digests.load \
         app.config.x.webpacker[:digests_path]
     end

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -4,16 +4,20 @@ require 'webpacker/helper'
 require 'webpacker/digests'
 
 class Webpacker::Engine < ::Rails::Engine
-  initializer :webpacker do
+  initializer :webpacker do |app|
     ActiveSupport.on_load :action_controller do
       ActionController::Base.helper Webpacker::Helper
     end
 
-    if Rails.configuration.x.webpacker[:digesting]
-      Rails.application.config.x.webpacker[:digests_path] ||= \
-        Rails.root.join('public/packs/digests.json')
+    app.config.x.webpacker[:packs_dist_path] ||= '/packs'
+
+    if app.config.x.webpacker[:digesting]
+      app.config.x.webpacker[:digests_path] ||= \
+        Rails.root.join('public', \
+                        app.config.x.webpacker[:packs_dist_path], \
+                        'digests.json')
       Webpacker::Digests.load \
-        Rails.application.config.x.webpacker[:digests_path]
+        app.config.x.webpacker[:digests_path]
     end
   end
 end

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -10,9 +10,10 @@ class Webpacker::Engine < ::Rails::Engine
     end
 
     if Rails.configuration.x.webpacker[:digesting]
+      Rails.application.config.x.webpacker[:digests_path] ||= \
+        Rails.root.join('public/packs/digests.json')
       Webpacker::Digests.load \
-        Rails.application.config.x.webpacker[:digests_path] ||
-          Rails.root.join('public/packs/digests.json')
+        Rails.application.config.x.webpacker[:digests_path]
     end
   end
 end

--- a/lib/webpacker/source.rb
+++ b/lib/webpacker/source.rb
@@ -11,7 +11,7 @@ class Webpacker::Source
     if config[:dev_server_host].present?
       "#{config[:dev_server_host]}/#{filename}"
     elsif config[:digesting]
-      "/packs/#{digested_filename}"
+      "/#{dist}/#{digested_filename}"
     else
       "/packs/#{filename}"
     end
@@ -26,6 +26,10 @@ class Webpacker::Source
 
     def digested_filename
       Webpacker::Digests.lookup(name)
+    end
+
+    def dist
+      config[:dist] || 'packs'
     end
 
     def filename

--- a/lib/webpacker/source.rb
+++ b/lib/webpacker/source.rb
@@ -11,9 +11,9 @@ class Webpacker::Source
     if config[:dev_server_host].present?
       "#{config[:dev_server_host]}/#{filename}"
     elsif config[:digesting]
-      "/#{dist}/#{digested_filename}"
+      File.join(dist_path, digested_filename)
     else
-      "/packs/#{filename}"
+      File.join(dist_path, filename)
     end
   end
 
@@ -28,8 +28,8 @@ class Webpacker::Source
       Webpacker::Digests.lookup(name)
     end
 
-    def dist
-      config[:dist] || 'packs'
+    def dist_path
+      config[:packs_dist_path]
     end
 
     def filename


### PR DESCRIPTION
So here it is. Something like composite patch.
Maybe some comments here.

- Shared options per webpack config. Useful to share same data between both config's, For example here i provide path which can (and seriously *must*) be used in build cleaner's.
- Defaults for `:digests_path`.
- `:packs_dist_path`: Destination folder, useful way to extract production builds and/or change location of dev build.
- Fixed per chunk array problem, it is when we builds SourceMap for prod.

And few cleanup's.

P.S. I can close my previous one.