### PR TITLE
Fix each test regexp of shared.js correctly

### DIFF
--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -24,9 +24,9 @@ config = {
 
   module: {
     rules: [
-      { test: /\.coffee(.erb)?$/, loader: "coffee-loader" },
+      { test: /\.coffee(\.erb)?$/, loader: "coffee-loader" },
       {
-        test: /\.js(.erb)?$/,
+        test: /\.js(\.erb)?$/,
         exclude: /node_modules/,
         loader: 'babel-loader',
         options: {
@@ -36,7 +36,7 @@ config = {
         }
       },
       {
-        test: /.erb$/,
+        test: /\.erb$/,
         enforce: 'pre',
         exclude: /node_modules/,
         loader: 'rails-erb-loader',


### PR DESCRIPTION
I found mistakes on regexps in the rule of webpack. At first glance `/.erb$/` looks like good, but the beginning `.` would match to any chars. So it could probably match with the wrong extension. (e.g. `foo.coffee_erb` `bar.jsxerb` `verb` ..)

This problem found when I tried webpacker with Rails 5.1.0-beta1. Cheers.