### PR TITLE
Correct "Linking to static assets" paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Static assets like images, fonts and stylesheets support is enabled out-of-box s
 import React from 'react'
 import ReactDOM from 'react-dom'
 import helloIcon from '../hello_react/images/icon.png'
-import './hello-react.sass'
+import '../hello_react/styles/hello-react.sass'
 
 const Hello = props => (
   <div className="hello-react">


### PR DESCRIPTION
The example is misleading, because doing it like in the the current state would cause Webpack to compile hello-react.sass two times, since it's imported by `hello_react.jsx` and considered as entry point when being in `app/javascript/packs`