### PR TITLE
get rid of babel loader warning

### DIFF
--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -26,7 +26,7 @@ end
 
 puts "Installing all JavaScript dependencies"
 run "./bin/yarn add webpack webpack-merge js-yaml path-complete-extname " \
-"webpack-manifest-plugin babel-loader coffee-loader coffee-script " \
+"webpack-manifest-plugin babel-loader@7.x coffee-loader coffee-script " \
 "babel-core babel-preset-env compression-webpack-plugin rails-erb-loader glob " \
 "extract-text-webpack-plugin node-sass file-loader sass-loader css-loader style-loader " \
 "postcss-loader autoprefixer postcss-smart-import precss"


### PR DESCRIPTION
`webpack 2.x | babel-loader >= 7.x (recommended) (^6.2.10 will also work, but with deprecation warnings)`
https://github.com/babel/babel-loader