### PR TITLE
Enable Tree Shaking (for react)

### DIFF
--- a/lib/install/examples/react/.babelrc
+++ b/lib/install/examples/react/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["env", "react"]
+  "presets": [
+    ["env", { "modules": false } ],
+    "react"
+  ]
 }


### PR DESCRIPTION
In order to enable [tree shaking](https://webpack.js.org/guides/tree-shaking/) out of the box, webpack needs to do the compiling of "module" statements (`import` and `export` statements).

Therefore, module compilation should be disabled for `babel-preset-env` in `.babelrc`.

Note: this only applies to `react`, as the other examples do not have a `.babelrc` right now