### PR TITLE
Fixed missing path to Elm Make.

### DIFF
--- a/lib/install/config/loaders/installers/elm.js
+++ b/lib/install/config/loaders/installers/elm.js
@@ -2,13 +2,15 @@ const path = require('path')
 const { env } = require('../configuration.js')
 
 const elmSource = path.resolve(process.cwd())
+const elmMake = `${elmSource}/node_modules/.bin/elm-make`
+const elmDefaultOptions = `cwd=${elmSource}&pathToMake=${elmMake}`
 
 const loaderOptions = () => {
   if (env.NODE_ENV === 'production') {
-    return `elm-webpack-loader?cwd=${elmSource}`
+    return `elm-webpack-loader?${elmDefaultOptions}`
   }
 
-  return `elm-hot-loader!elm-webpack-loader?cwd=${elmSource}&verbose=true&warn=true&debug=true`
+  return `elm-hot-loader!elm-webpack-loader?${elmDefaultOptions}&verbose=true&warn=true&debug=true`
 }
 
 module.exports = {


### PR DESCRIPTION
## Overview

Resolves an issue with running the `bin/webpack` binstub where the path to Elm Make could not be resolved due to being installed via Yarn. This would work if Elm was globally installed, though. In this case we don't want to make any assumptions on a globally installed version of Elm and only use what is provided by Yarn.

## Details

- Resolves this [Issue](https://github.com/rails/webpacker/issues/383).