### PR TITLE
Use babel-preset-env instead of latest

### DIFF
--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -33,7 +33,7 @@ const config = {
         loader: 'babel-loader',
         options: {
           presets: [
-            ['latest', { es2015: { modules: false } }]
+            ['env', { modules: false }]
           ]
         }
       },

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -10,7 +10,7 @@ append_to_file '.gitignore', <<-EOS
 /node_modules
 EOS
 
-run './bin/yarn add webpack webpack-merge path-complete-extname babel-loader babel-core babel-preset-latest coffee-loader coffee-script compression-webpack-plugin rails-erb-loader glob'
+run './bin/yarn add webpack webpack-merge path-complete-extname babel-loader babel-core babel-preset-env coffee-loader coffee-script compression-webpack-plugin rails-erb-loader glob'
 run './bin/yarn add --dev webpack-dev-server'
 
 environment \

--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -42,11 +42,11 @@ namespace :webpacker do
       config_path = Rails.root.join('config/webpack/shared.js')
       config = File.read(config_path)
 
-      if config =~ /presets:\s*\[\s*\[\s*'latest'/
+      if config =~ /presets:\s*\[\s*\[\s*'env'/
         puts "Replacing loader presets to include react in #{config_path}"
-        config.gsub!(/presets:(\s*\[)(\s*)\[(\s)*'latest'/, "presets:\\1\\2'react',\\2[\\3'latest'")
+        config.gsub!(/presets:(\s*\[)(\s*)\[(\s)*'env'/, "presets:\\1\\2'react',\\2[\\3'env'")
       else
-        puts "Couldn't automatically update loader presets in #{config_path}. Please set presets: [ 'react', [ 'latest', { 'es2015': { 'modules': false } } ] ]."
+        puts "Couldn't automatically update loader presets in #{config_path}. Please set presets: [ 'react', [ 'env', { 'modules': false } ] ]."
       end
 
       if config.include?("test: /\\.js(\\.erb)?$/")


### PR DESCRIPTION
Ref https://github.com/rails/webpacker/commit/af320768eb5dfe82952238468021aea308a048d8

https://github.com/babel/babel-preset-env is a newer preset that by default does the same thing as latest. (So at the minimum this is just a refactor, since preset-env replaces latest). If you have any questions, let me know (I'm maintaining Babel, and created preset-env)!

However if you use it's options, you can tell Babel to not compile certain ES6 features that are already supported in the browsers you target.

Example:

```js
{
  "presets": [
    ["env", {
      "targets": {
        "browsers": ["last 2 versions", "safari >= 7"]
      }
    }]
  ]
}
```

Or if you target chrome only, or want to have different babel configs when in development (latest Chrome).

Only catch is that if you need to minify, then you'll need an ES6-aware minifier, which is why we are working on https://github.com/babel/babili (babel-minify).