### PR TITLE
Fix nodejs and yarn checks

### DIFF
--- a/lib/tasks/webpacker/check_node.rake
+++ b/lib/tasks/webpacker/check_node.rake
@@ -3,8 +3,11 @@ namespace :webpacker do
   task :check_node do
     begin
       node_version = `node -v`
-      if node_version.tr("v", "").to_f < 6.4
-        puts "Webpacker requires Node.js >= 6.4 and you are using #{node_version}"
+      required_node_version = "6.4"
+
+      raise Errno::ENOENT if node_version.blank?
+      if Gem::Version.new(node_version.strip.tr("v", "")) < Gem::Version.new(required_node_version)
+        puts "Webpacker requires Node.js >= v#{required_node_version} and you are using #{node_version}"
         puts "Please upgrade Node.js https://nodejs.org/en/download/"
         puts "Exiting!" && exit!
       end

--- a/lib/tasks/webpacker/check_yarn.rake
+++ b/lib/tasks/webpacker/check_yarn.rake
@@ -2,7 +2,8 @@ namespace :webpacker do
   desc "Verifies if yarn is installed"
   task :check_yarn do
     begin
-      `yarn --version`
+      version = `yarn --version`
+      raise Errno::ENOENT if version.blank?
     rescue Errno::ENOENT
       puts "Webpacker requires yarn. Please download and install Yarn https://yarnpkg.com/lang/en/docs/install/"
       puts "Exiting!" && exit!


### PR DESCRIPTION
`webpacker:check_node` task is calculating nodejs version wrong

```
-> % bundle exec rake webpacker:check_node
Webpacker requires Node.js >= 6.4 and you are using v6.10.2
Please upgrade Node.js https://nodejs.org/en/download/
```

This PR replaces calculation to use `Gem::Version` instead of `version.to_f`. Also rails is using patched version of `backticks` which is not raising exception if the binary is not exists. More info can be found here: [Object#\`](http://www.rubydoc.info/docs/rails/Object#%60-instance_method) I've added a fix to `webpacker:check_node` and `webpacker:check_yarn` to raise `Errno::ENOENT` if the version check failed with blank value. I'm not sure if we have to raise and rescue in case of patched `backticks` in `active_support`, but I'm leaving it like this so it will work if the patch is removed.