### PR TITLE
Re-enable Spring for rails-erb-loader

### DIFF
--- a/lib/install/config/loaders/core/erb.js
+++ b/lib/install/config/loaders/core/erb.js
@@ -4,6 +4,6 @@ module.exports = {
   exclude: /node_modules/,
   loader: 'rails-erb-loader',
   options: {
-    runner: 'DISABLE_SPRING=1 bin/rails runner'
+    runner: 'bin/rails runner'
   }
 }


### PR DESCRIPTION
I'm the committer who originally disabled spring on this line. It was likely a mistake - see further discussion in the issue https://github.com/rails/webpacker/issues/216.

With `DISABLE_SPRING=1` removed, I've ran `bin/webpack` with both RAILS_ENV=development & production - both work.