### PR TITLE
Scope webpack config through env

### DIFF
--- a/lib/install/bin/webpack-dev-server.tt
+++ b/lib/install/bin/webpack-dev-server.tt
@@ -14,7 +14,7 @@ APP_PATH    = File.expand_path("../", __dir__)
 CONFIG_PATH = File.join(APP_PATH, "config/webpack/paths.yml")
 
 begin
-  paths = YAML.load(File.read(CONFIG_PATH))
+  paths = YAML.load(File.read(CONFIG_PATH))[NODE_ENV]
 
   NODE_MODULES_PATH   = File.join(APP_PATH.shellescape, paths["node_modules"])
   WEBPACK_CONFIG_PATH = File.join(APP_PATH.shellescape, paths["config"])

--- a/lib/install/bin/webpack.tt
+++ b/lib/install/bin/webpack.tt
@@ -15,8 +15,8 @@ CONFIG_PATH            = File.join(APP_PATH, "config/webpack/paths.yml")
 DEV_SERVER_CONFIG_PATH = File.join(APP_PATH, "config/webpack/development.server.yml")
 
 begin
-  paths            = YAML.load(File.read(CONFIG_PATH))
-  dev_server = YAML.load(File.read(DEV_SERVER_CONFIG_PATH))
+  paths            = YAML.load(File.read(CONFIG_PATH))[NODE_ENV]
+  dev_server       = YAML.load(File.read(DEV_SERVER_CONFIG_PATH))[NODE_ENV]
 
   NODE_MODULES_PATH   = File.join(APP_PATH.shellescape, paths["node_modules"])
   WEBPACK_CONFIG_PATH = File.join(APP_PATH.shellescape, paths["config"])

--- a/lib/install/config/webpack/configuration.js
+++ b/lib/install/config/webpack/configuration.js
@@ -7,8 +7,8 @@ const { readFileSync } = require('fs')
 
 const configPath = resolve('config', 'webpack')
 const loadersDir = join(__dirname, 'loaders')
-const paths = safeLoad(readFileSync(join(configPath, 'paths.yml'), 'utf8'))
-const devServer = safeLoad(readFileSync(join(configPath, 'development.server.yml'), 'utf8'))
+const paths = safeLoad(readFileSync(join(configPath, 'paths.yml'), 'utf8'))[env.NODE_ENV]
+const devServer = safeLoad(readFileSync(join(configPath, 'development.server.yml'), 'utf8'))[env.NODE_ENV]
 const publicPath = env.NODE_ENV !== 'production' && devServer.enabled ?
   `http://${devServer.host}:${devServer.port}/` : `/${paths.entry}/`
 

--- a/lib/install/config/webpack/development.server.yml
+++ b/lib/install/config/webpack/development.server.yml
@@ -9,6 +9,8 @@ development:
 
 test:
   <<: *default
+  enabled: false
 
 production:
   <<: *default
+  enabled: false

--- a/lib/install/config/webpack/development.server.yml
+++ b/lib/install/config/webpack/development.server.yml
@@ -1,4 +1,14 @@
 # Restart webpack-dev-server if you make changes here
-enabled: true
-host: localhost
-port: 8080
+default: &default
+  enabled: true
+  host: localhost
+  port: 8080
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/lib/install/config/webpack/paths.yml
+++ b/lib/install/config/webpack/paths.yml
@@ -1,19 +1,31 @@
 # Restart webpack-watcher or webpack-dev-server if you make changes here
-config: config/webpack
-entry: packs
-output: public
-node_modules: node_modules
-source: app/javascript
-extensions:
-  - .coffee
-  - .js
-  - .jsx
-  - .ts
-  - .vue
-  - .sass
-  - .scss
-  - .css
-  - .png
-  - .svg
-  - .gif
-  - .jpeg
+default: &default
+  config: config/webpack
+  entry: packs
+  output: public
+  manifest: manifest.json
+  node_modules: node_modules
+  source: app/javascript
+  extensions:
+    - .coffee
+    - .js
+    - .jsx
+    - .ts
+    - .vue
+    - .sass
+    - .scss
+    - .css
+    - .png
+    - .svg
+    - .gif
+    - .jpeg
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+  manifest: manifest-test.json
+
+production:
+  <<: *default

--- a/lib/install/config/webpack/shared.js
+++ b/lib/install/config/webpack/shared.js
@@ -34,7 +34,7 @@ module.exports = {
   plugins: [
     new webpack.EnvironmentPlugin(JSON.parse(JSON.stringify(env))),
     new ExtractTextPlugin(env.NODE_ENV === 'production' ? '[name]-[hash].css' : '[name].css'),
-    new ManifestPlugin({ fileName: 'manifest.json', publicPath, writeToFileEmit: true })
+    new ManifestPlugin({ fileName: paths.manifest, publicPath, writeToFileEmit: true })
   ],
 
   resolve: {

--- a/lib/install/config/webpack/test.js
+++ b/lib/install/config/webpack/test.js
@@ -1,0 +1,6 @@
+// Note: You must restart bin/webpack-watcher for changes to take effect
+
+const merge = require('webpack-merge')
+const sharedConfig = require('./shared.js')
+
+module.exports = merge(sharedConfig, {})

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -16,7 +16,7 @@ class Webpacker::Configuration < Webpacker::FileLoader
     end
 
     def manifest_path
-      Rails.root.join(output_path, "manifest.json")
+      Rails.root.join(output_path, paths.fetch(:manifest, "manifest.json"))
     end
 
     def output_path
@@ -37,6 +37,6 @@ class Webpacker::Configuration < Webpacker::FileLoader
   private
     def load
       return super unless File.exist?(@path)
-      HashWithIndifferentAccess.new(YAML.load(File.read(@path)))
+      HashWithIndifferentAccess.new(YAML.load(File.read(@path))[Rails.env])
     end
 end


### PR DESCRIPTION
Related to #189 

@dhh We discussed about env scoped config file in #153 and you asked the reasons for it, and at that point it wasn't very clear to me but it seems that it's more evident now to have it scoped as some of the options are conflicting in different env, especially testing. 

So, I made this small PR that adds env scope and also an option to generate different manifest file based on env (if specified)

Please review and merge whenever you get a chance.

// cc @renchap