### PR TITLE
Typo in default javascript pack

### DIFF
--- a/lib/install/config/production.js
+++ b/lib/install/config/production.js
@@ -7,7 +7,7 @@ var merge   = require('webpack-merge')
 var config = require('./shared.js')
 
 module.exports = merge(config, {
-  output: { filename: "[name]-[hash].js" },
+  output: { filename: '[name]-[hash].js' },
 
   plugins: [
     new webpack.LoaderOptionsPlugin({

--- a/lib/install/javascript/packs/application.js
+++ b/lib/install/javascript/packs/application.js
@@ -1,9 +1,9 @@
-// This file is will automatically compiled by Webpack, along with any other files
+// This file is automatically compiled by Webpack, along with any other files
 // present in this directory. You're encouraged to place your actual application logic in
-// a relevant structure within app/javascript, and only use these pack files to reference
-// that code, so it'll be compiled.
+// a relevant structure within app/javascript and only use these pack files to reference
+// that code so it'll be compiled.
 //
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
 
-console.log("Hello World from Webpacker")
+console.log('Hello World from Webpacker')


### PR DESCRIPTION
- Fixed some grammar in the default javascript pack `javascript/packs/application.js`
- Changed double quotes to single quotes for consistency in `config/production.js`