### PR TITLE
run ./bin/webpack with --json flag in webpacker:compile

### DIFF
--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -5,7 +5,7 @@ namespace :webpacker do
   desc "Compile javascript packs using webpack for production with digests"
   task compile: ["webpacker:verify_install", :environment] do
     puts "Compiling webpacker assets 🎉"
-    result = `NODE_ENV=production ./bin/webpack`
+    result = `NODE_ENV=production ./bin/webpack --json`
 
     unless $?.success?
       puts JSON.parse(result)["errors"]


### PR DESCRIPTION
this flag was removed in #153, but without it the error handling block
throws a `JSON::ParserError` and dumps the webpack output:

```
Webpacker is installed 🎉 🍰
Using /home/ubuntu/x/config/webpack/paths.yml file for setting up webpack paths
Compiling webpacker assets 🎉
(node:13993) DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.
rake aborted!
JSON::ParserError: 784: unexpected token at 'Hash: 07f7572619a3f21f5769
Version: webpack 2.3.2
Time: 5959ms
                                 Asset      Size  Chunks             Chunk Names
   application-8fe35cff8405fc080848.js    144 kB       0  [emitted]  application
application-8fe35cff8405fc080848.js.gz   43.8 kB          [emitted]  
                         manifest.json  68 bytes          [emitted]  
   [3] ./~/object-assign/index.js 2.11 kB {0} [
(rest of output omitted)
```

The error results with this flag aren't a great deal clearer - there's a lot of noise printed, but it does get rid of the misleading JSON error and puts the actual issue at the at the top level:

```
Webpacker is installed 🎉 🍰
Using /Users/thomasm/code/x/config/webpack/paths.yml file for setting up webpack paths
Compiling webpacker assets 🎉
(node:93604) DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.
./app/javascript/x/Dispatcher.js
Module not found: Error: Can't resolve 'no' in '/Users/thomasm/code/x/app/javascript/x'
resolve 'no' in '/Users/thomasm/code/x/app/javascript/x'
  Parsed request is a module
  using description file: /Users/thomasm/code/x/package.json (relative path: ./app/javascript/x)
    Field 'browser' doesn't contain a valid alias configuration
  after using description file: /Users/thomasm/code/x/package.json (relative path: ./app/javascript/x)
... continues
```