### PR TITLE
Add compression-webpack-plugin as a dependency

### DIFF
--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -10,7 +10,7 @@ append_to_file '.gitignore', <<-EOS
 /node_modules
 EOS
 
-run './bin/yarn add --dev webpack webpack-merge webpack-dev-server path-complete-extname babel-loader babel-core babel-preset-latest coffee-loader coffee-script rails-erb-loader glob'
+run './bin/yarn add --dev webpack webpack-merge webpack-dev-server path-complete-extname babel-loader babel-core babel-preset-latest coffee-loader coffee-script compression-webpack-plugin rails-erb-loader glob'
 
 environment \
   "# Make javascript_pack_tag lookup digest hash to enable long-term caching\n" +


### PR DESCRIPTION
fixes https://github.com/rails/webpacker/pull/132#issuecomment-282835933

```
$ ./bin/rake webpacker:compile
Running via Spring preloader in process 77877
module.js:442
    throw err;
    ^

Error: Cannot find module 'compression-webpack-plugin'
    at Function.Module._resolveFilename (module.js:440:15)
    at Function.Module._load (module.js:388:25)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/schpet/code/webpacker-feb2-1207/config/webpack/production.js:5:27)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
rake aborted!
JSON::ParserError: 743: unexpected token at ''
-e:1:in `<main>'
Tasks: TOP => webpacker:compile
(See full trace by running task with --trace)
```