### PR TITLE
execute the same ruby interpreter as is currently running

### DIFF
--- a/lib/tasks/installers.rake
+++ b/lib/tasks/installers.rake
@@ -11,9 +11,9 @@ namespace :webpacker do
       task task_name => ["webpacker:verify_install"] do
         template = File.expand_path("../install/#{task_name}.rb", __dir__)
         if Rails::VERSION::MAJOR >= 5
-          exec "./bin/rails app:template LOCATION=#{template}"
+          exec "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{template}"
         else
-          exec "./bin/rake rails:template LOCATION=#{template}"
+          exec "#{RbConfig.ruby} ./bin/rake rails:template LOCATION=#{template}"
         end
       end
     end

--- a/lib/tasks/webpacker/install.rake
+++ b/lib/tasks/webpacker/install.rake
@@ -4,9 +4,9 @@ namespace :webpacker do
   desc "Install webpacker in this application"
   task install: [:check_node, :check_yarn] do
     if Rails::VERSION::MAJOR >= 5
-      exec "./bin/rails app:template LOCATION=#{WEBPACKER_APP_TEMPLATE_PATH}"
+      exec "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{WEBPACKER_APP_TEMPLATE_PATH}"
     else
-      exec "./bin/rake rails:template LOCATION=#{WEBPACKER_APP_TEMPLATE_PATH}"
+      exec "#{RbConfig.ruby} ./bin/rake rails:template LOCATION=#{WEBPACKER_APP_TEMPLATE_PATH}"
     end
   end
 end


### PR DESCRIPTION
This makes it possible to run on Microsoft Windows.  Arguably it
is desirable elsewhere.

Fixes #245