### PR TITLE
Don't set ASSET_HOST environment if no asset host configured

### DIFF
--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -7,7 +7,8 @@ namespace :webpacker do
   task compile: ["webpacker:verify_install", :environment] do
     puts "Compiling webpacker assets 🎉"
     asset_host = Rails.application.config.action_controller.asset_host
-    result = `ASSET_HOST=#{asset_host} NODE_ENV=#{Webpacker::Env.current} ./bin/webpack --json`
+    asset_env = asset_host ? "ASSET_HOST=#{asset_host}" : ""
+    result = `#{asset_env} NODE_ENV=#{Webpacker::Env.current} ./bin/webpack --json`
 
     unless $?.success?
       puts JSON.parse(result)["errors"]


### PR DESCRIPTION
This change avoids setting the ASSET_HOST environment variable in the compilation rake task if no asset host is set in Rails' configuration.

Previously—introduced in #224—if no asset host was configured, this environment variable would be set to an empty string, which caused the default `ifHasCDN` check in `configuration.js` to always return `true` in production.