### PR TITLE
Updated Elm Webpack loader to use current working directory.

### DIFF
--- a/lib/install/config/loaders/installers/elm.js
+++ b/lib/install/config/loaders/installers/elm.js
@@ -1,5 +1,9 @@
+const path = require('path')
+
+const elmSource = path.resolve(process.cwd())
+
 module.exports = {
   test: /\.elm$/,
   exclude: [/elm-stuff/, /node_modules/],
-  loader: 'elm-hot-loader!elm-webpack-loader?verbose=true&warn=true&debug=true'
+  loader: `elm-hot-loader!elm-webpack-loader?verbose=true&warn=true&debug=true&cwd=${elmSource}`
 }

--- a/lib/install/elm.rb
+++ b/lib/install/elm.rb
@@ -19,4 +19,8 @@ run "./bin/yarn add elm"
 run "./bin/yarn add --dev elm-hot-loader elm-webpack-loader"
 run "yarn run elm package install -- --yes"
 
+puts "Updating elm source location"
+source_path = File.join Webpacker::Configuration.source, Webpacker::Configuration.paths.fetch(:entry, "packs")
+gsub_file "elm-package.json", /\"\.\"\n/, %("#{source_path}"\n)
+
 puts "Webpacker now supports elm 🎉"

--- a/lib/install/examples/elm/hello_elm.js
+++ b/lib/install/examples/elm/hello_elm.js
@@ -1,11 +1,11 @@
 // Run this example by adding <%= javascript_pack_tag "hello_elm" %> to the head of your layout
 // file, like app/views/layouts/application.html.erb. It will render "Hello Elm!" within the page.
 
-import App from './Main'
+import Elm from './Main'
 
 document.addEventListener('DOMContentLoaded', () => {
   const target = document.createElement('div')
 
   document.body.appendChild(target)
-  App.Main.embed(target)
+  Elm.Main.embed(target)
 })


### PR DESCRIPTION
## Overview

Ensures the [Elm Webpack Loader](https://github.com/elm-community/elm-webpack-loader#cwd-default-null-recommended) sets the current working directory to the Rails app root so that directives in the `elm-package.json` are fully honored.

This allows an Elm developer to add multiple Elm package dependencies as well as layout their app via multiple sub-directories/modules and Webpack will automatically pick up and compile them.

## Details

- Addresses a concern that @eeue56 pointed out in his [PR](https://github.com/rails/webpacker/pull/324#discussion_r115103572).
- See commits for details.
