### PR TITLE
Support uploaded manifest

### DIFF
--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -16,6 +16,10 @@ class Webpacker::Configuration < Webpacker::FileLoader
       output_path.join("manifest.json")
     end
 
+    def manifest_url
+      fetch(:manifest_url)
+    end
+
     def source_path
       Rails.root.join(source)
     end

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -6,11 +6,16 @@
 # "/packs/calendar-1016838bab065ae1e314.css" for long-term caching
 
 require "webpacker/file_loader"
+require 'open-uri'
 
 class Webpacker::Manifest < Webpacker::FileLoader
   class << self
     def file_path
       Webpacker::Configuration.manifest_path
+    end
+
+    def file_url
+      Webpacker::Configuration.manifest_url
     end
 
     def lookup(name)
@@ -45,7 +50,11 @@ class Webpacker::Manifest < Webpacker::FileLoader
 
   private
     def load
-      return super unless File.exist?(@path)
-      JSON.parse(File.read(@path))
+      if self.class.file_url
+        JSON.parse(open(self.class.file_url).read)
+      else
+        return super unless File.exist?(@path)
+        JSON.parse(File.read(@path))
+      end
     end
 end


### PR DESCRIPTION
see https://github.com/rails/webpacker/issues/412

I want to use uploaded `manifest.json` like this API.

example configurations:
```yml
development:        
  <<: *default

test:    
  <<: *default

staging:
  <<: *default
  manifest_url: http://staging.assets.host/public/packs/manifest.json

production:
  <<: *default
  manifest_url: http://prod.assets.host/public/packs/manifest.json
```

WDYT?