### PR TITLE
Use the project root (not vendor) as the yarn root

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ gem 'webpacker', github: 'rails/webpacker'
 
 Webpacker ships with three binstubs: `./bin/webpack`, `./bin/webpack-watcher` and `./bin/webpack-dev-server`.
 They're thin wrappers around the standard webpack.js executable, just to ensure that the right configuration
-file is loaded and the node_modules from vendor are used.
+file is loaded.
 
 
-A binstub is also created to install your npm dependencies declared in vendor,
+A binstub is also created to install your npm dependencies,
 and can be called via `./bin/yarn`.
 
 In development, you'll need to run `./bin/webpack-watcher` in a separate terminal from

--- a/lib/install/angular/tsconfig.json
+++ b/lib/install/angular/tsconfig.json
@@ -7,12 +7,12 @@
     "module": "es6",
     "moduleResolution": "node",
     "sourceMap": true,
-    "target": "es5",
-    "baseUrl": "./vendor/node_modules"
+    "target": "es5"
   },
   "exclude": [
     "**/*.spec.ts",
-    "vendor/node_modules"
+    "node_modules",
+    "public"
   ],
   "compileOnSave": false
 }

--- a/lib/install/bin/webpack-dev-server.tt
+++ b/lib/install/bin/webpack-dev-server.tt
@@ -4,9 +4,8 @@ RAILS_ENV   = ENV['RAILS_ENV'] || 'development'
 NODE_ENV    = ENV['NODE_ENV'] || RAILS_ENV
 
 APP_PATH    = File.expand_path('../', __dir__)
-VENDOR_PATH = File.expand_path('../vendor', __dir__)
 
-SET_NODE_PATH  = "NODE_PATH=#{VENDOR_PATH}/node_modules"
+SET_NODE_PATH  = "NODE_PATH=#{APP_PATH}/node_modules"
 WEBPACKER_BIN    = "./node_modules/.bin/webpack-dev-server"
 WEBPACK_CONFIG = "#{APP_PATH}/config/webpack/#{NODE_ENV}.js"
 
@@ -18,6 +17,6 @@ unless File.foreach(File.join(APP_PATH, RAILS_ENV_CONFIG)).detect { |line| line.
   puts "Warning: if you want to use webpack-dev-server, you need to tell Webpacker to serve asset packs from it. Please set config.x.webpacker[:dev_server_host] in #{RAILS_ENV_CONFIG}.\n\n"
 end
 
-Dir.chdir(VENDOR_PATH) do
+Dir.chdir(APP_PATH) do
   exec "#{SET_NODE_PATH} #{WEBPACKER_BIN} --config #{WEBPACK_CONFIG} --content-base #{APP_PATH}/public/packs #{ARGV.join(" ")}"
 end

--- a/lib/install/bin/webpack.tt
+++ b/lib/install/bin/webpack.tt
@@ -4,12 +4,11 @@ RAILS_ENV   = ENV['RAILS_ENV'] || 'development'
 NODE_ENV    = ENV['NODE_ENV'] || RAILS_ENV
 
 APP_PATH    = File.expand_path('../', __dir__)
-VENDOR_PATH = File.expand_path('../vendor', __dir__)
 
-SET_NODE_PATH  = "NODE_PATH=#{VENDOR_PATH}/node_modules"
+SET_NODE_PATH  = "NODE_PATH=#{APP_PATH}/node_modules"
 WEBPACK_BIN    = "./node_modules/webpack/bin/webpack.js"
 WEBPACK_CONFIG = "#{APP_PATH}/config/webpack/#{NODE_ENV}.js"
 
-Dir.chdir(VENDOR_PATH) do
+Dir.chdir(APP_PATH) do
   exec "#{SET_NODE_PATH} #{WEBPACK_BIN} --config #{WEBPACK_CONFIG} #{ARGV.join(" ")}"
 end

--- a/lib/install/bin/yarn.tt
+++ b/lib/install/bin/yarn.tt
@@ -1,6 +1,6 @@
 <%= shebang %>
-VENDOR_PATH = File.expand_path('../vendor', __dir__)
-Dir.chdir(VENDOR_PATH) do
+YARN_ROOT = File.expand_path('../', __dir__)
+Dir.chdir(YARN_ROOT) do
   begin
     exec "yarnpkg #{ARGV.join(" ")}"
   rescue Errno::ENOENT

--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -12,15 +12,15 @@ if(distDir === undefined) {
 }
 
 config = {
-  entry: glob.sync(path.join('..', 'app', 'javascript', 'packs', '*.js*')).reduce(
+  entry: glob.sync(path.join('app', 'javascript', 'packs', '*.js*')).reduce(
     function(map, entry) {
       var basename = path.basename(entry, extname(entry))
-      map[basename] = entry
+      map[basename] = path.resolve(entry)
       return map
     }, {}
   ),
 
-  output: { filename: '[name].js', path: path.resolve('..', 'public', distDir) },
+  output: { filename: '[name].js', path: path.resolve('public', distDir) },
 
   module: {
     rules: [
@@ -41,7 +41,7 @@ config = {
         exclude: /node_modules/,
         loader: 'rails-erb-loader',
         options: {
-          runner: 'DISABLE_SPRING=1 ../bin/rails runner'
+          runner: 'DISABLE_SPRING=1 bin/rails runner'
         }
       },
     ]
@@ -54,13 +54,13 @@ config = {
   resolve: {
     extensions: [ '.js', '.coffee' ],
     modules: [
-      path.resolve('../app/javascript'),
-      path.resolve('../vendor/node_modules')
+      path.resolve('app/javascript'),
+      path.resolve('node_modules')
     ]
   },
 
   resolveLoader: {
-    modules: [ path.resolve('../vendor/node_modules') ]
+    modules: [ path.resolve('node_modules') ]
   }
 }
 

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -7,6 +7,7 @@ directory "#{__dir__}/config", 'config/webpack'
 
 append_to_file '.gitignore', <<-EOS
 /public/packs
+/node_modules
 EOS
 
 run './bin/yarn add --dev webpack webpack-merge webpack-dev-server path-complete-extname babel-loader babel-core babel-preset-latest coffee-loader coffee-script rails-erb-loader glob'


### PR DESCRIPTION
This replaces #84, hardcoding the rails root (rather than vendor) as the node/yarn root.

There aren't yet tests for this gem, but I made a fixture app here that can be used to test that everything is working: https://github.com/dleavitt/webpacker-testcase

Both angular and react presets should still work, though the the angular preset won't compile properly because of #81.

This PR makes it possible to remove the javascript binstubs entirely if desired - all yarn/webpack stuff should now be runnable directly or via package.json scripts.