### PR TITLE
pass babel-loader options to js loader in vue-loader

### DIFF
--- a/lib/install/config/loaders/installers/vue.js
+++ b/lib/install/config/loaders/installers/vue.js
@@ -1,10 +1,12 @@
+const babelLoader = require('./babel')
+
 module.exports = {
   test: /.vue$/,
   loader: 'vue-loader',
   options: {
     extractCSS: true,
     loaders: {
-      js: 'babel-loader',
+      js: 'babel-loader?' + JSON.stringify(babelLoader.options),
       file: 'file-loader',
       scss: 'vue-style-loader!css-loader!postcss-loader!sass-loader',
       sass: 'vue-style-loader!css-loader!postcss-loader!sass-loader?indentedSyntax'

--- a/lib/install/config/loaders/installers/vue.js
+++ b/lib/install/config/loaders/installers/vue.js
@@ -6,7 +6,7 @@ module.exports = {
   options: {
     extractCSS: true,
     loaders: {
-      js: 'babel-loader?' + JSON.stringify(babelLoader.options),
+      js: `babel-loader?${JSON.stringify(babelLoader.options)}`,
       file: 'file-loader',
       scss: 'vue-style-loader!css-loader!postcss-loader!sass-loader',
       sass: 'vue-style-loader!css-loader!postcss-loader!sass-loader?indentedSyntax'


### PR DESCRIPTION
### Synopsis
Default babel `env` preset does not transform es2017 [Spread Operator](https://babeljs.io/docs/plugins/transform-object-rest-spread/) so I added babel plugin `transform-object-rest-spread` to my babel-loader config. But it din't work in my`component_name.vue` file. So I spent an hour or two in attempts to make it work and then found that `Spread Operator` works perfectly in any of my`.js` or `.coffe` files but it doesn't work at all in `.vue` files.

This is how I found [this issue](https://github.com/vuejs/vue-loader/issues/417) in vue-loader repository.

### Merge request
So my suggestion is to pass babel-loader config options into js loader of vue-loader. At least this solution resolved my problem.

May be it should also be added to react-loader but I'm not sure. I'm not familiar with react and can't check it properly.