### PR TITLE
Remove template strings from vue example

### DIFF
--- a/lib/install/examples/vue/hello_vue.js
+++ b/lib/install/examples/vue/hello_vue.js
@@ -4,16 +4,12 @@
 // like app/views/layouts/application.html.erb.
 // All it does is render <div>Hello Vue</div> at the bottom of the page.
 
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 import App from './app.vue'
 
 document.addEventListener('DOMContentLoaded', () => {
   document.body.appendChild(document.createElement('hello'))
-  const app = new Vue({
-    el: 'hello',
-    template: '<App/>',
-    components: { App }
-  })
+  const app = new Vue(App).$mount('hello')
 
   console.log(app)
 })


### PR DESCRIPTION
This gives a better convention to start users of with -
all templates are pre-compiled through webpack/vue-loader,
and the runtime-only version of vue is imported instead.

Resolves https://github.com/rails/webpacker/issues/300.