### PR TITLE
Add .babelrc when installing react

### DIFF
--- a/lib/install/react/.babelrc
+++ b/lib/install/react/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "react"]
+}

--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -46,6 +46,10 @@ namespace :webpacker do
 
       File.write config_path, config
 
+      puts "Copying .babelrc to project directory"
+      FileUtils.copy File.expand_path('../install/react/.babelrc', __dir__),
+        Rails.root
+
       puts "Copying react example to app/javascript/packs/hello_react.js"
       FileUtils.copy File.expand_path('../install/react/hello_react.js', __dir__),
         Rails.root.join('app/javascript/packs/hello_react.js')


### PR DESCRIPTION
React install was missing `.babelrc` so was throwing errors when I was running the build (unexpected `<` when getting to the JSX). This PR adds copying a `.babelrc` to the project root as part of the react install.