### PR TITLE
vue-loader with support of extract styles (#340)

### DIFF
--- a/lib/install/config/loaders/installers/vue.js
+++ b/lib/install/config/loaders/installers/vue.js
@@ -1,13 +1,41 @@
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
+const { env } = require('../configuration.js')
+
+// Change it to false if you prefer Vue styles to be inlined by javascript in runtime
+const extractStyles = false
+
+const cssLoader = [
+  { loader: 'css-loader', options: { minimize: env.NODE_ENV === 'production' } },
+  { loader: 'postcss-loader', options: { sourceMap: true } },
+  'resolve-url-loader'
+]
+const sassLoader = cssLoader.concat([
+  { loader: 'sass-loader', options: { sourceMap: true, indentedSyntax: true } }
+])
+const scssLoader = cssLoader.concat([
+  { loader: 'sass-loader', options: { sourceMap: true } }
+])
+
+function vueStyleLoader(loader) {
+  if (extractStyles) {
+    return ExtractTextPlugin.extract({
+      fallback: 'vue-style-loader',
+      use: loader
+    })
+  }
+  return ['vue-style-loader'].concat(loader)
+}
+
 module.exports = {
   test: /.vue$/,
   loader: 'vue-loader',
   options: {
-    extractCSS: true,
     loaders: {
       js: 'babel-loader',
       file: 'file-loader',
-      scss: 'vue-style-loader!css-loader!postcss-loader!sass-loader',
-      sass: 'vue-style-loader!css-loader!postcss-loader!sass-loader?indentedSyntax'
+      css: vueStyleLoader(cssLoader),
+      scss: vueStyleLoader(scssLoader),
+      sass: vueStyleLoader(sassLoader)
     }
   }
 }


### PR DESCRIPTION
this PR fixes two things

1. #340 issue
2. Styles parsing in `.vue` should work exactly the same way it works for regular `.css`/`.sass` files. This means that in `loaders/vue` we should use the same loaders configuration that we use in `loaders/sass`. But I'm not sure where to put shared loaders configuration. In this PR I just copy-pasted them.

I also added ability to disable styles extraction with `extractStyles` variable because in some cases it's better to inline styles rather than extract them. 

Any suggestions? How about such file?
`loaders/core/common(or shared or configuration).js`
```js
const cssLoader = [
  { loader: 'css-loader', options: { minimize: env === 'production' } },
  'postcss-loader'
]
module.exports = {
  css: cssLoader,
  sass: cssLoader.concat(['sass-loader?indentedSyntax'])
  scss: cssLoader.concat(['sass-loader'])
}
```