### PR TITLE
Updated gem version to use semantic versioning.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    webpacker (1.2)
+    webpacker (1.2.0)
       activesupport (>= 4.2)
       multi_json (~> 1.2)
       railties (>= 4.2)

--- a/README.md
+++ b/README.md
@@ -247,5 +247,13 @@ completed the compilation successfully before loading a view.
 ` <% helpers = ActionController::Base.helpers %>` at the beginning of each file
 - Consider chunking setup
 
+## Versioning
+
+Read [Semantic Versioning](http://semver.org) for details. Briefly, it means:
+
+- Major (X.y.z) - Incremented for any backwards incompatible public API changes.
+- Minor (x.Y.z) - Incremented for new, backwards compatible, public API enhancements/fixes.
+- Patch (x.y.Z) - Incremented for small, backwards compatible, bug fixes.
+
 ## License
 Webpacker is released under the [MIT License](https://opensource.org/licenses/MIT).

--- a/lib/webpacker/version.rb
+++ b/lib/webpacker/version.rb
@@ -1,3 +1,3 @@
 module Webpacker
-  VERSION = "1.2".freeze
+  VERSION = "1.2.0".freeze
 end


### PR DESCRIPTION
## Overview

- It's a good practice to use semantic versioning as a standard for
  communicating to others what has changed in this gem when updating
  dependencies in downsteam projects.
- [Documentation](http://semver.org).