### PR TITLE
help non advanced users get started using Vue

### DIFF
--- a/lib/install/examples/vue/hello_vue.js
+++ b/lib/install/examples/vue/hello_vue.js
@@ -29,15 +29,15 @@ document.addEventListener('DOMContentLoaded', () => {
 // </div>
 
 
-//import Vue from 'vue/dist/vue.esm'
-//import App from './app.vue'
+// import Vue from 'vue/dist/vue.esm'
+// import App from './app.vue'
 //
-//document.addEventListener('DOMContentLoaded', () => {
-//  const app = new Vue({
-//    el: '#hello',
-//    data: {
-//      message: "Can you say hello?"
-//    },
-//    components: { App }
-//  })
-//})
+// document.addEventListener('DOMContentLoaded', () => {
+//   const app = new Vue({
+//     el: '#hello',
+//     data: {
+//       message: "Can you say hello?"
+//     },
+//     components: { App }
+//   })
+// })

--- a/lib/install/examples/vue/hello_vue.js
+++ b/lib/install/examples/vue/hello_vue.js
@@ -13,3 +13,31 @@ document.addEventListener('DOMContentLoaded', () => {
 
   console.log(app)
 })
+
+
+// The above code uses Vue without the compiler, which means you cannot
+// use Vue to target elements in your existing html templates. You would
+// need to always use single file components.
+// To be able to target elements in your existing html/erb templates,
+// comment out the above code and uncomment the below
+// Add <%= javascript_pack_tag 'hello_vue' %> to your layout
+// Then add this markup to your html template:
+//
+// <div id='hello'>
+//   {{message}}
+//   <app></app>
+// </div>
+
+
+//import Vue from 'vue/dist/vue.esm'
+//import App from './app.vue'
+//
+//document.addEventListener('DOMContentLoaded', () => {
+//  const app = new Vue({
+//    el: '#hello',
+//    data: {
+//      message: "Can you say hello?"
+//    },
+//    components: { App }
+//  })
+//})


### PR DESCRIPTION
....by showing how to import the compiler and giving an easier hello world example

To make adoption easier for rails devs who may not yet be familiar with the modern js world or advanced Vue usage (Vue itself considers single file components to be advanced usage), I think it would benefit webpacker to at least offer some instructions on how to use vue the 'non advanced' way. 

I've been learning Vue over the past several months and wanted to try webpacker, but could never transition from the current example app to geting Vue to work using the  [hello world example from Vue](https://vuejs.org/v2/guide/index.html). The current webpacker vue hello world is clever, but likely confusing to much of the rails community. It took me several hours to figure out that I needed the vue compiler and then several more to figure out how to import it. 

I think one of the biggest advantages of Vue is how easy it is start by enhancing existing views and think this is an important stepping stone to using a more modern js frontend. This commit should help devs quickly get started.