### PR TITLE
Remove duplicated resolveLoader config declaration

### DIFF
--- a/lib/install/config/webpack/shared.js
+++ b/lib/install/config/webpack/shared.js
@@ -50,9 +50,5 @@ module.exports = {
       resolve(settings.source_path),
       'node_modules'
     ]
-  },
-
-  resolveLoader: {
-    modules: ['node_modules']
   }
 }


### PR DESCRIPTION
resolveLoader default setting is like below:

```
{
    modules: ["node_modules"],
    extensions: [".js", ".json"],
    mainFields: ["loader", "main"]
}
```

Is there any reason we duplicately declare it in `shared.js` ?

reference:
https://webpack.js.org/configuration/resolve/#resolveloader