### PR TITLE
Fix "stats" parameter in development config

### DIFF
--- a/lib/install/config/webpack/development.js
+++ b/lib/install/config/webpack/development.js
@@ -7,10 +7,6 @@ const { settings, output } = require('./configuration.js')
 module.exports = merge(sharedConfig, {
   devtool: 'cheap-eval-source-map',
 
-  stats: {
-    errorDetails: true
-  },
-
   output: {
     pathinfo: true
   },
@@ -27,6 +23,9 @@ module.exports = merge(sharedConfig, {
     historyApiFallback: true,
     watchOptions: {
       ignored: /node_modules/
+    },
+    stats: {
+      errorDetails: true
     }
   }
 })


### PR DESCRIPTION
The "stats" parameter didn't work because it was not placed properly. Webpack [documentation](https://webpack.js.org/configuration/stats/) says:

> For webpack-dev-server, this property needs to be in the devServer object.

