### PR TITLE
Add description about configuring json-loader on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ module.exports = {
 }
 ```
 
-Now if you `import()` any `.json` files inside your javascript
+Finally add `.json` to the list of extensions in `config/webpacker.yml`. Now if you `import()` any `.json` files inside your javascript
 they will be processed using `json-loader`. Voila!
 
 


### PR DESCRIPTION
To enable additional loaders, we should add extensions in `config/webpacker.yml`.
So I add about it.
Thanks!