### PR TITLE
Add node modules to correct group (Fixes #117)

### DIFF
--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -10,7 +10,8 @@ append_to_file '.gitignore', <<-EOS
 /node_modules
 EOS
 
-run './bin/yarn add --dev webpack webpack-merge webpack-dev-server path-complete-extname babel-loader babel-core babel-preset-latest coffee-loader coffee-script compression-webpack-plugin rails-erb-loader glob'
+run './bin/yarn add webpack webpack-merge path-complete-extname babel-loader babel-core babel-preset-latest coffee-loader coffee-script compression-webpack-plugin rails-erb-loader glob'
+run './bin/yarn add --dev webpack-dev-server'
 
 environment \
   "# Make javascript_pack_tag lookup digest hash to enable long-term caching\n" +

--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -102,7 +102,7 @@ namespace :webpacker do
       FileUtils.copy File.expand_path('../install/angular/tsconfig.json', __dir__),
         Rails.root.join('tsconfig.json')
 
-      exec './bin/yarn add "typescript ts-loader core-js zone.js rxjs @angular/core @angular/common @angular/compiler @angular/platform-browser @angular/platform-browser-dynamic"'
+      exec './bin/yarn add typescript ts-loader core-js zone.js rxjs @angular/core @angular/common @angular/compiler @angular/platform-browser @angular/platform-browser-dynamic"'
     end
 
     desc "Install everything needed for Vue"

--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -31,7 +31,7 @@ namespace :webpacker do
   task :install do
     if Rails::VERSION::MAJOR >= 5
       exec "./bin/rails app:template LOCATION=#{WEBPACKER_APP_TEMPLATE_PATH}"
-    else 
+    else
       exec "./bin/rake rails:template LOCATION=#{WEBPACKER_APP_TEMPLATE_PATH}"
     end
   end
@@ -66,7 +66,7 @@ namespace :webpacker do
       FileUtils.copy File.expand_path('../install/react/hello_react.jsx', __dir__),
         Rails.root.join('app/javascript/packs/hello_react.jsx')
 
-      exec './bin/yarn add --dev babel-preset-react && ./bin/yarn add react react-dom'
+      exec './bin/yarn add react react-dom babel-preset-react'
     end
 
     desc "Install everything needed for Angular"
@@ -102,7 +102,7 @@ namespace :webpacker do
       FileUtils.copy File.expand_path('../install/angular/tsconfig.json', __dir__),
         Rails.root.join('tsconfig.json')
 
-      exec './bin/yarn add --dev typescript ts-loader && ./bin/yarn add "core-js zone.js rxjs @angular/core @angular/common @angular/compiler @angular/platform-browser @angular/platform-browser-dynamic"'
+      exec './bin/yarn add "typescript ts-loader core-js zone.js rxjs @angular/core @angular/common @angular/compiler @angular/platform-browser @angular/platform-browser-dynamic"'
     end
 
     desc "Install everything needed for Vue"


### PR DESCRIPTION
Fixes this https://github.com/rails/webpacker/issues/117. Basically, it moves the node module dependencies in it's place. 