### PR TITLE
Fix resolve.modules to includes default node_modules lookup

### DIFF
--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -54,6 +54,7 @@ config = {
   resolve: {
     extensions: [ '.js', '.coffee' ],
     modules: [
+      'node_modules',
       path.resolve('../app/javascript'),
       path.resolve('../vendor/node_modules')
     ]


### PR DESCRIPTION
A relative node_modules path must be set to let nested packages sub
dependencies be resolved as expected. The way how Node scans
node_modules folders.

Yarn and NPM3 onwards tries to not install packages nested, but whenever
two distinct versions of a same packages are required nesting can
happens. When this happens a package can't simply be resolved by looking
into vendor/node_modules, the entire node_modules lookup
(./node_modules, ../node_modules, ../../node_modules ...) relatively
from to the loaded package must be looked into.