### PR TITLE
Add option to use rails root for node

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ As the rubygems version isn't promised to be kept up to date until the release o
 gem 'webpacker', github: 'rails/webpacker'
 ```
 
+
+## Installing outside of vendor
+
+By default, `webpacker:install` uses `vendor` as the root path for yarn. This can cause problems for tooling, node modules and Javascript developers, all of whom expect Javascript source code to be in a subdirectory of the yarn root path.
+
+To install to the application root, run `bin/rails webpacker:install:root`. Everything else should work normally.
+
 ## Binstubs
 
 Webpacker ships with three binstubs: `./bin/webpack`, `./bin/webpack-watcher` and `./bin/webpack-dev-server`.

--- a/lib/install/bin/webpack-dev-server.tt
+++ b/lib/install/bin/webpack-dev-server.tt
@@ -1,12 +1,14 @@
 <%= shebang %>
 
+<% yarn_root = ENV['WEBPACKER_TARGET'] == 'root' ? 'APP_PATH' : 'VENDOR_PATH' %>
+
 RAILS_ENV   = ENV['RAILS_ENV'] || 'development'
 WEBPACK_ENV = ENV['WEBPACK_ENV'] || RAILS_ENV
 
 APP_PATH    = File.expand_path('../', __dir__)
-VENDOR_PATH = File.expand_path('../vendor', __dir__)
+<%= "VENDOR_PATH = File.expand_path('../vendor', __dir__)" unless ENV['WEBPACKER_TARGET'] == 'root' %>
 
-SET_NODE_PATH  = "NODE_PATH=#{VENDOR_PATH}/node_modules"
+SET_NODE_PATH  = "NODE_PATH=#{<%= yarn_root %>}/node_modules"
 WEBPACKER_BIN    = "./node_modules/.bin/webpack-dev-server"
 WEBPACK_CONFIG = "#{APP_PATH}/config/webpack/#{WEBPACK_ENV}.js"
 
@@ -18,6 +20,6 @@ unless File.foreach(File.join(APP_PATH, RAILS_ENV_CONFIG)).detect { |line| line.
   puts "Warning: if you want to use webpack-dev-server, you need to tell Webpacker to serve asset packs from it. Please set config.x.webpacker[:dev_server_host] in #{RAILS_ENV_CONFIG}.\n\n"
 end
 
-Dir.chdir(VENDOR_PATH) do
+Dir.chdir(<%= yarn_root %>) do
   exec "#{SET_NODE_PATH} #{WEBPACKER_BIN} --config #{WEBPACK_CONFIG} --content-base public/packs #{ARGV.join(" ")}"
 end

--- a/lib/install/bin/webpack.tt
+++ b/lib/install/bin/webpack.tt
@@ -1,15 +1,17 @@
 <%= shebang %>
 
+<% yarn_root = ENV['WEBPACKER_TARGET'] == 'root' ? 'APP_PATH' : 'VENDOR_PATH' %>
+
 RAILS_ENV   = ENV['RAILS_ENV'] || 'development'
 WEBPACK_ENV = ENV['WEBPACK_ENV'] || RAILS_ENV
 
 APP_PATH    = File.expand_path('../', __dir__)
-VENDOR_PATH = File.expand_path('../vendor', __dir__)
+<%= "VENDOR_PATH = File.expand_path('../vendor', __dir__)" unless ENV['WEBPACKER_TARGET'] == 'root' %>
 
-SET_NODE_PATH  = "NODE_PATH=#{VENDOR_PATH}/node_modules"
+SET_NODE_PATH  = "NODE_PATH=#{<%= yarn_root %>}/node_modules"
 WEBPACK_BIN    = "./node_modules/webpack/bin/webpack.js"
 WEBPACK_CONFIG = "#{APP_PATH}/config/webpack/#{WEBPACK_ENV}.js"
 
-Dir.chdir(VENDOR_PATH) do
+Dir.chdir(<%= yarn_root %>) do
   exec "#{SET_NODE_PATH} #{WEBPACK_BIN} --config #{WEBPACK_CONFIG} #{ARGV.join(" ")}"
 end

--- a/lib/install/bin/yarn.tt
+++ b/lib/install/bin/yarn.tt
@@ -1,6 +1,8 @@
 <%= shebang %>
-VENDOR_PATH = File.expand_path('../vendor', __dir__)
-Dir.chdir(VENDOR_PATH) do
+<% yarn_root = ENV['WEBPACKER_TARGET'] == 'root' ? '../' : '../vendor' %>
+
+YARN_ROOT = File.expand_path('<%= yarn_root %>', __dir__)
+Dir.chdir(YARN_ROOT) do
   begin
     exec "yarnpkg #{ARGV.join(" ")}"
   rescue Errno::ENOENT

--- a/lib/install/config/shared.js.tt
+++ b/lib/install/config/shared.js.tt
@@ -1,11 +1,14 @@
 // Note: You must restart bin/webpack-watcher for changes to take effect
 
+<% app_root = ENV['WEBPACKER_TARGET'] == 'root' ? '.' : '..' %>
+<% node_modules_path = ENV['WEBPACKER_TARGET'] == 'root' ? 'node_modules' : '../vendor/node_modules' %>
+
 var path = require('path')
 var glob = require('glob')
 var extname = require('path-complete-extname')
 
 module.exports = {
-  entry: glob.sync(path.join('..', 'app', 'javascript', 'packs', '*.js*')).reduce(
+  entry: glob.sync(path.resolve('<%= app_root %>', 'app', 'javascript', 'packs', '*.js*')).reduce(
     function(map, entry) {
       var basename = path.basename(entry, extname(entry))
       map[basename] = entry
@@ -13,7 +16,7 @@ module.exports = {
     }, {}
   ),
 
-  output: { filename: '[name].js', path: path.resolve('..', 'public', 'packs') },
+  output: { filename: '[name].js', path: path.resolve('<%= app_root %>', 'public', 'packs') },
 
   module: {
     rules: [
@@ -34,7 +37,7 @@ module.exports = {
         exclude: /node_modules/,
         loader: 'rails-erb-loader',
         options: {
-          runner: 'DISABLE_SPRING=1 ../bin/rails runner'
+          runner: 'DISABLE_SPRING=1 <%= app_root %>/bin/rails runner'
         }
       },
     ]
@@ -45,12 +48,12 @@ module.exports = {
   resolve: {
     extensions: [ '.js', '.coffee' ],
     modules: [
-      path.resolve('../app/javascript'),
-      path.resolve('../vendor/node_modules')
+      path.resolve('<%= app_root %>/app/javascript'),
+      path.resolve('<%= node_modules_path %>')
     ]
   },
 
   resolveLoader: {
-    modules: [ path.resolve('../vendor/node_modules') ]
+    modules: [ path.resolve('<%= node_modules_path %>') ]
   }
 }

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -7,6 +7,8 @@ directory "#{__dir__}/config", 'config/webpack'
 
 append_to_file '.gitignore', <<-EOS
 /public/packs
+/node_modules
+/vendor/node_modules
 EOS
 
 run './bin/yarn add --dev webpack@beta webpack-merge webpack-dev-server@beta path-complete-extname babel-loader babel-core babel-preset-latest coffee-loader coffee-script rails-erb-loader glob'

--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -21,6 +21,11 @@ namespace :webpacker do
   end
 
   namespace :install do
+    desc "Install webpacker with package.json in the Rails root rather than vendor"
+    task :root do
+      exec "./bin/rails app:template LOCATION=#{WEBPACKER_APP_TEMPLATE_PATH} WEBPACKER_TARGET=root"
+    end
+
     desc "Install everything needed for react"
     task :react do
       config_path = Rails.root.join('config/webpack/shared.js')


### PR DESCRIPTION
I was reading through rails/rails#27245, and thought the best and most "Railsey" solution would be to use `vendor` by default but make other options easy as well.

This PR adds a new rake task, `webpacker:install:root`, which uses `Rails.root` as the root directory for yarn, installing `node_modules`, `package.json` and `yarn.lock` there.

`webpacker:install` continues to function as it always has, installing to `vendor`. 

This change is backwards compatible. It just adds some conditionals to the install template; none of the runtime or asset compilation code is affected. All of that as well as all of the instructions in the README still just work, whether you install to vendor or to root.

I think this is a good solution in that it leaves `vendor` as the default but puts the choice in the hands of early adopters, allowing you guys to gather feedback on both approaches.

**Why it's important to have this choice**

I know this has already been discussed, but I want to reiterate why it's important to have this as an option. The Javascript ecosystem has matured, and having `package.json` and `node_modules` in the project root (or at least above all JS code) is one of its few universals. Because of this:
- Using `vendor` breaks most existing tooling. It can be worked around in some cases, but not in others. E.g. I don't think there's any way at the moment to get Atom's `eslint` package to handle this without major nastiness. Bundling one-off solutions for every popular use case (eg #41) is not a great solution.
- Using `vendor` breaks `package.json` scripting, JS land's `bundle exec` / `rake` / binstubs. Instead JS commands have to be wrapped in bin scripts or rake tasks that call out to Javascript. This is gross to implement and especially painful on JRuby. Wouldn't it be nice just to run `yarn start` to boot up the frontend?
- If you're using webpack, your frontend is likely just as serious as your backend. Using `vendor` marginalizes the frontend.
- Using `vendor` raises the barrier to getting Javascript developers excited about Rails. Their tooling doesn't work, their conventions don't apply, they need to edit obscure Ruby files to do basic things they could otherwise do straightforwardly in JS. Rails has gotten a reputation as being behind the curve on modern frontend development. This won't help.

**Other notes / topics for bikeshedding**
- There aren't tests for this repo yet, so I made a little fixture app here to demonstrate that this works: https://github.com/dleavitt/webpacker-testcase
- Is `webpacker:install:root` the cleanest way to do this? Should it be a flag or something instead?
- Not sure what the best practice is for passing info to the `.tt` files. Currently just using an ENV var.
- Not sure if my variable names are the best.
- `webpacker:install:angular` won’t quite work out of the box after `webpacker:install:root` - a couple paths will need to be adjusted in the generated tsconfig file.
- This will probably necessitate corresponding changes to Rails’s yarn generator.

In summary:

![61790976](https://cloud.githubusercontent.com/assets/71686/22634324/6b9bb438-ebdd-11e6-8353-3a41ffd8ccb1.jpg)
