### PR TITLE
Adds compile option to configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
-## [2.0] - 2017-05-24
+## Unreleased
 
+### Fixed
+- Update `webpack-dev-server.tt` to respect RAILS_ENV and NODE_ENV values [#502](https://github.com/rails/webpacker/issues/502)
+
+### Breaking changes
+- Add `compile_missing_packs` option to `config/webpacker.yml` for configuring lazy compilation of packs when not found [#503](https://github.com/rails/webpacker/pull/503). To enable expected behavior for defaults and production, update `config/webpacker.yml`:
+
+  ```yaml
+    default: &default
+      compile_missing_packs: true
+
+    production:
+      compile_missing_packs: false
+  ```
+
+## [2.0] - 2017-05-24
 
 ### Fixed
 - Update `.babelrc` to fix compilation issues - [#306](https://github.com/rails/webpacker/issues/306)

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -4,7 +4,7 @@ default: &default
   source_path: app/javascript
   source_entry_path: packs
   public_output_path: packs
-  compile_missing_packs: false
+  compile_missing_packs: true
 
   extensions:
     - .coffee
@@ -34,7 +34,8 @@ test:
   <<: *default
 
   public_output_path: packs-test
-  compile_missing_packs: true
 
 production:
   <<: *default
+
+  compile_missing_packs: false

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -4,7 +4,7 @@ default: &default
   source_path: app/javascript
   source_entry_path: packs
   public_output_path: packs
-  compile: false
+  compile_missing_packs: false
 
   extensions:
     - .coffee
@@ -34,7 +34,7 @@ test:
   <<: *default
 
   public_output_path: packs-test
-  compile: true
+  compile_missing_packs: true
 
 production:
   <<: *default

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -4,6 +4,7 @@ default: &default
   source_path: app/javascript
   source_entry_path: packs
   public_output_path: packs
+  compile: false
 
   extensions:
     - .coffee
@@ -33,6 +34,7 @@ test:
   <<: *default
 
   public_output_path: packs-test
+  compile: true
 
 production:
   <<: *default

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -36,8 +36,8 @@ class Webpacker::Configuration < Webpacker::FileLoader
       fetch(:source_path)
     end
 
-    def compile?
-      fetch(:compile).nil? ? Webpacker.env.test? : fetch(:compile)
+    def compile_missing_packs?
+      fetch(:compile_missing_packs)
     end
 
     def fetch(key)

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -36,6 +36,10 @@ class Webpacker::Configuration < Webpacker::FileLoader
       fetch(:source_path)
     end
 
+    def compile?
+      fetch(:compile).nil? ? Webpacker.env.test? : fetch(:compile)
+    end
+
     def fetch(key)
       data.fetch(key, defaults[key])
     end

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -16,7 +16,7 @@ class Webpacker::Manifest < Webpacker::FileLoader
     def lookup(name)
       load if Webpacker.env.development?
 
-      if Webpacker.env.test?
+      if Webpacker::Configuration.compile?
         find(name) || compile_and_find!(name)
       else
         find!(name)

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -16,7 +16,7 @@ class Webpacker::Manifest < Webpacker::FileLoader
     def lookup(name)
       load if Webpacker.env.development?
 
-      if Webpacker::Configuration.compile?
+      if Webpacker::Configuration.compile_missing_packs?
         find(name) || compile_and_find!(name)
       else
         find!(name)

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -29,4 +29,8 @@ class ConfigurationTest < Minitest::Test
     source_path = File.join(File.dirname(__FILE__), "test_app/app/javascript").to_s
     assert_equal Webpacker::Configuration.source_path.to_s, source_path
   end
+
+  def test_compile
+    assert_equal Webpacker::Configuration.compile?, false
+  end
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -31,6 +31,6 @@ class ConfigurationTest < Minitest::Test
   end
 
   def test_compile_missing_packs
-    refute Webpacker::Configuration.compile_missing_packs?
+    assert Webpacker::Configuration.compile_missing_packs?
   end
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -30,7 +30,7 @@ class ConfigurationTest < Minitest::Test
     assert_equal Webpacker::Configuration.source_path.to_s, source_path
   end
 
-  def test_compile
-    assert_equal Webpacker::Configuration.compile?, false
+  def test_compile_missing_packs
+    refute Webpacker::Configuration.compile_missing_packs?
   end
 end

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -10,11 +10,12 @@ class ManifestTest < Minitest::Test
     manifest_path = File.join(File.dirname(__FILE__), "test_app/public/packs", "manifest.json").to_s
     asset_file = "calendar.js"
 
-    error = assert_raises Webpacker::FileLoader::NotFoundError do
-      Webpacker::Manifest.lookup(asset_file)
+    Webpacker::Configuration.stub :compile_missing_packs?, false do
+      error = assert_raises Webpacker::FileLoader::NotFoundError do
+        Webpacker::Manifest.lookup(asset_file)
+      end
+      assert_equal error.message, "Can't find #{asset_file} in #{manifest_path}. Is webpack still compiling?"
     end
-
-    assert_equal error.message, "Can't find #{asset_file} in #{manifest_path}. Is webpack still compiling?"
   end
 
   def test_lookup_success


### PR DESCRIPTION
This change introduces a new configuration option for enabling lazy compilation via `config/webpacker.yml`. 

Along with #502, this would allow for running a webpack-dev-server process in the test environment instead of enforcing compilation to the `public` directory. The fallback for a missing `compile` key keeps the default lazy-compilation behavior intact.

The `compile` key name borrows from the `assets.compile` option for the asset pipeline.