### PR TITLE
binstubs: do not exec via the shell, but rather execute the programs directly

### DIFF
--- a/lib/install/bin/webpack-dev-server.tt
+++ b/lib/install/bin/webpack-dev-server.tt
@@ -27,7 +27,9 @@ rescue Errno::ENOENT, NoMethodError
   exit!
 end
 
+newenv = { "NODE_PATH" => NODE_MODULES_PATH }
+cmdline = [WEBPACK_BIN, "--progress", "--color", "--config", DEV_SERVER_CONFIG] + ARGV
+
 Dir.chdir(APP_PATH) do
-  exec "NODE_PATH=#{NODE_MODULES_PATH} #{WEBPACK_BIN} --progress --color " \
-    "--config #{DEV_SERVER_CONFIG} #{ARGV.join(" ")}"
+  exec newenv, *cmdline
 end

--- a/lib/install/bin/webpack.tt
+++ b/lib/install/bin/webpack.tt
@@ -27,7 +27,9 @@ end
 WEBPACK_BIN    = "#{NODE_MODULES_PATH}/.bin/webpack"
 WEBPACK_CONFIG = "#{WEBPACK_CONFIG_PATH}/#{NODE_ENV}.js"
 
+newenv = { "NODE_PATH" => NODE_MODULES_PATH }
+cmdline = [WEBPACK_BIN, "--config", WEBPACK_CONFIG] + ARGV
+
 Dir.chdir(APP_PATH) do
-  exec "NODE_PATH=#{NODE_MODULES_PATH} #{WEBPACK_BIN} --config #{WEBPACK_CONFIG}" \
-    " #{ARGV.join(" ")}"
+  exec newenv, *cmdline
 end


### PR DESCRIPTION
Windows cmd does not support the ENVVAR=VALUE syntax prepended to a command, so the binstubs did not work
there. To avoid that, use the exec form that does not go via the shell, and instead executes the program directly.

Fixes: #245

--

It appears the testsuite does not test these binstubs, and I don't know how to generate the resulting file to execute....