### PR TITLE
Updated README.md to add related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1113,6 +1113,10 @@ completed the compilation successfully before loading a view.
 - HMR - [#188](https://github.com/rails/webpacker/issues/188)
 - Support rails engines - [#348](https://github.com/rails/webpacker/issues/348)
 
-
 ## License
 Webpacker is released under the [MIT License](https://opensource.org/licenses/MIT).
+
+## Related Projects
+- [react\_on\_rails Gem](https://github.com/shakacode/react_on_rails): Integration of Rails with React, Redux, React-Router, including Server Rendering utilizing [Webpacker Lite](https://github.com/shakacode/webpacker_lite).
+- [webpacker\_lite Gem](https://github.com/shakacode/webpacker_lite): A slimmed down version of Webpacker that provides only the helpers with customizations for React on Rails. See article [Webpacker Lite: Why Fork Webpacker?](https://blog.shakacode.com/webpacker-lite-why-fork-webpacker-f0a7707fac92).
+- [react-rails Gem](https://github.com/reactjs/react-rails): Integration of Rails with React utilizing Webpacker.


### PR DESCRIPTION
This is similar to how https://github.com/reactjs/react-rails lists related projects. I believe that it's useful to show the community alternatives.

Why did [ShakaCode](http://www.shakacode.com) fork [rails/webpacker](https://github.com/rails/webpacker)?

3 reasons:

1. React on Rails needed only the helpers in Webpacker to obtain the correct file path or relative URL to Webpack created assets, given different Rails environments, fingerprinting of assets, hot-reloading, etc.
2. We preferred a simpler configuration to get the core functionality needed. You configure just one thing: The directory within `/public` where Webpack will create the manifest and output file. Then you configure your Webpack config to generate a simple manifest that maps the base output names to the possibly fingerprinted versions. Note, unlike Webpacker, Webpacker Lite wants your manifest to **NOT** contain any host information.
3. We needed the ability to quickly make changes needed by [react_on_rails](https://github.com/shakacode/react_on_rails)

For more details on how this project differs from Webpacker and why we forked, please see [Webpacker Lite: Why Fork Webpacker?](https://blog.shakacode.com/webpacker-lite-why-fork-webpacker-f0a7707fac92).

The [Webpacker Lite README](https://github.com/shakacode/webpacker_lite) has more details on some subtle differences. For example, Webpacker puts detailed server path information in the manifest.json. Webpacker Lite wants just minimal information in the manifest.json. There's other little differences like that. I wanted Webpacker Lite to make the minimal requirements for the hand-coded Webpack config. Since Webpacker handles the config, it can put logic in either on the Rails or Webpack side.

