### PR TITLE
Use relative node_modules path for webpack resolve.modules config

### DIFF
--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -57,7 +57,7 @@ const config = {
     extensions: ['.js', '.coffee'],
     modules: [
       path.resolve('app/javascript'),
-      path.resolve('node_modules')
+      'node_modules'
     ]
   },
 


### PR DESCRIPTION
Yarn (and NPM3+) try to flatten the node_modules directory, but when different versions of the same package are required Yarn (and NPM as well) will fallback to a nested structure.

If `node_modules` is set as an absolute path, webpack will only search in that directory, ignoring a potential nested node packages.

> A relative path will be scanned similarly to how Node scans for node_modules, by looking through the current directory as well as it's ancestors (i.e. ./node_modules, ../node_modules, and on).

`resolve.modules` defaults to:
```javascript
modules: ["node_modules"]
```

Ref: https://webpack.js.org/configuration/resolve/#resolve-modules
