### PR TITLE
Supply ASSET_HOST to webpack for internal asset compilation

### DIFF
--- a/lib/install/config/webpack/configuration.js
+++ b/lib/install/config/webpack/configuration.js
@@ -9,13 +9,18 @@ const configPath = resolve('config', 'webpack')
 const loadersDir = join(__dirname, 'loaders')
 const paths = safeLoad(readFileSync(join(configPath, 'paths.yml'), 'utf8'))[env.NODE_ENV]
 const devServer = safeLoad(readFileSync(join(configPath, 'development.server.yml'), 'utf8'))[env.NODE_ENV]
-const publicPath = env.NODE_ENV !== 'production' && devServer.enabled ?
-  `http://${devServer.host}:${devServer.port}/` : `/${paths.entry}/`
+
+// Compute public path based on environment and ASSET_HOST in production
+const ifHasCDN = env.ASSET_HOST !== undefined && env.NODE_ENV === 'production'
+const devServerUrl = `http://${devServer.host}:${devServer.port}/${paths.entry}/`
+const publicUrl = ifHasCDN ? `${env.ASSET_HOST}/${paths.entry}/` : `/${paths.entry}/`
+const publicPath = env.NODE_ENV !== 'production' && devServer.enabled ? devServerUrl : publicUrl
 
 module.exports = {
   devServer,
   env,
   paths,
   loadersDir,
+  publicUrl,
   publicPath
 }

--- a/lib/install/config/webpack/shared.js
+++ b/lib/install/config/webpack/shared.js
@@ -23,7 +23,11 @@ module.exports = {
     }, {}
   ),
 
-  output: { filename: '[name].js', path: resolve(paths.output, paths.entry) },
+  output: {
+    filename: '[name].js',
+    path: resolve(paths.output, paths.entry),
+    publicPath
+  },
 
   module: {
     rules: readdirSync(loadersDir).map(file => (

--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -6,7 +6,8 @@ namespace :webpacker do
   desc "Compile javascript packs using webpack for production with digests"
   task compile: ["webpacker:verify_install", :environment] do
     puts "Compiling webpacker assets 🎉"
-    result = `NODE_ENV=#{Webpacker::Env.current} ./bin/webpack --json`
+    asset_host = Rails.application.config.action_controller.asset_host
+    result = `ASSET_HOST=#{asset_host} NODE_ENV=#{Webpacker::Env.current} ./bin/webpack --json`
 
     unless $?.success?
       puts JSON.parse(result)["errors"]


### PR DESCRIPTION
Related to https://github.com/rails/webpacker/issues/208

## With CDN
```json
 {
"app.js": "//d309ficnxxdltp.cloudfront.net/entries/app-15c9cd01cb8b89b930bf.js",
"lacuna-webfont.woff": "//d309ficnxxdltp.cloudfront.net/entries/lacuna-webfont-0eb6add367ef5fc69c4569894525bd52.woff" 
}
```

## Without CDN

```json
{
"app.js": "/entries/app-dd8750c877fb3fcd1082.js",
"lacuna-webfont.woff": "/entries/lacuna-webfont-0eb6add367ef5fc69c4569894525bd52.woff" 
}
```