### PR TITLE
Use https in readme's gem instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ or you can add the gem and run `./bin/rails webpacker:install` in an existing ap
 As the rubygems version isn't promised to be kept up to date until the release of Rails 5.1, you may want to include the gem directly from GitHub:
 
 ```ruby
-gem 'webpacker', github: 'rails/webpacker'
+gem 'webpacker', git: 'https://github.com/rails/webpacker.git'
 ```
 
 You can also see a list of available commands by running `./bin/rails webpacker`


### PR DESCRIPTION
Using the git protocol, yields the following warning during a `bundle install`:

> The git source `git://github.com/rails/webpacker.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.

Use https instead.