### PR TITLE
Add a lookup_path helper that returns full pack path based on name

### DIFF
--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -13,7 +13,7 @@ namespace :webpacker do
       exit! $?.exitstatus
     end
 
-    puts "Compiled digests for all packs in #{Webpacker::Configuration.output_path}: "
+    puts "Compiled digests for all packs in #{Webpacker::Configuration.packs_path}: "
     puts JSON.parse(File.read(Webpacker::Configuration.manifest_path))
   end
 end

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -17,17 +17,21 @@ class Webpacker::Configuration < Webpacker::FileLoader
     end
 
     def manifest_path
-      Rails.root.join(output_path, paths.fetch(:manifest, "manifest.json"))
+      Rails.root.join(packs_path, paths.fetch(:manifest, "manifest.json"))
     end
 
-    def output_path
-      Rails.root.join(paths.fetch(:output, "public"), paths.fetch(:entry, "packs"))
+    def packs_path
+      Rails.root.join(output_path, paths.fetch(:entry, "packs"))
     end
 
     def paths
       load if Webpacker::Env.development?
       raise Webpacker::FileLoader::FileLoaderError.new("Webpacker::Configuration.load must be called first") unless instance
       instance.data
+    end
+
+    def output_path
+      Rails.root.join(paths.fetch(:output, "public"))
     end
 
     def source_path

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -20,6 +20,10 @@ class Webpacker::Manifest < Webpacker::FileLoader
       raise Webpacker::FileLoader::FileLoaderError.new("Webpacker::Manifest.load must be called first") unless instance
       instance.data[name.to_s] || raise(Webpacker::FileLoader::NotFoundError.new("Can't find #{name} in #{file_path}. Is webpack still compiling?"))
     end
+
+    def lookup_path(name)
+      Rails.root.join(File.join(Webpacker::Configuration.output_path, lookup(name)))
+    end
   end
 
   private


### PR DESCRIPTION
Related to https://github.com/rails/webpacker/issues/231

```rb
# Production
irb(main):001:0> Webpacker::Manifest.lookup_path('admin/application.js')
=> #<Pathname:/Users/gaurav/webpacker-example-app/public/entries/admin/application-5fdeda182bb4fe694c49.js>
irb(main):002:0> Webpacker::Manifest.lookup_path('app.js')
=> #<Pathname:/Users/gaurav/webpacker-example-app/public/entries/app-ec0bee47eec8c98b0850.js>

# Development
irb(main):001:0> Webpacker::Manifest.lookup_path('app.js')
=> #<Pathname:/Users/gaurav/webpacker-example-app/public/entries/app.js>
```

@rmosolgo Is this good enough?