### PR TITLE
Fix publicPath in file-loader config

### DIFF
--- a/lib/install/config/loaders/core/assets.js
+++ b/lib/install/config/loaders/core/assets.js
@@ -1,11 +1,11 @@
-const { env, publicPath } = require('../configuration.js')
+const { env, output } = require('../configuration.js')
 
 module.exports = {
   test: /\.(jpg|jpeg|png|gif|svg|eot|ttf|woff|woff2)$/i,
   use: [{
     loader: 'file-loader',
     options: {
-      publicPath,
+      publicPath: output.publicPath,
       name: env.NODE_ENV === 'production' ? '[name]-[hash].[ext]' : '[name].[ext]'
     }
   }]


### PR DESCRIPTION
70eace2b8b7035954fb921c7066a24d75e775a86 changed the export to `output.publicPath`, but this has not been updated.