### PR TITLE
Don’t crash if sprockets is absent

### DIFF
--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -88,6 +88,8 @@ namespace :webpacker do
 end
 
 # Compile packs after we've compiled all other assets during precompilation
-Rake::Task['assets:precompile'].enhance do
-  Rake::Task['webpacker:compile'].invoke
+if Rake::Task.task_defined?('assets:precompile')
+  Rake::Task['assets:precompile'].enhance do
+    Rake::Task['webpacker:compile'].invoke
+  end
 end


### PR DESCRIPTION
Currently Webpacker has an implicit dependency on Sprockets. Webpacker enhances `assets:precompile` so trying to run any rake task will fail if webpacker is in the Gemfile but Sprockets hasn’t been initialized.

This PR fixes that issue.

A good next step might be to define `assets:precompile` to `webpacker:compile` if the former is absent, for compatibility with existing tooling.