### PR TITLE
Listen on 0.0.0.0 but serve from localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
 ## Unreleased
 
 ### Fixed
+
 - Update `webpack-dev-server.tt` to respect RAILS_ENV and NODE_ENV values [#502](https://github.com/rails/webpacker/issues/502)
+- Use `0.0.0.0` as default listen address for `webpack-dev-server`
+- Serve assets using `localhost` from dev server - [#424](https://github.com/rails/webpacker/issues/424)
+
+```yml
+  dev_server:
+    host: localhost
+```
 
 ### Breaking changes
+
 - Add `compile` option to `config/webpacker.yml` for configuring lazy compilation of packs when a file under tracked paths is changed [#503](https://github.com/rails/webpacker/pull/503). To enable expected behavior, update `config/webpacker.yml`:
 
   ```yaml

--- a/README.md
+++ b/README.md
@@ -263,13 +263,22 @@ webpacker: ./bin/webpack-dev-server
 foreman start
 ```
 
+By default, `webpack-dev-server` listens on `0.0.0.0` that means listening
+on all IP addresses available on your system: LAN IP address, localhost, 127.0.0.1 etc. However, we use `localhost` as default hostname for serving assets in browser
+and if you want to change that, for example on cloud9 you can do so
+by changing host set in `config/webpacker.yml`.
+
+```bash
+dev_server:
+  host: example.com
+```
+
 You can also pass CLI options supported by [webpack-dev-server](https://webpack.js.org/configuration/dev-server/). Please note that inline options will always take
 precedence over the ones already set in the configuration file.
 
 ```bash
-./bin/webpack-dev-server --host 0.0.0.0 --inline true --hot false
+./bin/webpack-dev-server --host example.com --inline true --hot false
 ```
-
 
 ### Webpack
 

--- a/lib/install/bin/webpack-dev-server.tt
+++ b/lib/install/bin/webpack-dev-server.tt
@@ -3,6 +3,7 @@ $stdout.sync = true
 
 require "shellwords"
 require "yaml"
+require "socket"
 
 ENV["RAILS_ENV"] ||= "development"
 RAILS_ENV = ENV["RAILS_ENV"]
@@ -15,6 +16,8 @@ CONFIG_FILE       = File.join(APP_PATH, "config/webpacker.yml")
 NODE_MODULES_PATH = File.join(APP_PATH, "node_modules")
 WEBPACK_CONFIG    = File.join(APP_PATH, "config/webpack/#{NODE_ENV}.js")
 
+LISTEN_IP_ADDR  = "0.0.0.0"
+
 def args(key)
   index = ARGV.index(key)
   index ? ARGV[index + 1] : nil
@@ -23,20 +26,39 @@ end
 begin
   dev_server = YAML.load_file(CONFIG_FILE)[RAILS_ENV]["dev_server"]
 
-  DEV_SERVER_HOST = "http#{"s" if args('--https') || dev_server["https"]}://#{args('--host') || dev_server["host"]}:#{args('--port') || dev_server["port"]}"
+  HOSTNAME        = args('--host') || dev_server["host"]
+  PORT            = args('--port') || dev_server["port"]
+  HTTPS           = ARGV.include?('--https') || dev_server["https"]
+  DEV_SERVER_ADDR = "http#{"s" if HTTPS}://#{HOSTNAME}:#{PORT}"
 
 rescue Errno::ENOENT, NoMethodError
-  puts "Webpack dev_server configuration not found in #{CONFIG_FILE}."
-  puts "Please run bundle exec rails webpacker:install to install webpacker"
+  $stdout.puts "Webpack dev_server configuration not found in #{CONFIG_FILE}."
+  $stdout.puts "Please run bundle exec rails webpacker:install to install webpacker"
   exit!
+end
+
+begin
+  server = TCPServer.new(LISTEN_IP_ADDR, PORT)
+  server.close
+
+rescue Errno::EADDRINUSE
+  $stdout.puts "Another program is running on port #{PORT}. Set a new port in #{CONFIG_FILE} for dev_server"
+  exit!
+end
+
+# Delete supplied host and port CLI arguments
+["--host", "--port"].each do |arg|
+  ARGV.delete(args(arg))
+  ARGV.delete(arg)
 end
 
 newenv = {
   "NODE_PATH" => NODE_MODULES_PATH.shellescape,
-  "ASSET_HOST" => DEV_SERVER_HOST.shellescape
+  "ASSET_HOST" => DEV_SERVER_ADDR.shellescape
 }.freeze
 
-cmdline = ["yarn", "run", "webpack-dev-server", "--", "--progress", "--color", "--config", WEBPACK_CONFIG] + ARGV
+cmdline = ["yarn", "run", "webpack-dev-server", "--", "--progress", "--color", "--config",
+WEBPACK_CONFIG, "--host", LISTEN_IP_ADDR, "--port", PORT.to_s] + ARGV
 
 Dir.chdir(APP_PATH) do
   exec newenv, *cmdline

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -26,7 +26,7 @@ development:
   <<: *default
 
   dev_server:
-    host: 0.0.0.0
+    host: localhost
     port: 8080
     https: false
 


### PR DESCRIPTION
Fixes - https://github.com/rails/webpacker/issues/424
Supersedes - https://github.com/rails/webpacker/pull/431

- Always listen on 0.0.0.0
- Always serve assets using `localhost`, which can be overridden either using cli or setting up another host in webpacker.yml

![screen shot 2017-06-07 at 23 44 37](https://user-images.githubusercontent.com/771039/26904733-51689e60-4bdb-11e7-869b-e2ce4969fb8d.png)
