### PR TITLE
Allow Rails 4.x support

### DIFF
--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -26,7 +26,11 @@ namespace :webpacker do
 
   desc "Install webpacker in this application"
   task :install do
-    exec "./bin/rails app:template LOCATION=#{WEBPACKER_APP_TEMPLATE_PATH}"
+    if Rails::VERSION::MAJOR >= 5
+      exec "./bin/rails app:template LOCATION=#{WEBPACKER_APP_TEMPLATE_PATH}"
+    else 
+      exec "./bin/rake rails:template LOCATION=#{WEBPACKER_APP_TEMPLATE_PATH}"
+    end
   end
 
   namespace :install do

--- a/webpacker.gemspec
+++ b/webpacker.gemspec
@@ -9,9 +9,9 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency 'activesupport', '>= 5.0'
+  s.add_dependency 'activesupport', '>= 4.0'
   s.add_dependency 'multi_json',    '~> 1.2'
-  s.add_dependency 'railties',      '>= 5.0'
+  s.add_dependency 'railties',      '>= 4.0'
 
   s.add_development_dependency 'bundler', '~> 1.12'
 

--- a/webpacker.gemspec
+++ b/webpacker.gemspec
@@ -9,9 +9,9 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency 'activesupport', '>= 4.0'
+  s.add_dependency 'activesupport', '>= 4.2'
   s.add_dependency 'multi_json',    '~> 1.2'
-  s.add_dependency 'railties',      '>= 4.0'
+  s.add_dependency 'railties',      '>= 4.2'
 
   s.add_development_dependency 'bundler', '~> 1.12'
 


### PR DESCRIPTION
Technically, nothing in webpacker is dependent on Rails 5.x.
Although there is only official support for Rails 5.1, this
minor change allows the usage of webpacker for Rails 4.x. This
is helpful for enterprise users of Rails that are still working
on supporting Rails 5.x but really want to use the new conventions
for supporting Webpack before fully upgrading to Rails 5.1.