### PR TITLE
es6 variables and style changes

### DIFF
--- a/lib/install/config/development.js
+++ b/lib/install/config/development.js
@@ -1,9 +1,9 @@
 // Note: You must restart bin/webpack-watcher for changes to take effect
 
-var webpack = require('webpack')
-var merge   = require('webpack-merge')
+const webpack = require('webpack')
+const merge   = require('webpack-merge')
 
-var sharedConfig = require('./shared.js')
+const sharedConfig = require('./shared.js')
 
 module.exports = merge(sharedConfig.config, {
   devtool: 'sourcemap',

--- a/lib/install/config/production.js
+++ b/lib/install/config/production.js
@@ -1,9 +1,9 @@
 // Note: You must restart bin/webpack-watcher for changes to take effect
 
-var webpack = require('webpack')
-var merge   = require('webpack-merge')
+const webpack = require('webpack')
+const merge   = require('webpack-merge')
 
-var sharedConfig = require('./shared.js')
+const sharedConfig = require('./shared.js')
 
 module.exports = merge(sharedConfig.config, {
   output: { filename: '[name]-[hash].js' },

--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -7,7 +7,7 @@ const glob = require('glob')
 const extname = require('path-complete-extname')
 let distDir = process.env.WEBPACK_DIST_DIR
 
-if(distDir === undefined) {
+if (distDir === undefined) {
   distDir = 'packs'
 }
 

--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -1,11 +1,11 @@
 // Note: You must restart bin/webpack-watcher for changes to take effect
 
-var webpack = require('webpack')
-var path = require('path')
-var process = require('process')
-var glob = require('glob')
-var extname = require('path-complete-extname')
-var distDir = process.env.WEBPACK_DIST_DIR
+const webpack = require('webpack')
+const path = require('path')
+const process = require('process')
+const glob = require('glob')
+const extname = require('path-complete-extname')
+let distDir = process.env.WEBPACK_DIST_DIR
 
 if(distDir === undefined) {
   distDir = 'packs'
@@ -14,7 +14,7 @@ if(distDir === undefined) {
 config = {
   entry: glob.sync(path.join('app', 'javascript', 'packs', '*.js*')).reduce(
     function(map, entry) {
-      var basename = path.basename(entry, extname(entry))
+      const basename = path.basename(entry, extname(entry))
       map[basename] = path.resolve(entry)
       return map
     }, {}


### PR DESCRIPTION
Since you use ES2017 the variable declarations should be made using `let` and `const` instead of `var`. Also in the webpack configuration files and in the react-files there were semicolons missing from the end of the lines. I do not know whether this was intentional.
Since it is marked as a warning when using the AirBNB ESlint configuration (which is widely used), I added these.

Let me know what you think.