### PR TITLE
Update .babelrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-- Added [Elm](http://elm-lang.org) support. You can now add Elm support via the following methods:
+### Fixed
+- Update `.babelrc` to fix compilation issues - [#306](https://github.com/rails/webpacker/issues/306)
+
+### Added
+- [Elm](http://elm-lang.org) support. You can now add Elm support via the following methods:
   - New app: `rails new <app> --webpack=elm`
   - Within an existing app: `rails webpacker:install:elm`
 

--- a/lib/install/config/.babelrc
+++ b/lib/install/config/.babelrc
@@ -5,7 +5,8 @@
       "targets": {
         "browsers": "> 1%",
         "uglify": true
-      }
+      },
+      "useBuiltIns": true
     }]
   ]
 }

--- a/lib/install/config/.babelrc
+++ b/lib/install/config/.babelrc
@@ -3,9 +3,9 @@
     ["env", {
       "modules": false,
       "targets": {
-        "node": "current"
-      },
-      "useBuiltIns": true
+        "browsers": "> 1%",
+        "uglify": true
+      }
     }]
   ]
 }

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -25,7 +25,7 @@ end
 puts "Installing all JavaScript dependencies"
 run "yarn add webpack webpack-merge js-yaml path-complete-extname " \
 "webpack-manifest-plugin babel-loader@7.x coffee-loader coffee-script " \
-"babel-core babel-preset-env compression-webpack-plugin rails-erb-loader glob " \
+"babel-core babel-preset-env babel-polyfill compression-webpack-plugin rails-erb-loader glob " \
 "extract-text-webpack-plugin node-sass file-loader sass-loader css-loader style-loader " \
 "postcss-loader autoprefixer postcss-smart-import precss"
 


### PR DESCRIPTION
Remove `useBuiltIns` as it is only needed when using `babel-polyfill`.
Target browsers which have >1% usage instead of nodejs as it is more relevant for our users.
Use `uglify: true` setting as we are using UglifyJS in production. (I will make a PR to switch to https://github.com/babel/babili separately after I've tried it)

Resolves #306 and #35 properly.