### PR TITLE
Fix adding .ts to extensions

### DIFF
--- a/lib/tasks/installers/angular.rake
+++ b/lib/tasks/installers/angular.rake
@@ -23,7 +23,7 @@ namespace :webpacker do
         puts "The configuration file already has a reference to .ts extension, skipping the addition of this extension to the list..."
       else
         puts "Adding '.ts' in loader extensions in #{config_path}..."
-        config.gsub!(/extensions:(.*')(\s*\])/, "extensions:\\1, '.ts'\\2")
+        config.gsub!(/extensions = (.*')(\s*\])/, "extensions = \\1, '.ts'\\2")
       end
 
       File.write config_path, config


### PR DESCRIPTION
Format is :
> const extensions = ['.js', '.coffee']

not:

> const extensions: ['.js', '.coffee']

This fixes adding the typescript extension in the shared webpack config while runnning webpacker:install:angular