### PR TITLE
only use dev server in manifest if it's enabled

### DIFF
--- a/lib/install/config/webpack/configuration.js
+++ b/lib/install/config/webpack/configuration.js
@@ -14,7 +14,7 @@ const devServer = safeLoad(readFileSync(join(configPath, 'development.server.yml
 const ifHasCDN = env.ASSET_HOST !== undefined && env.NODE_ENV === 'production'
 const devServerUrl = `http://${devServer.host}:${devServer.port}/${paths.entry}/`
 const publicUrl = ifHasCDN ? `${env.ASSET_HOST}/${paths.entry}/` : `/${paths.entry}/`
-const publicPath = env.NODE_ENV !== 'production' ? devServerUrl : publicUrl
+const publicPath = env.NODE_ENV !== 'production' && devServer.enabled ? devServerUrl : publicUrl
 
 module.exports = {
   devServer,


### PR DESCRIPTION
# Problem

The dev server is configured to be [disabled by default in the test environment](https://github.com/rails/webpacker/blob/master/lib/install/config/webpack/development.server.yml#L13).  However, [this setting is ignored](https://github.com/rails/webpacker/blob/master/lib/install/config/webpack/configuration.js#L17) when writing the manifest.  I believe this was erroneously changed in #295 

# Solution

Restore that line of code so that if the dev server is not enabled, don't use it in the manifest.
