### PR TITLE
Fixed Elm install issue with older Webpacker gem versions.

### DIFF
--- a/lib/install/config/webpack/paths.yml
+++ b/lib/install/config/webpack/paths.yml
@@ -9,7 +9,6 @@ default: &default
   source: app/javascript
   extensions:
     - .coffee
-    - .elm
     - .js
     - .jsx
     - .ts

--- a/lib/install/elm.rb
+++ b/lib/install/elm.rb
@@ -11,9 +11,6 @@ puts "Copying elm app file to #{Webpacker::Configuration.entry_path}"
 copy_file "#{__dir__}/examples/elm/hello_elm.js",
           "#{Webpacker::Configuration.entry_path}/hello_elm.js"
 
-puts "Updating .gitignore to include elm-stuff folder"
-insert_into_file ".gitignore", "/elm-stuff\n", before: "/node_modules\n"
-
 puts "Installing all elm dependencies"
 run "./bin/yarn add elm"
 run "./bin/yarn add --dev elm-hot-loader elm-webpack-loader"
@@ -22,5 +19,8 @@ run "yarn run elm package install -- --yes"
 puts "Updating elm source location"
 source_path = File.join Webpacker::Configuration.source, Webpacker::Configuration.paths.fetch(:entry, "packs")
 gsub_file "elm-package.json", /\"\.\"\n/, %("#{source_path}"\n)
+
+puts "Updating .gitignore to include elm-stuff folder"
+insert_into_file ".gitignore", "/elm-stuff\n", before: "/node_modules\n"
 
 puts "Webpacker now supports elm 🎉"

--- a/lib/install/elm.rb
+++ b/lib/install/elm.rb
@@ -16,6 +16,9 @@ run "./bin/yarn add elm"
 run "./bin/yarn add --dev elm-hot-loader elm-webpack-loader"
 run "yarn run elm package install -- --yes"
 
+puts "Updating Webpack paths to include Elm file extension"
+insert_into_file Webpacker::Configuration.file_path, "    - .elm\n", after: /extensions:\n/
+
 puts "Updating elm source location"
 source_path = File.join Webpacker::Configuration.source, Webpacker::Configuration.paths.fetch(:entry, "packs")
 gsub_file "elm-package.json", /\"\.\"\n/, %("#{source_path}"\n)


### PR DESCRIPTION
## Overview

Ensures the `elm.rb` script remains the single source of all operations related to adding Elm support to Rails/Webpack (in case older versions of this gem is used during app generation/install).

## Details

- Fixes an [issue](https://github.com/rails/webpacker/issues/351) that @joshuaclayton discovered.
- @gauravtiwari This might be a worthwhile practice to adopt for the other JavaScript installers.