### PR TITLE
Vue does not require an eventListener

### DIFF
--- a/lib/install/examples/vue/hello_vue.js
+++ b/lib/install/examples/vue/hello_vue.js
@@ -7,13 +7,11 @@
 import Vue from 'vue/dist/vue.esm'
 import App from './app.vue'
 
-document.addEventListener('DOMContentLoaded', () => {
-  document.body.appendChild(document.createElement('hello'))
-  const app = new Vue({
-    el: 'hello',
-    template: '<App/>',
-    components: { App }
-  })
-
-  console.log(app)
+document.body.appendChild(document.createElement('hello'))
+const app = new Vue({
+  el: 'hello',
+  template: '<App/>',
+  components: { App }
 })
+
+console.log(app)


### PR DESCRIPTION
It seems that Vue does not require an eventListener for DOMContentLoaded. 

Can somebody verify this PR? It seems to work without eventListener on my end.