### PR TITLE
Fix glob pattern to avoid matching directories

### DIFF
--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -13,7 +13,7 @@ if (distDir === undefined) {
 }
 
 const extensions = ['.js', '.coffee']
-const extensionGlob = `*(${extensions.join('|')})*`
+const extensionGlob = `*{${extensions.join(',')}}*`
 const packPaths = glob.sync(path.join('app', 'javascript', 'packs', extensionGlob))
 
 const config = {


### PR DESCRIPTION
Follow up to https://github.com/rails/webpacker/pull/174

Given:
```sh
$ ls -l app/javascript/packs/
total 0
-rw-r--r--  1 javan  staff   0 Mar 16 12:20 a.js
-rw-r--r--  1 javan  staff   0 Mar 16 12:20 b.coffee
drwxr-xr-x  2 javan  staff  68 Mar 16 12:20 c
```
Before:
```node
> extensionGlob = `*(${extensions.join('|')})*`
'*(.js|.coffee)*'

> glob.sync(path.join('app', 'javascript', 'packs', extensionGlob))
[ 'app/javascript/packs/a.js',
  'app/javascript/packs/b.coffee',
  'app/javascript/packs/c' ]
```

After:
```node
> extensionGlob = `*{${extensions.join(',')}}*`
'*{.js,.coffee}*'

> glob.sync(path.join('app', 'javascript', 'packs', extensionGlob))
[ 'app/javascript/packs/a.js', 
  'app/javascript/packs/b.coffee' ]
```