### PR TITLE
Update README.md with related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,3 +249,7 @@ completed the compilation successfully before loading a view.
 
 ## License
 Webpacker is released under the [MIT License](https://opensource.org/licenses/MIT).
+
+## Related Projects
+* [Webpacker Lite](https://github.com/shakacode/webpacker_lite): Light and unopinionated webpacker, without the generators or Webpack replacements. You have to configure Webpack with the [Manifest Plugin](https://www.npmjs.com/package/webpack-manifest-plugin). Webpacker Lite is designed to work with [React on Rails](https://github.com/shakacode/react_on_rails).
+* [React on Rails](https://github.com/shakacode/react_on_rails): Opinionated integration of Rails with React, React-Router, and Redux using Webpack via [Webpacker Lite](https://github.com/shakacode/webpacker_lite).


### PR DESCRIPTION
We can add some other related projects, like https://rubygems.org/gems/webpacker-react. However, that one might not be ready for production yet, with less than 2700 downloads as of now.  React on Rails has almost 330,000 downloads. While Webpacker Lite is new, it will have heavy traffic due to React on Rails and it offers a viable alternative to Webpacker for those that do not want to auto-configure webpack.