### PR TITLE
Fix Vue auto-generated example

### DIFF
--- a/lib/install/vue/hello_vue.js
+++ b/lib/install/vue/hello_vue.js
@@ -6,10 +6,11 @@
 import Vue from 'vue'
 import App from './app.vue'
 
-document.body.appendChild(document.createElement('hello'))
-
-Vue({
-  el: 'hello',
-  template: '<App/>',
-  components: { App }
-})
+document.addEventListener("DOMContentLoaded", () => {
+   document.body.appendChild(document.createElement('hello'))
+   var app = new Vue({
+     el: 'hello',
+     template: '<App/>',
+     components: { App }
+   })
+});


### PR DESCRIPTION
In the example, the appendChild method is called before the body element exists, resulting in `Cannot read property 'appendChild' of null`

This change listens for DOMContentLoaded before executing the rest of the Vue example code