### PR TITLE
Use NODE_ENV as default env

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    webpacker (1.0)
+    webpacker (1.1)
       activesupport (>= 4.2)
       multi_json (~> 1.2)
       railties (>= 4.2)

--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -5,7 +5,7 @@ namespace :webpacker do
   desc "Compile javascript packs using webpack for production with digests"
   task compile: ["webpacker:verify_install", :environment] do
     puts "Compiling webpacker assets 🎉"
-    result = `NODE_ENV=production ./bin/webpack`
+    result = `NODE_ENV=#{ENV["NODE_ENV"]} ./bin/webpack`
 
     unless $?.success?
       puts JSON.parse(result)["errors"]

--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -5,7 +5,7 @@ namespace :webpacker do
   desc "Compile javascript packs using webpack for production with digests"
   task compile: ["webpacker:verify_install", :environment] do
     puts "Compiling webpacker assets 🎉"
-    result = `NODE_ENV=#{ENV["NODE_ENV"]} ./bin/webpack`
+    result = `NODE_ENV=#{ENV["NODE_ENV"] || "production"} ./bin/webpack`
 
     unless $?.success?
       puts JSON.parse(result)["errors"]

--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -1,3 +1,4 @@
+require "webpacker/env"
 require "webpacker/configuration"
 REGEX_MAP = /\A.*\.map\z/
 
@@ -5,7 +6,7 @@ namespace :webpacker do
   desc "Compile javascript packs using webpack for production with digests"
   task compile: ["webpacker:verify_install", :environment] do
     puts "Compiling webpacker assets 🎉"
-    result = `NODE_ENV=#{ENV["NODE_ENV"] || "production"} ./bin/webpack`
+    result = `NODE_ENV=#{Webpacker::Env.current} ./bin/webpack`
 
     unless $?.success?
       puts JSON.parse(result)["errors"]

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -24,7 +24,7 @@ class Webpacker::Configuration < Webpacker::FileLoader
     end
 
     def paths
-      load if Rails.env.development?
+      load if ENV["NODE_ENV"] == "development"
       raise Webpacker::FileLoader::FileLoaderError.new("Webpacker::Configuration.load must be called first") unless instance
       instance.data
     end
@@ -37,6 +37,6 @@ class Webpacker::Configuration < Webpacker::FileLoader
   private
     def load
       return super unless File.exist?(@path)
-      HashWithIndifferentAccess.new(YAML.load(File.read(@path))[Rails.env])
+      HashWithIndifferentAccess.new(YAML.load(File.read(@path))[ENV["NODE_ENV"]])
     end
 end

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -1,5 +1,6 @@
 # Loads webpacker configuration from config/webpack/paths.yml
 require "webpacker/file_loader"
+require "webpacker/env"
 
 class Webpacker::Configuration < Webpacker::FileLoader
   class << self
@@ -24,7 +25,7 @@ class Webpacker::Configuration < Webpacker::FileLoader
     end
 
     def paths
-      load if ENV["NODE_ENV"] == "development"
+      load if Webpacker::Env.development?
       raise Webpacker::FileLoader::FileLoaderError.new("Webpacker::Configuration.load must be called first") unless instance
       instance.data
     end
@@ -37,6 +38,6 @@ class Webpacker::Configuration < Webpacker::FileLoader
   private
     def load
       return super unless File.exist?(@path)
-      HashWithIndifferentAccess.new(YAML.load(File.read(@path))[ENV["NODE_ENV"]])
+      HashWithIndifferentAccess.new(YAML.load(File.read(@path))[Webpacker::Env.current])
     end
 end

--- a/lib/webpacker/env.rb
+++ b/lib/webpacker/env.rb
@@ -1,0 +1,27 @@
+# Singleton registry for determining NODE_ENV from config/webpack/paths.yml
+require "webpacker/file_loader"
+
+class Webpacker::Env < Webpacker::FileLoader
+  class << self
+    def current
+      raise Webpacker::FileLoader::FileLoaderError.new("Webpacker::Env.load must be called first") unless instance
+      instance.data
+    end
+
+    def development?
+      current == "development"
+    end
+
+    def file_path
+      Rails.root.join("config", "webpack", "paths.yml")
+    end
+  end
+
+  private
+    def load
+      environments = File.exist?(@path) ? YAML.load(File.read(@path)).keys : [].freeze
+      return ENV["NODE_ENV"] if environments.include?(ENV["NODE_ENV"])
+      return Rails.env if environments.include?(Rails.env)
+      "production"
+    end
+end

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -15,7 +15,7 @@ class Webpacker::Manifest < Webpacker::FileLoader
     end
 
     def lookup(name)
-      load if Rails.env.development?
+      load if ENV["NODE_ENV"] == "development"
       raise Webpacker::FileLoader::FileLoaderError.new("Webpacker::Manifest.load must be called first") unless instance
       instance.data[name.to_s] || raise(Webpacker::FileLoader::NotFoundError.new("Can't find #{name} in #{file_path}. Is webpack still compiling?"))
     end

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -6,6 +6,7 @@
 # "/packs/calendar-1016838bab065ae1e314.css" for long-term caching
 
 require "webpacker/file_loader"
+require "webpacker/env"
 require "webpacker/configuration"
 
 class Webpacker::Manifest < Webpacker::FileLoader
@@ -15,7 +16,7 @@ class Webpacker::Manifest < Webpacker::FileLoader
     end
 
     def lookup(name)
-      load if ENV["NODE_ENV"] == "development"
+      load if Webpacker::Env.development?
       raise Webpacker::FileLoader::FileLoaderError.new("Webpacker::Manifest.load must be called first") unless instance
       instance.data[name.to_s] || raise(Webpacker::FileLoader::NotFoundError.new("Can't find #{name} in #{file_path}. Is webpack still compiling?"))
     end

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -9,7 +9,7 @@ class Webpacker::Engine < ::Rails::Engine
       ActionController::Base.helper Webpacker::Helper
     end
 
-    # Setup NODE_ENV environment based on config/webpack/paths.yml
+    # Determine NODE_ENV environment based on config/webpack/paths.yml
     Webpacker::Env.load
     # Loads webpacker config data from config/webpack/paths.yml
     Webpacker::Configuration.load

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -1,6 +1,7 @@
 require "rails/railtie"
 
 require "webpacker/helper"
+require "webpacker/env"
 
 class Webpacker::Engine < ::Rails::Engine
   initializer :webpacker do |app|
@@ -8,9 +9,8 @@ class Webpacker::Engine < ::Rails::Engine
       ActionController::Base.helper Webpacker::Helper
     end
 
-    # Use NODE_ENV if defined, else fallback to RAILS_ENV
-    ENV["NODE_ENV"] ||= ENV["RAILS_ENV"]
-
+    # Setup NODE_ENV environment based on config/webpack/paths.yml
+    Webpacker::Env.load
     # Loads webpacker config data from config/webpack/paths.yml
     Webpacker::Configuration.load
     # Loads manifest data from public/packs/manifest.json

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -8,6 +8,9 @@ class Webpacker::Engine < ::Rails::Engine
       ActionController::Base.helper Webpacker::Helper
     end
 
+    # Use NODE_ENV if defined, else fallback to RAILS_ENV
+    ENV["NODE_ENV"] ||= ENV["RAILS_ENV"]
+
     # Loads webpacker config data from config/webpack/paths.yml
     Webpacker::Configuration.load
     # Loads manifest data from public/packs/manifest.json


### PR DESCRIPTION
Related and Fixes to #195 #194 and #164 

Basically now webpacker env works similar to how Rails.env works, but with exception to other env like `staging`. On these env it will behave as it's `production`.

```bash
RAILS_ENV=staging NODE_ENV=staging bundle exec rails c
RAILS_ENV=test NODE_ENV=development bundle exec rails c
```

![screen shot 2017-03-28 at 08 38 41](https://cloud.githubusercontent.com/assets/771039/24394018/39b56ffe-1392-11e7-88ee-5ac965f4d87c.png)

![screen shot 2017-03-28 at 08 39 00](https://cloud.githubusercontent.com/assets/771039/24394028/42f20af0-1392-11e7-8eb1-24ae015ef79d.png)

![screen shot 2017-03-28 at 08 39 19](https://cloud.githubusercontent.com/assets/771039/24394033/491bfb16-1392-11e7-9873-a81c3acd71e3.png)


Please review :)
