### PR TITLE
Expose `RAILS_ENV` as `process.env.NODE_ENV`

### DIFF
--- a/lib/install/bin/webpack-dev-server.tt
+++ b/lib/install/bin/webpack-dev-server.tt
@@ -2,14 +2,13 @@
 
 RAILS_ENV   = ENV['RAILS_ENV'] || 'development'
 NODE_ENV    = ENV['NODE_ENV'] || RAILS_ENV
-WEBPACK_ENV = ENV['WEBPACK_ENV'] || RAILS_ENV
 
 APP_PATH    = File.expand_path('../', __dir__)
 VENDOR_PATH = File.expand_path('../vendor', __dir__)
 
 SET_NODE_PATH  = "NODE_PATH=#{VENDOR_PATH}/node_modules"
 WEBPACKER_BIN    = "./node_modules/.bin/webpack-dev-server"
-WEBPACK_CONFIG = "#{APP_PATH}/config/webpack/#{WEBPACK_ENV}.js"
+WEBPACK_CONFIG = "#{APP_PATH}/config/webpack/#{NODE_ENV}.js"
 
 # Warn the user if the configuration is not set
 RAILS_ENV_CONFIG = File.join("config", "environments", "#{RAILS_ENV}.rb")

--- a/lib/install/bin/webpack-dev-server.tt
+++ b/lib/install/bin/webpack-dev-server.tt
@@ -1,6 +1,7 @@
 <%= shebang %>
 
 RAILS_ENV   = ENV['RAILS_ENV'] || 'development'
+NODE_ENV    = ENV['NODE_ENV'] || RAILS_ENV
 WEBPACK_ENV = ENV['WEBPACK_ENV'] || RAILS_ENV
 
 APP_PATH    = File.expand_path('../', __dir__)

--- a/lib/install/bin/webpack.tt
+++ b/lib/install/bin/webpack.tt
@@ -1,6 +1,7 @@
 <%= shebang %>
 
 RAILS_ENV   = ENV['RAILS_ENV'] || 'development'
+NODE_ENV    = ENV['NODE_ENV'] || RAILS_ENV
 WEBPACK_ENV = ENV['WEBPACK_ENV'] || RAILS_ENV
 
 APP_PATH    = File.expand_path('../', __dir__)

--- a/lib/install/bin/webpack.tt
+++ b/lib/install/bin/webpack.tt
@@ -2,14 +2,13 @@
 
 RAILS_ENV   = ENV['RAILS_ENV'] || 'development'
 NODE_ENV    = ENV['NODE_ENV'] || RAILS_ENV
-WEBPACK_ENV = ENV['WEBPACK_ENV'] || RAILS_ENV
 
 APP_PATH    = File.expand_path('../', __dir__)
 VENDOR_PATH = File.expand_path('../vendor', __dir__)
 
 SET_NODE_PATH  = "NODE_PATH=#{VENDOR_PATH}/node_modules"
 WEBPACK_BIN    = "./node_modules/webpack/bin/webpack.js"
-WEBPACK_CONFIG = "#{APP_PATH}/config/webpack/#{WEBPACK_ENV}.js"
+WEBPACK_CONFIG = "#{APP_PATH}/config/webpack/#{NODE_ENV}.js"
 
 Dir.chdir(VENDOR_PATH) do
   exec "#{SET_NODE_PATH} #{WEBPACK_BIN} --config #{WEBPACK_CONFIG} #{ARGV.join(" ")}"

--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -48,7 +48,7 @@ config = {
   },
 
   plugins: [
-    new webpack.EnvironmentPluginDefinePlugin(Object.keys(process.env))
+    new webpack.EnvironmentPlugin(Object.keys(process.env))
   ],
 
   resolve: {

--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -1,5 +1,6 @@
 // Note: You must restart bin/webpack-watcher for changes to take effect
 
+var webpack = require('webpack')
 var path = require('path')
 var process = require('process')
 var glob = require('glob')
@@ -46,7 +47,13 @@ config = {
     ]
   },
 
-  plugins: [],
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        'NODE_ENV': JSON.stringify(process.env.RAILS_ENV)
+      }
+    })
+  ],
 
   resolve: {
     extensions: [ '.js', '.coffee' ],

--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -48,11 +48,7 @@ config = {
   },
 
   plugins: [
-    new webpack.DefinePlugin({
-      'process.env': {
-        'NODE_ENV': JSON.stringify(process.env.RAILS_ENV)
-      }
-    })
+    new webpack.EnvironmentPluginDefinePlugin(Object.keys(process.env))
   ],
 
   resolve: {

--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -5,10 +5,10 @@ namespace :webpacker do
   desc "Compile javascript packs using webpack for production with digests"
   task :compile => :environment do
     dist_path = Rails.application.config.x.webpacker[:packs_dist_path]
-    result    = `WEBPACK_DIST_PATH=#{dist_path} WEBPACK_ENV=production ./bin/webpack --json`
-    
+    result    = `WEBPACK_DIST_PATH=#{dist_path} NODE_ENV=production ./bin/webpack --json`
+
     exit! $?.exitstatus unless $?.success?
-    
+
     webpack_digests = JSON.parse(result)['assetsByChunkName'].each_with_object({}) do |(chunk, file), h|
       h[chunk] = file.is_a?(Array) ? file.find {|f| REGEX_MAP !~ f } : file
     end.to_json


### PR DESCRIPTION
As seen in [optimizing performance][1], React makes use of the `process.env.NODE_ENV` to conditionally exclude code when creating a production build.

This pull request uses exposes the value of `RAILS_ENV` inside the packs, so webpack can take advantage of it and make the production build smaller.

With a fresh Rails 5 app, this is the size before the change:
```
$ RAILS_ENV=production bin/webpack
Hash: 205a8b63e1f09ece9742
Version: webpack 2.2.0
Time: 1900ms
                              Asset     Size  Chunks                    Chunk Names
hello_react-205a8b63e1f09ece9742.js   728 kB       0  [emitted]  [big]  hello_react
application-205a8b63e1f09ece9742.js  3.01 kB       1  [emitted]         application
...
```

And this is after:
```
$ RAILS_ENV=production bin/webpack
Hash: b2c19f7c4e64877b870a
Version: webpack 2.2.0
Time: 1559ms
                              Asset     Size  Chunks                    Chunk Names
hello_react-b2c19f7c4e64877b870a.js   669 kB       0  [emitted]  [big]  hello_react
application-b2c19f7c4e64877b870a.js  3.01 kB       1  [emitted]         application
...
```



[1]: https://github.com/facebook/react/blob/30c7c4fbe6f35af93ddec0c7ae661d592821b296/docs/docs/optimizing-performance.md

