### PR TITLE
Add --host option to webpack-dev-server

### DIFF
--- a/lib/install/bin/webpack-dev-server.tt
+++ b/lib/install/bin/webpack-dev-server.tt
@@ -28,6 +28,6 @@ rescue Errno::ENOENT, NoMethodError
 end
 
 Dir.chdir(APP_PATH) do
-  exec "NODE_PATH=#{NODE_MODULES_PATH} #{WEBPACK_BIN} --progress --color " \
+  exec "NODE_PATH=#{NODE_MODULES_PATH} #{WEBPACK_BIN} --host 0.0.0.0 --progress --color " \
     "--config #{DEV_SERVER_CONFIG}"
 end


### PR DESCRIPTION
# `--host` option by default

My webpack-dev-server returned `curl: (52) Empty reply from server` when I accessed localhost:8080 by `curl localhost:8080` on docker-compose. To prevent it, I added `--host` option. And I want to be set the option by default. What do you think about it?

## docker-compose

```
version: '2'
services:
  webpack:
    build: .
    volumes:
      - .:/usr/src/app
    command: /usr/src/app/bin/webpack-dev-server
    ports:
      - "8080:8080"

```
The run command and outputs are below:

```
$ docker-compose run webpack
 10% building modules 2/2 modules 0 active
Project is running at http://0.0.0.0:8080/
webpack output is served from http://localhost:8080/
..........
  [130] ./~/url/util.js 314 bytes {0} {1} [built]
  [131] (webpack)-dev-server/client/overlay.js 3.6 kB {0} {1} [built]
  [132] (webpack)-dev-server/client/socket.js 856 bytes {0} {1} [built]
  [134] (webpack)/hot/emitter.js 77 bytes {0} {1} [built]
  [162] ./app/javascript/packs/application.js 530 bytes {1} [built]
  [262] multi (webpack)-dev-server/client?http://0.0.0.0:8080 ./app/javascript/packs/application.js 40 bytes {1} [built]
     + 71 hidden modules
webpack: Compiled successfully.
```

Before I added the option:

```
$ curl localhost:8080
curl: (52) Empty reply from server
```

After that:

```
$ curl localhost:8080
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>Cannot GET /</pre>
</body>
</html>
```

## refs
https://github.com/webpack/webpack-dev-server/issues/547#issuecomment-284737321

## env
* ruby: ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]
* rails: Rails 5.1.0.rc1
* node: v7.7.4