### PR TITLE
Rakefile is already loaded

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -14,7 +14,6 @@ module Webpacker::Compiler
     end
 
     def load_rake_task(name)
-      @load_rakefile ||= Rake.load_rakefile(Rails.root.join("Rakefile"))
       Rake::Task[name]
     end
 end


### PR DESCRIPTION
I am getting duplicated task running with system tests because of this.
No idea when you need to manually load project's Rakefile inside a rake task.

Fixes https://github.com/rails/webpacker/issues/476 for me.