### PR TITLE
Implements webpacker:install:angular rake task and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,17 +83,17 @@ pipeline does it.
 
 ## Linking to sprockets assets
 
-It's possible to link to assets that have been precompiled by sprockets. Add the `.erb` extension 
+It's possible to link to assets that have been precompiled by sprockets. Add the `.erb` extension
 to your javascript file, then you can use Sprockets' asset helpers:
 
-``` 
+```
 // app/javascript/my_pack/example.js.erb
 
 <% helpers = ActionController::Base.helpers %>
 var railsImagePath = "<%= helpers.image_path('rails.png') %>";
 ```
 
-This is enabled by the `rails-erb-loader` loader rule in `config/webpack/shared.js`. 
+This is enabled by the `rails-erb-loader` loader rule in `config/webpack/shared.js`.
 
 ## Ready for React
 
@@ -101,6 +101,9 @@ To use Webpacker with React, just create a new app with `rails new myapp --webpa
 will be added via yarn and changes to the configuration files made. Now you can create JSX files and
 have them properly compiled automatically.
 
+## Ready for Angular with TypeScript
+
+To use Webpacker with Angular, just create a new app with `rails new myapp --webpack=angular` (or run `rails webpacker:install:angular` on a Rails 5.1 app already setup with webpack). TypeScript support and the Angular core libraires will be added via yarn and changes to the configuration files made. An example component written in TypeScript is also added to your project in `app/javascript` so that you can experiment Angular right away.
 
 ## Work left to do
 

--- a/lib/install/angular/hello_angular.js
+++ b/lib/install/angular/hello_angular.js
@@ -1,0 +1,7 @@
+// Run this Angular example by adding the following HTML markup to your view:
+//
+// <hello-angular>Loading...</hello-angular>
+//
+// <%= javascript_pack_tag 'hello_angular' %>
+
+require("hello_angular")

--- a/lib/install/angular/hello_angular/app/app.component.ts
+++ b/lib/install/angular/hello_angular/app/app.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'hello-angular',
+  template: `<h1>Hello {{name}}</h1>`
+})
+export class AppComponent {
+  name = 'Angular!';
+}

--- a/lib/install/angular/hello_angular/app/app.module.ts
+++ b/lib/install/angular/hello_angular/app/app.module.ts
@@ -1,0 +1,16 @@
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+
+import { AppComponent } from './app.component';
+
+@NgModule({
+  declarations: [
+    AppComponent
+  ],
+  imports: [
+    BrowserModule
+  ],
+  providers: [],
+  bootstrap: [AppComponent]
+})
+export class AppModule { }

--- a/lib/install/angular/hello_angular/index.ts
+++ b/lib/install/angular/hello_angular/index.ts
@@ -1,0 +1,6 @@
+import './polyfills.ts';
+
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic().bootstrapModule(AppModule);

--- a/lib/install/angular/hello_angular/polyfills.ts
+++ b/lib/install/angular/hello_angular/polyfills.ts
@@ -1,0 +1,19 @@
+// This file includes polyfills needed by Angular and is loaded before
+// the app. You can add your own extra polyfills to this file.
+import 'core-js/es6/symbol';
+import 'core-js/es6/object';
+import 'core-js/es6/function';
+import 'core-js/es6/parse-int';
+import 'core-js/es6/parse-float';
+import 'core-js/es6/number';
+import 'core-js/es6/math';
+import 'core-js/es6/string';
+import 'core-js/es6/date';
+import 'core-js/es6/array';
+import 'core-js/es6/regexp';
+import 'core-js/es6/map';
+import 'core-js/es6/set';
+import 'core-js/es6/reflect';
+
+import 'core-js/es7/reflect';
+import 'zone.js/dist/zone';

--- a/lib/install/angular/tsconfig.json
+++ b/lib/install/angular/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "declaration": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "lib": ["es6", "dom"],
+    "module": "es6",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "target": "es5",
+    "baseUrl": "./vendor/node_modules"
+  },
+  "exclude": [
+    "**/*.spec.ts",
+    "vendor/node_modules"
+  ],
+  "compileOnSave": false
+}

--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -48,6 +48,42 @@ namespace :webpacker do
 
       exec './bin/yarn add --dev babel-preset-react && ./bin/yarn add react react-dom'
     end
+
+    desc "Install everything needed for Angular"
+    task :angular do
+      config_path = Rails.root.join('config/webpack/shared.js')
+      config = File.read(config_path)
+
+      if config.include?('ts-loader')
+        puts "The configuration file already has a reference to ts-loader, skipping the test rule..."
+      else
+        puts "Adding a loader rule to include ts-loader for .ts files in #{config_path}..."
+        config.gsub!(/rules:(\s*\[)(\s*\{)/, "rules:\\1\\2 test: /\.ts$/, loader: 'ts-loader' },\\2")
+      end
+
+      if config =~ /["'].ts["']/
+        puts "The configuration file already has a reference to .ts extension, skipping the addition of this extension to the list..."
+      else
+        puts "Adding '.ts' in loader extensions in #{config_path}..."
+        config.gsub!(/extensions:(.*')(\s*\])/, "extensions:\\1, '.ts'\\2")
+      end
+
+      File.write config_path, config
+
+      puts "Copying Angular example to app/javascript/packs/hello_angular.js"
+      FileUtils.copy File.expand_path('../install/angular/hello_angular.js', File.dirname(__FILE__)),
+        Rails.root.join('app/javascript/packs/hello_angular.js')
+
+      puts "Copying Angular Hello app to app/javascript/hello_angular"
+      FileUtils.copy_entry File.expand_path('../install/angular/hello_angular', File.dirname(__FILE__)),
+        Rails.root.join('app/javascript/hello_angular')
+
+      puts "Copying tsconfig.json to the Rails root directory"
+      FileUtils.copy File.expand_path('../install/angular/tsconfig.json', File.dirname(__FILE__)),
+        Rails.root.join('tsconfig.json')
+
+      exec './bin/yarn add --dev typescript ts-loader && ./bin/yarn add "core-js zone.js rxjs @angular/core @angular/common @angular/compiler @angular/platform-browser @angular/platform-browser-dynamic"'
+    end
   end
 end
 


### PR DESCRIPTION
This PR implements `rake webpacker:install:angular` to setup webpack with TypeScript support, the Angular core librairies and a nice 'Hello Angular' example component.
