### PR TITLE
Only load non-hidden .js files as loader

### DIFF
--- a/lib/install/config/webpack/shared.js
+++ b/lib/install/config/webpack/shared.js
@@ -5,7 +5,6 @@
 const webpack = require('webpack')
 const { basename, dirname, join, relative, resolve } = require('path')
 const { sync } = require('glob')
-const { readdirSync } = require('fs')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const ManifestPlugin = require('webpack-manifest-plugin')
 const extname = require('path-complete-extname')
@@ -27,9 +26,7 @@ module.exports = {
   output: { filename: '[name].js', path: resolve(paths.output, paths.entry) },
 
   module: {
-    rules: readdirSync(loadersDir).map(file => (
-      require(join(loadersDir, file))
-    ))
+    rules: sync(join(loadersDir, '*.js')).map(loader => require(loader))
   },
 
   plugins: [


### PR DESCRIPTION
Some editors, vim for example, create temporary hidden swap files when editing a file. This PR makes the webpack configuration use only non-hidden JavaScript files from the loaders directory. Which means it ignores swap files, instead of giving an error because they aren't valid JavaScript.