### PR TITLE
Better default, keep ignore files starting with '_' for webpack entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ make any changes for a basic setup out the box. But this is where you do go if y
 more advanced.
 
 The configuration for what Webpack is supposed to compile by default rests on the convention that
-every file in `app/javascript/packs/*` should be turned into their own output files (or entry points,
+every file in `app/javascript/packs/*` (except files starting with `_`) should be turned into their own output files (or entry points,
 as Webpack calls it).
 
 Let's say you're building a calendar. Your structure could look like this:

--- a/lib/install/config/webpack/shared.js
+++ b/lib/install/config/webpack/shared.js
@@ -11,7 +11,7 @@ const ManifestPlugin = require('webpack-manifest-plugin')
 const extname = require('path-complete-extname')
 const { env, paths, publicPath, loadersDir } = require('./configuration.js')
 
-const extensionGlob = `**/*{${paths.extensions.join(',')}}*`
+const extensionGlob = `**/[^_]*{${paths.extensions.join(',')}}*`
 const packPaths = sync(join(paths.source, paths.entry, extensionGlob))
 
 module.exports = {


### PR DESCRIPTION
Many use `_` to denote SCSS/CSS partials. It's better to ignore those as entry points since most of the times it end up with variable not defined or similar errors.