### PR TITLE
allow vue templates to be precompiled by erb (with `.vue.erb` extension)

### DIFF
--- a/lib/install/config/loaders/installers/vue.js
+++ b/lib/install/config/loaders/installers/vue.js
@@ -27,7 +27,7 @@ function vueStyleLoader(loader) {
 }
 
 module.exports = {
-  test: /.vue$/,
+  test: /\.vue(\.erb)?$/,
   loader: 'vue-loader',
   options: {
     loaders: {


### PR DESCRIPTION
Or is there any reason why vue templates should not be precompiled by erb?

More specifically this PR does not change that they are precompiled (every file ending in `.erb` is compiled afaik), but now they can be imported with vue-loader.