### PR TITLE
Revert the extension path to not expand to sub-directories to stop OOM

### DIFF
--- a/lib/install/config/webpack/shared.js
+++ b/lib/install/config/webpack/shared.js
@@ -11,7 +11,7 @@ const ManifestPlugin = require('webpack-manifest-plugin')
 const extname = require('path-complete-extname')
 const { env, settings, output, loadersDir } = require('./configuration.js')
 
-const extensionGlob = `**/*{${settings.extensions.join(',')}}*`
+const extensionGlob = `*{${settings.extensions.join(',')}}*`
 const entryPath = join(settings.source_path, settings.source_entry_path)
 const packPaths = sync(join(entryPath, extensionGlob))
 


### PR DESCRIPTION
After upgrading to 2.0, I was consistently running out of RAM when trying to run webpack.

After some digging, I came across a comment on the webpack project that helped shed some light.

https://github.com/webpack/webpack/issues/1914#issuecomment-303837359

It seems that in PR 201 (https://github.com/rails/webpacker/pull/201), the `extensionGlob`
was changed from `*{${paths.extensions.join(',')}}*` to `**/*{${paths.extensions.join(',')}}*`

This change removes the `**/` in the extension and fixes my OOM issue.

I am not sure about the ramifications for allowing pack files in subdirectories
(the original intent of the PR that introduced the change). Maybe we need a comment or a
flag when generating the configuration that will set it one way or the other?