### PR TITLE
Allow pack files to be placed in subdirectories

### DIFF
--- a/lib/install/config/webpack/shared.js
+++ b/lib/install/config/webpack/shared.js
@@ -3,7 +3,7 @@
 /* eslint import/no-dynamic-require: 0 */
 
 const webpack = require('webpack')
-const { basename, join, resolve } = require('path')
+const { basename, dirname, join, relative, resolve } = require('path')
 const { sync } = require('glob')
 const { readdirSync } = require('fs')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
@@ -11,14 +11,15 @@ const ManifestPlugin = require('webpack-manifest-plugin')
 const extname = require('path-complete-extname')
 const { env, paths, publicPath, loadersDir } = require('./configuration.js')
 
-const extensionGlob = `*{${paths.extensions.join(',')}}*`
+const extensionGlob = `**/*{${paths.extensions.join(',')}}*`
 const packPaths = sync(join(paths.source, paths.entry, extensionGlob))
 
 module.exports = {
   entry: packPaths.reduce(
     (map, entry) => {
       const localMap = map
-      localMap[basename(entry, extname(entry))] = resolve(entry)
+      const namespace = relative(join(paths.source, paths.entry), dirname(entry))
+      localMap[join(namespace, basename(entry, extname(entry)))] = resolve(entry)
       return localMap
     }, {}
   ),


### PR DESCRIPTION
With this commit, you can organize JavaScript files with namespaces.

For example:

```text
app/javascript/packs/admin/hello_vue.js
app/javascript/packs/admin/hello.vue
app/javascript/packs/hello_vue.js
app/javascript/packs/hello.vue
```
