### PR TITLE
Use correct env for compiling webpack

### DIFF
--- a/lib/install/bin/webpack-dev-server.tt
+++ b/lib/install/bin/webpack-dev-server.tt
@@ -14,7 +14,7 @@ APP_PATH    = File.expand_path("../", __dir__)
 CONFIG_PATH = File.join(APP_PATH, "config/webpack/paths.yml")
 
 begin
-  paths = YAML.load(File.read(CONFIG_PATH))[NODE_ENV]
+  paths = YAML.load(File.read(CONFIG_PATH))[RAILS_ENV]
 
   NODE_MODULES_PATH   = File.join(APP_PATH.shellescape, paths["node_modules"])
   WEBPACK_CONFIG_PATH = File.join(APP_PATH.shellescape, paths["config"])

--- a/lib/install/bin/webpack.tt
+++ b/lib/install/bin/webpack.tt
@@ -15,13 +15,13 @@ CONFIG_PATH            = File.join(APP_PATH, "config/webpack/paths.yml")
 DEV_SERVER_CONFIG_PATH = File.join(APP_PATH, "config/webpack/development.server.yml")
 
 begin
-  paths            = YAML.load(File.read(CONFIG_PATH))[NODE_ENV]
-  dev_server       = YAML.load(File.read(DEV_SERVER_CONFIG_PATH))[NODE_ENV]
+  paths            = YAML.load(File.read(CONFIG_PATH))[RAILS_ENV]
+  dev_server       = YAML.load(File.read(DEV_SERVER_CONFIG_PATH))[RAILS_ENV]
 
   NODE_MODULES_PATH   = File.join(APP_PATH.shellescape, paths["node_modules"])
   WEBPACK_CONFIG_PATH = File.join(APP_PATH.shellescape, paths["config"])
 
-  if NODE_ENV == "development" && dev_server["enabled"]
+  if RAILS_ENV == "development" && dev_server["enabled"]
     puts "Warning: webpack-dev-server is currently enabled in #{DEV_SERVER_CONFIG_PATH}. " \
       "Disable to serve assets directly from public/packs directory"
   end
@@ -32,7 +32,7 @@ rescue Errno::ENOENT, NoMethodError
 end
 
 WEBPACK_BIN    = "#{NODE_MODULES_PATH}/.bin/webpack"
-WEBPACK_CONFIG = "#{WEBPACK_CONFIG_PATH}/#{NODE_ENV}.js"
+WEBPACK_CONFIG = "#{WEBPACK_CONFIG_PATH}/#{RAILS_ENV}.js"
 
 Dir.chdir(APP_PATH) do
   exec "NODE_PATH=#{NODE_MODULES_PATH} #{WEBPACK_BIN} --config #{WEBPACK_CONFIG}" \

--- a/lib/install/config/webpack/configuration.js
+++ b/lib/install/config/webpack/configuration.js
@@ -7,9 +7,9 @@ const { readFileSync } = require('fs')
 
 const configPath = resolve('config', 'webpack')
 const loadersDir = join(__dirname, 'loaders')
-const paths = safeLoad(readFileSync(join(configPath, 'paths.yml'), 'utf8'))[env.NODE_ENV]
-const devServer = safeLoad(readFileSync(join(configPath, 'development.server.yml'), 'utf8'))[env.NODE_ENV]
-const publicPath = env.NODE_ENV !== 'production' && devServer.enabled ?
+const paths = safeLoad(readFileSync(join(configPath, 'paths.yml'), 'utf8'))[env.RAILS_ENV]
+const devServer = safeLoad(readFileSync(join(configPath, 'development.server.yml'), 'utf8'))[env.RAILS_ENV]
+const publicPath = env.RAILS_ENV !== 'production' && devServer.enabled ?
   `http://${devServer.host}:${devServer.port}/` : `/${paths.entry}/`
 
 module.exports = {

--- a/lib/install/config/webpack/shared.js
+++ b/lib/install/config/webpack/shared.js
@@ -33,7 +33,7 @@ module.exports = {
 
   plugins: [
     new webpack.EnvironmentPlugin(JSON.parse(JSON.stringify(env))),
-    new ExtractTextPlugin(env.NODE_ENV === 'production' ? '[name]-[hash].css' : '[name].css'),
+    new ExtractTextPlugin(env.RAILS_ENV === 'production' ? '[name]-[hash].css' : '[name].css'),
     new ManifestPlugin({ fileName: paths.manifest, publicPath, writeToFileEmit: true })
   ],
 

--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -5,7 +5,7 @@ namespace :webpacker do
   desc "Compile javascript packs using webpack for production with digests"
   task compile: ["webpacker:verify_install", :environment] do
     puts "Compiling webpacker assets 🎉"
-    result = `NODE_ENV=production ./bin/webpack`
+    result = `NODE_ENV=production RAILS_ENV=#{Rails.env} ./bin/webpack`
 
     unless $?.success?
       puts JSON.parse(result)["errors"]


### PR DESCRIPTION
Fixes: #194

Even if Rails.env is non production we want to keep NODE_ENV=production don't we? See comments on https://github.com/rails/webpacker/pull/164
So we want to do most of our checks based on RAILS_ENV even in js