### PR TITLE
Make sure Digest::lookup always pick the correct js file name.

### DIFF
--- a/lib/webpacker/digests.rb
+++ b/lib/webpacker/digests.rb
@@ -27,7 +27,12 @@ class Webpacker::Digests
   end
 
   def lookup(name)
-    @digests[name.to_s]
+    lookedup = @digests[name.to_s]
+    if lookedup.respond_to?(:select)
+      lookedup.select { |fn| fn.end_with?('.js') }.first
+    else
+      lookedup
+    end
   end
 
   private


### PR DESCRIPTION
Fix #151 