### PR TITLE
Exact tail matching for file extensions.

### DIFF
--- a/lib/install/config/webpack/shared.js
+++ b/lib/install/config/webpack/shared.js
@@ -11,7 +11,7 @@ const ManifestPlugin = require('webpack-manifest-plugin')
 const extname = require('path-complete-extname')
 const { env, settings, output, loadersDir } = require('./configuration.js')
 
-const extensionGlob = `**/*{${settings.extensions.join(',')}}*`
+const extensionGlob = `**/*{${settings.extensions.join(',')}}`
 const entryPath = join(settings.source_path, settings.source_entry_path)
 const packPaths = sync(join(entryPath, extensionGlob))
 


### PR DESCRIPTION
Putting wildcard at tail is annoying because it detects my vim backup files (`*~`).