### PR TITLE
Fix install task message of webpacker.rake

### DIFF
--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -6,9 +6,10 @@ tasks = {
   "webpacker:check_webpack_binstubs"  => "Verifies that bin/webpack & bin/webpack-dev-server are present",
   "webpacker:verify_install"          => "Verifies if webpacker is installed",
   "webpacker:yarn_install"            => "Support for older Rails versions. Install all JavaScript dependencies as specified via Yarn",
-  "webpacker:install:react"           => "Installs and setup example react component",
-  "webpacker:install:vue"             => "Installs and setup example vue component",
-  "webpacker:install:angular"         => "Installs and setup example angular2 component"
+  "webpacker:install:react"           => "Installs and setup example React component",
+  "webpacker:install:vue"             => "Installs and setup example Vue component",
+  "webpacker:install:angular"         => "Installs and setup example Angular component",
+  "webpacker:install:elm"             => "Installs and setup example Elm component"
 }.freeze
 
 desc "Lists all available tasks in webpacker"


### PR DESCRIPTION
I found mistake in `webpacker.rake`.
That's `angular2`.
We will call `Angular` instead of `angular2, angular4, angular...`.

It was announced [NG-BE 2016 Keynote by Igor Minar](https://youtu.be/aJIMoLgqU_o?t=1389).

This PR is correcting the messages of other tasks by referring [here](https://github.com/rails/webpacker/blob/74cde3c0f028516f11a793c17235ea71af21bca6/lib/tasks/installers.rake#L2-L5
).