### PR TITLE
Lazy compile in test env

### DIFF
--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -18,17 +18,6 @@ namespace :webpacker do
     puts "Compiled digests for all packs in #{Webpacker::Configuration.packs_path}: "
     puts JSON.parse(File.read(Webpacker::Configuration.manifest_path))
   end
-
-  desc "Compile javascript packs using webpack for test with digests"
-  task compile_before_test: ["webpacker:compile"] do
-    Webpacker::Manifest.load(Webpacker::Manifest.file_path)
-  end
-end
-
-# Compile packs prior to system and controller tests running
-if Rake::Task.task_defined?("test:system")
-  Rake::Task["test:system"].enhance(["webpacker:compile_before_test"])
-  Rake::Task["test:controllers"].enhance(["webpacker:compile_before_test"])
 end
 
 # Compile packs after we've compiled all other assets during precompilation

--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -8,7 +8,7 @@ namespace :webpacker do
     puts "Compiling webpacker assets 🎉"
     asset_host = Rails.application.config.action_controller.asset_host
     asset_env = asset_host ? "ASSET_HOST=#{asset_host}" : ""
-    result = `#{asset_env} NODE_ENV=#{Webpacker::Env.current} ./bin/webpack --json`
+    result = `#{asset_env} NODE_ENV=#{Webpacker.env} ./bin/webpack --json`
 
     unless $?.success?
       puts JSON.parse(result)["errors"]

--- a/lib/webpacker.rb
+++ b/lib/webpacker.rb
@@ -1,8 +1,3 @@
-require "webpacker/env"
-require "webpacker/configuration"
-require "webpacker/manifest"
-require "webpacker/compiler"
-
 module Webpacker
   extend self
 
@@ -18,4 +13,8 @@ module Webpacker
   end
 end
 
+require "webpacker/env"
+require "webpacker/configuration"
+require "webpacker/manifest"
+require "webpacker/compiler"
 require "webpacker/railtie" if defined?(Rails)

--- a/lib/webpacker.rb
+++ b/lib/webpacker.rb
@@ -1,7 +1,19 @@
+require "webpacker/env"
+require "webpacker/configuration"
+require "webpacker/manifest"
+require "webpacker/compiler"
+
 module Webpacker
-  def self.bootstrap
+  extend self
+
+  def bootstrap
     Webpacker::Env.load
     Webpacker::Configuration.load
+    Webpacker::Manifest.load
+  end
+
+  def compile
+    Webpacker::Compiler.compile
     Webpacker::Manifest.load
   end
 end

--- a/lib/webpacker.rb
+++ b/lib/webpacker.rb
@@ -11,6 +11,10 @@ module Webpacker
     Webpacker::Compiler.compile
     Webpacker::Manifest.load
   end
+
+  def env
+    Webpacker::Env.current.inquiry
+  end
 end
 
 require "webpacker/env"

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -1,0 +1,20 @@
+require "rake"
+
+module Webpacker::Compiler
+  extend self
+
+  def compile
+    compile_task.invoke
+    compile_task.reenable
+  end
+
+  private
+    def compile_task
+      @compile_task ||= load_rake_task("webpacker:compile")
+    end
+
+    def load_rake_task(name)
+      @load_rakefile ||= Rake.load_rakefile(Rails.root.join("Rakefile"))
+      Rake::Task[name]
+    end
+end

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -25,7 +25,7 @@ class Webpacker::Configuration < Webpacker::FileLoader
     end
 
     def paths
-      load if Webpacker::Env.development?
+      load if Webpacker.env.development?
       raise Webpacker::FileLoader::FileLoaderError.new("Webpacker::Configuration.load must be called first") unless instance
       instance.data
     end
@@ -46,6 +46,6 @@ class Webpacker::Configuration < Webpacker::FileLoader
   private
     def load
       return super unless File.exist?(@path)
-      HashWithIndifferentAccess.new(YAML.load(File.read(@path))[Webpacker::Env.current])
+      HashWithIndifferentAccess.new(YAML.load(File.read(@path))[Webpacker.env])
     end
 end

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -1,6 +1,6 @@
 # Loads webpacker configuration from config/webpack/paths.yml
+
 require "webpacker/file_loader"
-require "webpacker/env"
 
 class Webpacker::Configuration < Webpacker::FileLoader
   class << self

--- a/lib/webpacker/env.rb
+++ b/lib/webpacker/env.rb
@@ -8,14 +8,6 @@ class Webpacker::Env < Webpacker::FileLoader
       instance.data
     end
 
-    def development?
-      current == "development"
-    end
-
-    def test?
-      current == "test"
-    end
-
     def file_path
       Rails.root.join("config", "webpack", "paths.yml")
     end

--- a/lib/webpacker/env.rb
+++ b/lib/webpacker/env.rb
@@ -12,6 +12,10 @@ class Webpacker::Env < Webpacker::FileLoader
       current == "development"
     end
 
+    def test?
+      current == "test"
+    end
+
     def file_path
       Rails.root.join("config", "webpack", "paths.yml")
     end

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -1,5 +1,3 @@
-require "webpacker/manifest"
-
 module Webpacker::Helper
   # Computes the full path for a given webpacker asset.
   # Return relative path using manifest.json and passes it to asset_url helper

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -14,7 +14,7 @@ class Webpacker::Manifest < Webpacker::FileLoader
     end
 
     def lookup(name)
-      if Webpacker::Env.test?
+      if Webpacker.env.test?
         compile_and_retry_on_error do
           lookup_or_raise(name)
         end
@@ -29,7 +29,7 @@ class Webpacker::Manifest < Webpacker::FileLoader
 
     private
       def lookup_or_raise(name)
-        load if Webpacker::Env.development?
+        load if Webpacker.env.development?
         raise Webpacker::FileLoader::FileLoaderError.new("Webpacker::Manifest.load must be called first") unless instance
         instance.data[name.to_s] || raise(Webpacker::FileLoader::NotFoundError.new("Can't find #{name} in #{file_path}. Is webpack still compiling?"))
       end

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -6,9 +6,6 @@
 # "/packs/calendar-1016838bab065ae1e314.css" for long-term caching
 
 require "webpacker/file_loader"
-require "webpacker/env"
-require "webpacker/configuration"
-require "webpacker/compiler"
 
 class Webpacker::Manifest < Webpacker::FileLoader
   class << self

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -8,6 +8,7 @@
 require "webpacker/file_loader"
 require "webpacker/env"
 require "webpacker/configuration"
+require "webpacker/compiler"
 
 class Webpacker::Manifest < Webpacker::FileLoader
   class << self
@@ -16,14 +17,37 @@ class Webpacker::Manifest < Webpacker::FileLoader
     end
 
     def lookup(name)
-      load if Webpacker::Env.development?
-      raise Webpacker::FileLoader::FileLoaderError.new("Webpacker::Manifest.load must be called first") unless instance
-      instance.data[name.to_s] || raise(Webpacker::FileLoader::NotFoundError.new("Can't find #{name} in #{file_path}. Is webpack still compiling?"))
+      if Webpacker::Env.test?
+        compile_and_retry_on_error do
+          lookup_or_raise(name)
+        end
+      else
+        lookup_or_raise(name)
+      end
     end
 
     def lookup_path(name)
       Rails.root.join(File.join(Webpacker::Configuration.output_path, lookup(name)))
     end
+
+    private
+      def lookup_or_raise(name)
+        load if Webpacker::Env.development?
+        raise Webpacker::FileLoader::FileLoaderError.new("Webpacker::Manifest.load must be called first") unless instance
+        instance.data[name.to_s] || raise(Webpacker::FileLoader::NotFoundError.new("Can't find #{name} in #{file_path}. Is webpack still compiling?"))
+      end
+
+      def compile_and_retry_on_error
+        retried = false
+        begin
+          yield
+        rescue
+          raise if retried
+          retried = true
+          Webpacker.compile
+          retry
+        end
+      end
   end
 
   private

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -3,10 +3,8 @@ require "webpacker_test"
 class EnvTest < Minitest::Test
   def test_current_env
     assert_equal Webpacker::Env.current, "production"
-  end
-
-  def test_env_is_development?
-    refute_predicate Webpacker::Env, :development?
+    assert_equal Webpacker.env, "production"
+    assert Webpacker.env.production?
   end
 
   def test_file_path


### PR DESCRIPTION
* Adds new `Webpacker.compile` API (that invokes the `webpacker:compile` rake task)
* Lazily compiles in test env to avoid `Webpacker::FileLoader::*` exceptions
* Eliminates the need enhance Rails test tasks

Differences from https://github.com/rails/webpacker/pull/341
* Doesn't require any changes to an application's test classes
* Doesn't attempt to recompile when files change

/cc @gauravtiwari @dhh