### PR TITLE
Ignore packs generated for tests in git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,12 @@
   rm config/webpack/development.server.js
   ```
 
+  __Warning__: For now you also have to add a pattern in `.gitignore` by hand.
+  ```diff
+   /public/packs
+  +/public/packs-test
+   /node_modules
+   ```
 
 ## [1.2] - 2017-04-27
 Some of the changes made requires you to run below commands to install new changes.

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -22,6 +22,7 @@ chmod "bin", 0755 & ~File.umask, verbose: false
 if File.exists?(".gitignore")
   append_to_file ".gitignore", <<-EOS
 /public/packs
+/public/packs-test
 /node_modules
 EOS
 end


### PR DESCRIPTION
Should we also add a warning to [[2.0] - 2017-05-24 / Breaking Change](https://github.com/rails/webpacker/blob/master/CHANGELOG.md#breaking-change)?
And maybe later specify up to which version this applies when this fix lands in a gem release?