### PR TITLE
Default to ERB for rails-erb-loader

### DIFF
--- a/lib/install/config/loaders/core/erb.js
+++ b/lib/install/config/loaders/core/erb.js
@@ -4,6 +4,7 @@ module.exports = {
   exclude: /node_modules/,
   loader: 'rails-erb-loader',
   options: {
-    runner: 'DISABLE_SPRING=1 bin/rails runner'
+    runner: 'DISABLE_SPRING=1 bin/rails runner',
+    engine: 'erb'
   }
 }


### PR DESCRIPTION
Looks like `rails-erb-loader` has a default ERB template engine of `erubis`, not `erb`. This results in a build error on a freshly generated Rails 5.1.0.rc1 app.

https://github.com/usabilityhub/rails-erb-loader#options

```
ERROR in ./app/javascript/packs/sessions.js.erb
Module build failed: Error: Command failed: DISABLE_SPRING=1 bin/rails runner /Developer/testapp/node_modules/rails-erb-loader/erb_transformer.rb __RAILS_ERB_LOADER_DELIMETER__ erubis
/Users/testuser/.rvm/gems/ruby-2.3.1@testapp/gems/activesupport-5.1.0.rc1/lib/active_support/dependencies.rb:292:in `require': cannot load such file -- erubis (LoadError)
```