### PR TITLE
Always set NODE_ENV and RAILS_ENV when running Webpack

### DIFF
--- a/lib/install/bin/webpack-dev-server.tt
+++ b/lib/install/bin/webpack-dev-server.tt
@@ -1,7 +1,10 @@
 <%= shebang %>
 
-RAILS_ENV = ENV['RAILS_ENV'] || 'development'
-NODE_ENV  = ENV['NODE_ENV'] || RAILS_ENV
+ENV['RAILS_ENV'] ||= 'development'
+RAILS_ENV   = ENV['RAILS_ENV']
+
+ENV['NODE_ENV'] ||= RAILS_ENV
+NODE_ENV    = ENV['NODE_ENV']
 
 APP_PATH = File.expand_path('../', __dir__)
 

--- a/lib/install/bin/webpack-watcher.tt
+++ b/lib/install/bin/webpack-watcher.tt
@@ -1,5 +1,8 @@
 <%= shebang %>
 
+ENV['RAILS_ENV'] ||= 'development'
+ENV['NODE_ENV'] ||= ENV['RAILS_ENV']
+
 BIN_PATH = File.expand_path('.', __dir__)
 
 Dir.chdir(BIN_PATH) do

--- a/lib/install/bin/webpack.tt
+++ b/lib/install/bin/webpack.tt
@@ -1,7 +1,10 @@
 <%= shebang %>
 
-RAILS_ENV = ENV['RAILS_ENV'] || 'development'
-NODE_ENV  = ENV['NODE_ENV'] || RAILS_ENV
+ENV['RAILS_ENV'] ||= 'development'
+RAILS_ENV   = ENV['RAILS_ENV']
+
+ENV['NODE_ENV'] ||= RAILS_ENV
+NODE_ENV    = ENV['NODE_ENV']
 
 APP_PATH = File.expand_path('../', __dir__)
 


### PR DESCRIPTION
As the shared config uses Webpack's EnvironmentPlugin, those environment variables should be always defined so we can rely on them in Javascript code.

For example, this is outputing debug when running in development, but Webpack / Uglifier removes this dead code in the production build.
```es6
if(process.env.RAILS_ENV === "development") { console.debug("something") }
```