### PR TITLE
Removing version number to fix a compile issue with hello_vue.js

### DIFF
--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -131,7 +131,7 @@ namespace :webpacker do
       FileUtils.copy File.expand_path('../install/vue/app.vue', File.dirname(__FILE__)),
         Rails.root.join('app/javascript/packs/app.vue')
 
-      exec "./bin/yarn add vue@2.1.10 vue-loader vue-template-compiler sass-loader node-sass css-loader url-loader axios"
+      exec "./bin/yarn add vue vue-loader vue-template-compiler sass-loader node-sass css-loader url-loader axios"
     end
 
   end


### PR DESCRIPTION

Previously, [a version number (2.1.10)](https://github.com/rails/webpacker/blob/master/lib/tasks/webpacker.rake#L137
) was specified as Vue pointed to 2.2.0.beta1 (which breaks webpack compilation).  

[This PR](https://github.com/rails/webpacker/pull/121/files) removes that version number. 

Users are encouraged to use `./bin/yarn` to control the package version in the event of dependencies breaking default pack again. 