### PR TITLE
Use rake in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ As the rubygems version isn't promised to be kept up to date until the release o
 gem 'webpacker', github: 'rails/webpacker'
 ```
 
-You can also see a list of available commands by running `./bin/rails webpacker`
+You can also see a list of available commands by running `rake webpacker`
 
 ## Binstubs
 


### PR DESCRIPTION
Using `./bin/rails` as documented is failing against a new rails 4.2.x application:

```
~ » rails -v
Rails 4.2.8

~ » rails new foo
...

~ » cd foo
~/foo » echo "gem 'webpacker', git: 'https://github.com/rails/webpacker.git'" >> Gemfile
~/foo » bundle
Fetching https://github.com/rails/webpacker.git
Fetching gem metadata from https://rubygems.org/...........
Fetching version metadata from https://rubygems.org/...
Fetching dependency metadata from https://rubygems.org/..
Resolving dependencies...
Using rake 12.0.0
Using i18n 0.8.1
Using minitest 5.10.2
Using thread_safe 0.3.6
Using builder 3.2.3
Using erubis 2.7.0
Using mini_portile2 2.1.0
Using rack 1.6.6
Using mime-types-data 3.2016.0521
Using arel 6.0.4
Using debug_inspector 0.0.3
Using bundler 1.14.6
Using byebug 9.0.6
Using coffee-script-source 1.12.2
Using execjs 2.7.0
Using thor 0.19.4
Using concurrent-ruby 1.0.5
Using multi_json 1.12.1
Using json 1.8.6
Using rdoc 4.3.0
Using sass 3.4.23
Using tilt 2.0.7
Using sqlite3 1.3.13
Using turbolinks-source 5.0.3
Using tzinfo 1.2.3
Using nokogiri 1.7.1
Using rack-test 0.6.3
Using mime-types 3.1
Using binding_of_caller 0.7.2
Using coffee-script 2.4.1
Using uglifier 3.2.0
Using sprockets 3.7.1
Using sdoc 0.4.2
Using turbolinks 5.0.1
Using activesupport 4.2.8
Using loofah 2.0.3
Using mail 2.6.5
Using rails-deprecated_sanitizer 1.0.3
Using globalid 0.4.0
Using activemodel 4.2.8
Using jbuilder 2.6.3
Using spring 2.0.1
Using rails-html-sanitizer 1.0.3
Using rails-dom-testing 1.0.8
Using activejob 4.2.8
Using activerecord 4.2.8
Using actionview 4.2.8
Using actionpack 4.2.8
Using actionmailer 4.2.8
Using railties 4.2.8
Using sprockets-rails 3.2.0
Using coffee-rails 4.1.1
Using jquery-rails 4.3.1
Using webpacker 1.2 from https://github.com/rails/webpacker.git (at master@9d579e8)
Using rails 4.2.8
Using sass-rails 5.0.6
Using web-console 2.3.0
Bundle complete! 13 Gemfile dependencies, 57 gems now installed.
Use `bundle show [gemname]` to see where a bundled gem is installed.

~/foo » ./bin/rails webpacker:install
Error: Command 'webpacker:install' not recognized
Did you mean: `$ rake webpacker:install` ?
...

~/foo » rake webpacker:install
Running via Spring preloader in process 66337
Copying webpack core config and loaders
      create  config/webpack
... snip ...
Webpacker successfully installed 🎉 🍰

~/foo » echo woohoo!
woohoo!
```