### PR TITLE
Adjust Elm compilation flags for production

### DIFF
--- a/lib/install/config/loaders/installers/elm.js
+++ b/lib/install/config/loaders/installers/elm.js
@@ -4,11 +4,11 @@ const { env } = require('../configuration.js')
 const elmSource = path.resolve(process.cwd())
 
 const loaderOptions = () => {
-  if (env.NODE_ENV === 'production') {
-    return `elm-webpack-loader?cwd=${elmSource}`
+  if (['development', 'test'].includes(env.NODE_ENV)) {
+    return `elm-hot-loader!elm-webpack-loader?cwd=${elmSource}&verbose=true&warn=true&debug=true`
   }
 
-  return `elm-hot-loader!elm-webpack-loader?cwd=${elmSource}&verbose=true&warn=true&debug=true`
+  return `elm-webpack-loader?cwd=${elmSource}`
 }
 
 module.exports = {

--- a/lib/install/config/loaders/installers/elm.js
+++ b/lib/install/config/loaders/installers/elm.js
@@ -2,11 +2,17 @@ const path = require('path')
 const { env } = require('../configuration.js')
 
 const elmSource = path.resolve(process.cwd())
-const elmLoader = env.NODE_ENV === 'production' ?  'elm-webpack-loader' : 'elm-hot-loader!elm-webpack-loader'
-const debug = env.NODE_ENV === 'production' ? 'false' : 'true'
+
+const loaderOptions = () => {
+    if (env.NODE_ENV === "production") {
+        return `elm-webpack-loader?cwd=${elmSource}`
+    }
+
+    return `elm-hot-loader!elm-webpack-loader?cwd=${elmSource}&verbose=true&warn=true&debug=true`
+}
 
 module.exports = {
   test: /\.elm$/,
   exclude: [/elm-stuff/, /node_modules/],
-  loader: `${elmLoader}?verbose=true&warn=true&debug=${debug}&cwd=${elmSource}`
+  loader: loaderOptions()
 }

--- a/lib/install/config/loaders/installers/elm.js
+++ b/lib/install/config/loaders/installers/elm.js
@@ -4,11 +4,11 @@ const { env } = require('../configuration.js')
 const elmSource = path.resolve(process.cwd())
 
 const loaderOptions = () => {
-    if (env.NODE_ENV === "production") {
-        return `elm-webpack-loader?cwd=${elmSource}`
-    }
+  if (env.NODE_ENV === 'production') {
+    return `elm-webpack-loader?cwd=${elmSource}`
+  }
 
-    return `elm-hot-loader!elm-webpack-loader?cwd=${elmSource}&verbose=true&warn=true&debug=true`
+  return `elm-hot-loader!elm-webpack-loader?cwd=${elmSource}&verbose=true&warn=true&debug=true`
 }
 
 module.exports = {

--- a/lib/install/config/loaders/installers/elm.js
+++ b/lib/install/config/loaders/installers/elm.js
@@ -1,9 +1,12 @@
 const path = require('path')
+const { env } = require('../configuration.js')
 
 const elmSource = path.resolve(process.cwd())
+const elmLoader = env.NODE_ENV === 'production' ?  'elm-webpack-loader' : 'elm-hot-loader!elm-webpack-loader'
+const debug = env.NODE_ENV === 'production' ? 'false' : 'true'
 
 module.exports = {
   test: /\.elm$/,
   exclude: [/elm-stuff/, /node_modules/],
-  loader: `elm-hot-loader!elm-webpack-loader?verbose=true&warn=true&debug=true&cwd=${elmSource}`
+  loader: `${elmLoader}?verbose=true&warn=true&debug=${debug}&cwd=${elmSource}`
 }

--- a/lib/install/config/loaders/installers/elm.js
+++ b/lib/install/config/loaders/installers/elm.js
@@ -4,11 +4,11 @@ const { env } = require('../configuration.js')
 const elmSource = path.resolve(process.cwd())
 
 const loaderOptions = () => {
-  if (['development', 'test'].includes(env.NODE_ENV)) {
-    return `elm-hot-loader!elm-webpack-loader?cwd=${elmSource}&verbose=true&warn=true&debug=true`
+  if (env.NODE_ENV === 'production') {
+    return `elm-webpack-loader?cwd=${elmSource}`
   }
 
-  return `elm-webpack-loader?cwd=${elmSource}`
+  return `elm-hot-loader!elm-webpack-loader?cwd=${elmSource}&verbose=true&warn=true&debug=true`
 }
 
 module.exports = {


### PR DESCRIPTION
Two independent changes:

1. The more important change is to not compile elm with debug in the `production` environment. Otherwise a web page with a compiled Elm app will display the debugger window:

<img width="202" alt="elm-debugger-small" src="https://cloud.githubusercontent.com/assets/1040764/25829453/304b7000-3424-11e7-9b44-aac8f340130f.png">


2. Less important/more uncertain change: do not user `elm-hot-loader` in production.
The docs say that Hot Module Replacement is usable in production but experimental and possibly buggy. See the [Caveats section](https://webpack.github.io/docs/hot-module-replacement-with-webpack.html#caveats) at https://webpack.github.io/docs/hot-module-replacement-with-webpack.html.
I am not a webpack expert and would be happy to change this back if someone provides a rationale, but my take is that HMR shouldn't be the default for production.

For both I switched only on the `production` environment, but there is a case that it should have the same behavior for `staging`.