### PR TITLE
Use arrow syntax in shared config

### DIFF
--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -12,13 +12,11 @@ if (distDir === undefined) {
 }
 
 config = {
-  entry: glob.sync(path.join('app', 'javascript', 'packs', '*.js*')).reduce(
-    function(map, entry) {
-      const basename = path.basename(entry, extname(entry))
-      map[basename] = path.resolve(entry)
-      return map
-    }, {}
-  ),
+  entry: glob.sync(path.join('app', 'javascript', 'packs', '*.js*')).reduce((map, entry) => {
+    const basename = path.basename(entry, extname(entry))
+    map[basename] = path.resolve(entry)
+    return map
+  }, {}),
 
   output: { filename: '[name].js', path: path.resolve('public', distDir) },
 


### PR DESCRIPTION
Simple change to shorten code a little using [Arrow function](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Functions/Arrow_functions). 