### PR TITLE
Update the list of file formats to be compresses.

### DIFF
--- a/lib/install/config/webpack/production.js
+++ b/lib/install/config/webpack/production.js
@@ -15,7 +15,7 @@ module.exports = merge(sharedConfig, {
     new CompressionPlugin({
       asset: '[path].gz[query]',
       algorithm: 'gzip',
-      test: /\.(js|css|svg|eot|ttf|woff|woff2)$/
+      test: /\.(js|css|html|json|ico|svg|eot|otf|ttf)$/
     })
   ]
 })


### PR DESCRIPTION
*.woff and *.woff2 file formats are already compressed
and further compressions produces diminishing returns.

I used the following list from Fastly:
https://www.fastly.com/blog/new-gzip-settings-and-deciding-what-compress/

cc @gauravtiwari