### PR TITLE
Do not write files in test env

### DIFF
--- a/lib/install/config/webpack/shared.js
+++ b/lib/install/config/webpack/shared.js
@@ -40,7 +40,7 @@ module.exports = {
     new ExtractTextPlugin(env.NODE_ENV === 'production' ? '[name]-[hash].css' : '[name].css'),
     new ManifestPlugin({
       publicPath: output.publicPath,
-      writeToFileEmit: true
+      writeToFileEmit: env.NODE_ENV !== 'test'
     })
   ],
 


### PR DESCRIPTION
# Problem

When running unit tests with Karma, karma forcibly and inflexibly overrides the `output.path` of Webpack to be `/_karma_webpack_`, which in almost every system is not writable.  Since Karma has been like this for almost a year, it seems that it's assuming no files are getting written to the filesystem during a test run.  While odd, this appears to be the case and isn't causing anyone else problems per se.

For Rails devs, this means running Karma-based unit tests requires a writable file in the root directory of their machine, and any CI environment, which is not ideal.

# Solution

Configure the `ManifestPlugin` to not write files in the "test" environment.

## Notes

I'm not sure if this is the right way to solve this problem.  Since it's being done to afford Karma-based unit testing, this might not be the right thing for Webpacker.  But, it would be nice if this behavior could be controlled in some other way.  It seems that the overall theory of Webpacker is that the developer should not be messing with `config/webpack/{development,shared,production,test}.js` and instead be changing `config/webpacker.yml`  so I'm open to any ideas on how to make this configurable in there if that's the right thing.

Fixes #435 (also more details)