### PR TITLE
Fixed a bug where node 6.10 would be converted to 6.1

### DIFF
--- a/lib/tasks/webpacker/check_node.rake
+++ b/lib/tasks/webpacker/check_node.rake
@@ -3,7 +3,8 @@ namespace :webpacker do
   task :check_node do
     begin
       node_version = `node -v`
-      if node_version.tr("v", "").to_f < 6.4
+      major_version, minor_version = node_version.tr("v", "").split(".").map(&:to_i)
+      if (major_version.to_i > 6) || (major_version == 6 && minor_version >= 4)
         puts "Webpacker requires Node.js >= 6.4 and you are using #{node_version}"
         puts "Please upgrade Node.js https://nodejs.org/en/download/"
         puts "Exiting!" && exit!

--- a/lib/tasks/webpacker/check_node.rake
+++ b/lib/tasks/webpacker/check_node.rake
@@ -4,7 +4,7 @@ namespace :webpacker do
     begin
       node_version = `node -v`
       major_version, minor_version = node_version.tr("v", "").split(".").map(&:to_i)
-      if (major_version.to_i > 6) || (major_version == 6 && minor_version >= 4)
+      if (major_version <= 6) || (major_version == 6 && minor_version < 4)
         puts "Webpacker requires Node.js >= 6.4 and you are using #{node_version}"
         puts "Please upgrade Node.js https://nodejs.org/en/download/"
         puts "Exiting!" && exit!

--- a/lib/tasks/webpacker/check_node.rake
+++ b/lib/tasks/webpacker/check_node.rake
@@ -4,7 +4,7 @@ namespace :webpacker do
     begin
       node_version = `node -v`
       major_version, minor_version = node_version.tr("v", "").split(".").map(&:to_i)
-      if (major_version <= 6) || (major_version == 6 && minor_version < 4)
+      if (major_version < 6) || (major_version == 6 && minor_version < 4)
         puts "Webpacker requires Node.js >= 6.4 and you are using #{node_version}"
         puts "Please upgrade Node.js https://nodejs.org/en/download/"
         puts "Exiting!" && exit!


### PR DESCRIPTION
The previous way converted a s "6.10" to 6.1 before comparison with 6.4. This meant that Node 6.10 (the LTS running on Heroku) was converted to 6.1, and was less than the required 6.4

This change now compares on major version first, then an integer of the major and minor.