### PR TITLE
Fix asset host duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
-- Added [Elm](http://elm-lang.org) support. You can now add Elm support via the following methods:
+## [Unreleased]
+
+### Added
+
+- [Elm](http://elm-lang.org) support. You can now add Elm support via the following methods:
   - New app: `rails new <app> --webpack=elm`
   - Within an existing app: `rails webpacker:install:elm`
+
+- Fix asset host duplication - [#320](https://github.com/rails/webpacker/issues/320)
 
 ## [1.2] - 2017-04-27
 Some of the changes made requires you to run below commands to install new changes.

--- a/lib/install/config/loaders/core/assets.js
+++ b/lib/install/config/loaders/core/assets.js
@@ -1,11 +1,21 @@
-const { env, publicPath } = require('../configuration.js')
+const Url = require('url-parse')
+const { env, paths, publicPath } = require('../configuration.js')
+
+// Compute path for internal pack assets if ASSET_HOST is supplied
+const computeAssetPath = (host) => {
+  if (!host) { return `/${paths.entry}/` }
+  const { slashes, href } = new Url(host)
+  if (slashes) { return `${href}/${paths.entry}/` }
+  if (href) { return `//${href}/${paths.entry}/` }
+  return `/${paths.entry}/`
+}
 
 module.exports = {
   test: /\.(jpg|jpeg|png|gif|svg|eot|ttf|woff|woff2)$/i,
   use: [{
     loader: 'file-loader',
     options: {
-      publicPath,
+      publicPath: env.NODE_ENV === 'production' ? computeAssetPath(env.ASSET_HOST) : publicPath,
       name: env.NODE_ENV === 'production' ? '[name]-[hash].[ext]' : '[name].[ext]'
     }
   }]

--- a/lib/install/config/loaders/core/assets.js
+++ b/lib/install/config/loaders/core/assets.js
@@ -10,13 +10,18 @@ const computeAssetPath = (host) => {
   return `/${paths.entry}/`
 }
 
+// Get asset options based on NODE_ENV
+const assetOptions = () => {
+  if (env.NODE_ENV === 'production') {
+    return { publicPath: computeAssetPath(env.ASSET_HOST), name: '[name]-[hash].[ext]' }
+  }
+  return { publicPath, name: '[name].[ext]' }
+}
+
 module.exports = {
   test: /\.(jpg|jpeg|png|gif|svg|eot|ttf|woff|woff2)$/i,
   use: [{
     loader: 'file-loader',
-    options: {
-      publicPath: env.NODE_ENV === 'production' ? computeAssetPath(env.ASSET_HOST) : publicPath,
-      name: env.NODE_ENV === 'production' ? '[name]-[hash].[ext]' : '[name].[ext]'
-    }
+    options: assetOptions(env)
   }]
 }

--- a/lib/install/config/loaders/core/assets.js
+++ b/lib/install/config/loaders/core/assets.js
@@ -1,24 +1,33 @@
+/* eslint no-else-return: 0 */
+
 const Url = require('url-parse')
 const { env, paths, publicPath } = require('../configuration.js')
 
 // Make sure host has slashes
 const ensureSlashes = ({ href, slashes }) => {
-  if (slashes) { return `${href}/${paths.entry}/` }
-  return `//${href}/${paths.entry}/`
+  if (slashes) {
+    return `${href}/${paths.entry}/`
+  } else {
+    return `//${href}/${paths.entry}/`
+  }
 }
 
 // Compute path for internal pack assets if ASSET_HOST is supplied
 const computeAssetPath = (host) => {
-  if (!host) { return `/${paths.entry}/` }
-  return ensureSlashes(new Url(host))
+  if (!host) {
+    return `/${paths.entry}/`
+  } else {
+    return ensureSlashes(new Url(host))
+  }
 }
 
 // Get asset options based on NODE_ENV
 const assetOptions = (nodeENV) => {
   if (nodeENV === 'production') {
     return { publicPath: computeAssetPath(env.ASSET_HOST), name: '[name]-[hash].[ext]' }
+  } else {
+    return { publicPath, name: '[name].[ext]' }
   }
-  return { publicPath, name: '[name].[ext]' }
 }
 
 module.exports = {

--- a/lib/install/config/loaders/core/assets.js
+++ b/lib/install/config/loaders/core/assets.js
@@ -22,6 +22,6 @@ module.exports = {
   test: /\.(jpg|jpeg|png|gif|svg|eot|ttf|woff|woff2)$/i,
   use: [{
     loader: 'file-loader',
-    options: assetOptions(env)
+    options: assetOptions()
   }]
 }

--- a/lib/install/config/loaders/core/assets.js
+++ b/lib/install/config/loaders/core/assets.js
@@ -2,9 +2,9 @@ const Url = require('url-parse')
 const { env, paths, publicPath } = require('../configuration.js')
 
 // Make sure host has slashes
-const ensureSlashes = ({ host, slashes }) => {
-  if (slashes) { return `${host}/${paths.entry}/` }
-  return `//${host}/${paths.entry}/`
+const ensureSlashes = ({ href, slashes }) => {
+  if (slashes) { return `${href}/${paths.entry}/` }
+  return `//${href}/${paths.entry}/`
 }
 
 // Compute path for internal pack assets if ASSET_HOST is supplied

--- a/lib/install/config/loaders/core/assets.js
+++ b/lib/install/config/loaders/core/assets.js
@@ -1,13 +1,16 @@
 const Url = require('url-parse')
 const { env, paths, publicPath } = require('../configuration.js')
 
+// Make sure host has slashes
+const ensureSlashes = ({ host, slashes }) => {
+  if (slashes) { return `${host}/${paths.entry}/` }
+  return `//${host}/${paths.entry}/`
+}
+
 // Compute path for internal pack assets if ASSET_HOST is supplied
 const computeAssetPath = (host) => {
   if (!host) { return `/${paths.entry}/` }
-  const { slashes, href } = new Url(host)
-  if (slashes) { return `${href}/${paths.entry}/` }
-  if (href) { return `//${href}/${paths.entry}/` }
-  return `/${paths.entry}/`
+  return ensureSlashes(new Url(host))
 }
 
 // Get asset options based on NODE_ENV

--- a/lib/install/config/loaders/core/assets.js
+++ b/lib/install/config/loaders/core/assets.js
@@ -14,8 +14,8 @@ const computeAssetPath = (host) => {
 }
 
 // Get asset options based on NODE_ENV
-const assetOptions = () => {
-  if (env.NODE_ENV === 'production') {
+const assetOptions = (nodeENV) => {
+  if (nodeENV === 'production') {
     return { publicPath: computeAssetPath(env.ASSET_HOST), name: '[name]-[hash].[ext]' }
   }
   return { publicPath, name: '[name].[ext]' }
@@ -25,6 +25,6 @@ module.exports = {
   test: /\.(jpg|jpeg|png|gif|svg|eot|ttf|woff|woff2)$/i,
   use: [{
     loader: 'file-loader',
-    options: assetOptions()
+    options: assetOptions(env.NODE_ENV)
   }]
 }

--- a/lib/install/config/webpack/configuration.js
+++ b/lib/install/config/webpack/configuration.js
@@ -10,17 +10,14 @@ const loadersDir = join(__dirname, 'loaders')
 const paths = safeLoad(readFileSync(join(configPath, 'paths.yml'), 'utf8'))[env.NODE_ENV]
 const devServer = safeLoad(readFileSync(join(configPath, 'development.server.yml'), 'utf8'))[env.NODE_ENV]
 
-// Compute public path based on environment and ASSET_HOST in production
-const ifHasCDN = env.ASSET_HOST !== undefined && env.NODE_ENV === 'production'
-const devServerUrl = `http://${devServer.host}:${devServer.port}/${paths.entry}/`
-const publicUrl = ifHasCDN ? `${env.ASSET_HOST}/${paths.entry}/` : `/${paths.entry}/`
-const publicPath = env.NODE_ENV !== 'production' && devServer.enabled ? devServerUrl : publicUrl
+// Compute public path based on environment
+const publicPath = env.NODE_ENV !== 'production' && devServer.enabled ?
+  `//${devServer.host}:${devServer.port}/${paths.entry}/` : `/${paths.entry}/`
 
 module.exports = {
   devServer,
   env,
   paths,
   loadersDir,
-  publicUrl,
   publicPath
 }

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -27,7 +27,7 @@ run "yarn add webpack webpack-merge js-yaml path-complete-extname " \
 "webpack-manifest-plugin babel-loader@7.x coffee-loader coffee-script " \
 "babel-core babel-preset-env compression-webpack-plugin rails-erb-loader glob " \
 "extract-text-webpack-plugin node-sass file-loader sass-loader css-loader style-loader " \
-"postcss-loader autoprefixer postcss-smart-import precss"
+"postcss-loader autoprefixer postcss-smart-import precss url-parse"
 
 puts "Installing dev server for live reloading"
 run "yarn add --dev webpack-dev-server"

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -27,7 +27,6 @@ run "yarn add webpack webpack-merge js-yaml path-complete-extname " \
 "webpack-manifest-plugin babel-loader@7.x coffee-loader coffee-script " \
 "babel-core babel-preset-env babel-polyfill compression-webpack-plugin rails-erb-loader glob " \
 "extract-text-webpack-plugin node-sass file-loader sass-loader css-loader style-loader " \
-"postcss-loader autoprefixer postcss-smart-import precss url-parse"
 "postcss-loader autoprefixer postcss-smart-import precss resolve-url-loader url-parse"
 
 puts "Installing dev server for live reloading"


### PR DESCRIPTION
Fixes https://github.com/rails/webpacker/issues/320 and other linked issues around asset host. 

Since we are using Rails asset helper tag internally, CDN is applied automatically on all top level webpack assets, however the internal JS assets like images and fonts don't use CDN. 

Previously in #224 a fix was introduced but it broke the expected behaviour - basically we were applying ASSET_HOST twice. This PR fixes this and only applies ASSET_HOST to internal file loader assets. 