### PR TITLE
Use export default instead of module.exports in Vue component example

### DIFF
--- a/lib/install/examples/vue/app.vue
+++ b/lib/install/examples/vue/app.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script>
-module.exports = {
+export default {
   data: function () {
     return {
       message: "Hello Vue!"


### PR DESCRIPTION
I encountered a problem importing new modules within the `<script>` tag of the example Vue component, and it turned out that `module.exports =` was the culprit. It looks like vue-loader prefers the `export default` syntax, as depicted here: https://vue-loader.vuejs.org/en/start/spec.html

Once I made that change in my example file, I was able to add `import` statements to the top of the `<script>` tag without a problem. 