### PR TITLE
Fix Typescript compilation

### DIFF
--- a/lib/install/config/shared.js
+++ b/lib/install/config/shared.js
@@ -12,7 +12,7 @@ if (distDir === undefined) {
   distDir = 'packs'
 }
 
-const extensions = ['.js', '.coffee']
+const extensions = ['.js', '.coffee', '.ts']
 const extensionGlob = `*{${extensions.join(',')}}*`
 const packPaths = glob.sync(path.join('app', 'javascript', 'packs', extensionGlob))
 


### PR DESCRIPTION
Without this, .ts files have to be referenced directly.