### PR TITLE
Switch to postcss-cssnext

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ file in your app root with standard plugins.
 ```yml
 plugins:
   postcss-smart-import: {}
-  cssnext: {}
+  postcss-cssnext: {}
 ```
 
 
@@ -897,7 +897,7 @@ const Hello = props => (
 ### CSS-Next
 
 [css-next](http://cssnext.io/) is supported out-of-box in Webpacker allowing the use of
-latest css features, today.
+latest CSS features, today.
 
 
 ### Ignoring swap files

--- a/lib/install/config/.postcssrc.yml
+++ b/lib/install/config/.postcssrc.yml
@@ -1,3 +1,3 @@
 plugins:
   postcss-smart-import: {}
-  cssnext: {}
+  postcss-cssnext: {}


### PR DESCRIPTION
`cssnext` shoud no longer be used: http://cssnext.io/postcss/
It has been replaced by `postcss-cssnext`.

Fixes #432.
Related to #344.