### PR TITLE
Remove Webpacker::Manifest.lookup_path

### DIFF
--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -23,10 +23,6 @@ class Webpacker::Manifest < Webpacker::FileLoader
       end
     end
 
-    def lookup_path(name)
-      Rails.root.join(File.join(Webpacker::Configuration.public_path, lookup(name)))
-    end
-
     private
       def find(name)
         instance.data[name.to_s] if instance

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -21,10 +21,4 @@ class ManifestTest < Minitest::Test
     asset_file = "bootstrap.js"
     assert_equal Webpacker::Manifest.lookup(asset_file), "/packs/bootstrap-300631c4f0e0f9c865bc.js"
   end
-
-  def test_lookup_path
-    file_path = File.join(File.dirname(__FILE__), "test_app/public/packs", "bootstrap-300631c4f0e0f9c865bc.js").to_s
-    asset_file = "bootstrap.js"
-    assert_equal Webpacker::Manifest.lookup_path(asset_file).to_s, file_path
-  end
 end


### PR DESCRIPTION
I think `Webpacker::Manifest.lookup_path` is not using now.