### PR TITLE
Ensure bin/yarn matches the one generated by Rails

### DIFF
--- a/lib/install/bin/yarn.tt
+++ b/lib/install/bin/yarn.tt
@@ -1,6 +1,6 @@
 <%= shebang %>
-YARN_ROOT = File.expand_path('../', __dir__)
-Dir.chdir(YARN_ROOT) do
+VENDOR_PATH = File.expand_path('..', __dir__)
+Dir.chdir(VENDOR_PATH) do
   begin
     exec "yarnpkg #{ARGV.join(" ")}"
   rescue Errno::ENOENT


### PR DESCRIPTION
Closes #102

As a result of #84 and of rails/rails#28093, generating a new rails app
with webpacker was raising a conflict in the creation of the `bin/yarn`
file. This commit removes that conflict.