### PR TITLE
Extract CSS and have smaller build size.

### DIFF
--- a/lib/install/config/loaders/installers/vue.js
+++ b/lib/install/config/loaders/installers/vue.js
@@ -2,6 +2,7 @@ module.exports = {
   test: /.vue$/,
   loader: 'vue-loader',
   options: {
+    extractCSS: true,
     loaders: {
       js: 'babel-loader',
       file: 'file-loader',

--- a/lib/install/examples/vue/hello_vue.js
+++ b/lib/install/examples/vue/hello_vue.js
@@ -1,5 +1,5 @@
 /* eslint no-console: 0 */
-// Run this example by adding <%= javascript_pack_tag 'hello_vue' %>
+// Run this example by adding <%= javascript_pack_tag 'hello_vue' %> and <%= stylesheet_pack_tag 'hello_vue' %>
 // to the head of your layout file,
 // like app/views/layouts/application.html.erb.
 // All it does is render <div>Hello Vue</div> at the bottom of the page.

--- a/lib/install/examples/vue/hello_vue.js
+++ b/lib/install/examples/vue/hello_vue.js
@@ -1,6 +1,6 @@
 /* eslint no-console: 0 */
-// Run this example by adding <%= javascript_pack_tag 'hello_vue' %> and <%= stylesheet_pack_tag 'hello_vue' %>
-// to the head of your layout file,
+// Run this example by adding <%= javascript_pack_tag 'hello_vue' %> and
+// <%= stylesheet_pack_tag 'hello_vue' %> to the head of your layout file,
 // like app/views/layouts/application.html.erb.
 // All it does is render <div>Hello Vue</div> at the bottom of the page.
 


### PR DESCRIPTION
[Extracting CSS into a Single File vue-loader](http://vue-loader.vuejs.org/en/configurations/extract-css.html).

This gets us ~7,6K smaller build, because we don 't need JS to inject styles into head during runtime.

Comparison:

Before:
<img width="691" alt="css-injected-into-head" src="https://cloud.githubusercontent.com/assets/957321/25569878/4984d9fa-2dd3-11e7-833f-c0d8669e6623.png">

After:
<img width="690" alt="extracted-css-file" src="https://cloud.githubusercontent.com/assets/957321/25569880/4f54b0d0-2dd3-11e7-87af-a66f7331eca4.png">
