### PR TITLE
Use [chunkhash] instead of [hash] by default

### DIFF
--- a/lib/install/config/production.js
+++ b/lib/install/config/production.js
@@ -6,7 +6,7 @@ const merge   = require('webpack-merge')
 const sharedConfig = require('./shared.js')
 
 module.exports = merge(sharedConfig.config, {
-  output: { filename: '[name]-[hash].js' },
+  output: { filename: '[name]-[chunkhash].js' },
 
   plugins: [
     new webpack.LoaderOptionsPlugin({


### PR DESCRIPTION
webpack docs on this here:
https://webpack.github.io/docs/long-term-caching.html

[hash] gives all packs the same hash, e.g.

```
Compiled digests for all packs in /Users/schpet/code/rails-webpack-testing/minification-test/public/packs/digests.json:
{"application":"application-2a726f371dbd0b903b72.js","foo":"foo-2a726f371dbd0b903b72.js"}
```

this means that if you change foo.js (or any of it's dependencies), it
will invalidate the cache for all other packs.

chunkhash gives each pack their own hash, e.g.

```
Compiled digests for all packs in
/Users/schpet/code/rails-webpack-testing/minification-test/public/packs/digests.json:
{"application":"application-7badfb4208be6956638b.js","foo":"foo-6607498e56881eb3c594.js"}
```

and on subsequent changes to foo.js, application.js keeps the same hash:

```
Compiled digests for all packs in /Users/schpet/code/rails-webpack-testing/minification-test/public/packs/digests.json:
{"application":"application-7badfb4208be6956638b.js","foo":"foo-67c0c22479fe4b41b27b.js"}
```