### PR TITLE
use File.exist? instead of File.exists?

### DIFF
--- a/lib/webpacker/digests.rb
+++ b/lib/webpacker/digests.rb
@@ -32,7 +32,7 @@ class Webpacker::Digests
 
   private
     def load
-      if File.exists?(@path)
+      if File.exist?(@path)
         JSON.parse(File.read(@path))
       else
         Rails.logger.info "Didn't find any digests file at #{@path}. You must first compile the packs via rails webpacker:compile"


### PR DESCRIPTION
File.exists? is deprecated in Ruby 2.1+
Ref: https://github.com/ruby/ruby/blob/v2_1_2/file.c#L1413