### PR TITLE
Install JS packages as dev-dependency

### DIFF
--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -19,7 +19,7 @@ EOS
 end
 
 puts "Installing all JavaScript dependencies"
-run "./bin/yarn add webpack webpack-merge js-yaml path-complete-extname " \
+run "./bin/yarn add --dev webpack webpack-merge js-yaml path-complete-extname " \
 "webpack-manifest-plugin babel-loader coffee-loader coffee-script " \
 "babel-core babel-preset-env compression-webpack-plugin rails-erb-loader glob " \
 "extract-text-webpack-plugin node-sass file-loader sass-loader css-loader style-loader " \


### PR DESCRIPTION
I think the packages installed by `webpacker:install` (such as webpack, babel) don't have to be installed as `dependencies` in `package.json`. 

This PR makes the packages `devDependencies`.