### PR TITLE
Support source name splats in helpers

### DIFF
--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -24,8 +24,9 @@ module Webpacker::Helper
   #   # In production mode:
   #   <%= javascript_pack_tag 'calendar', 'data-turbolinks-track': 'reload' %> # =>
   #   <script src="/packs/calendar-1016838bab065ae1e314.js" data-turbolinks-track="reload"></script>
-  def javascript_pack_tag(name, **options)
-    javascript_include_tag(Webpacker::Manifest.lookup("#{name}#{compute_asset_extname(name, type: :javascript)}"), **options)
+  def javascript_pack_tag(*names, **options)
+    sources = names.map { |name|  Webpacker::Manifest.lookup("#{name}#{compute_asset_extname(name, type: :javascript)}") }
+    javascript_include_tag(*sources, **options)
   end
 
   # Creates a link tag that references the named pack file, as compiled by Webpack per the entries list
@@ -41,7 +42,8 @@ module Webpacker::Helper
   #   # In production mode:
   #   <%= stylesheet_pack_tag 'calendar', 'data-turbolinks-track': 'reload' %> # =>
   #   <link rel="stylesheet" media="screen" href="/packs/calendar-1016838bab065ae1e122.css" data-turbolinks-track="reload" />
-  def stylesheet_pack_tag(name, **options)
-    stylesheet_link_tag(Webpacker::Manifest.lookup("#{name}#{compute_asset_extname(name, type: :stylesheet)}"), **options)
+  def stylesheet_pack_tag(*names, **options)
+    sources = names.map { |name|  Webpacker::Manifest.lookup("#{name}#{compute_asset_extname(name, type: :stylesheet)}") }
+    stylesheet_link_tag(*sources, **options)
   end
 end

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -16,8 +16,20 @@ class HelperTest < ActionView::TestCase
     assert_equal @view.javascript_pack_tag("bootstrap.js"), script
   end
 
+  def test_javascript_pack_tag_splat
+    script = %(<script src="/packs/bootstrap-300631c4f0e0f9c865bc.js" defer="defer"></script>\n) +
+      %(<script src="/packs/application-k344a6d59eef8632c9d1.js" defer="defer"></script>)
+    assert_equal @view.javascript_pack_tag("bootstrap.js", "application.js", defer: true), script
+  end
+
   def test_stylesheet_pack_tag
     style = %(<link rel="stylesheet" media="screen" href="/packs/bootstrap-c38deda30895059837cf.css" />)
     assert_equal @view.stylesheet_pack_tag("bootstrap.css"), style
+  end
+
+  def test_stylesheet_pack_tag_splat
+    style = %(<link rel="stylesheet" media="all" href="/packs/bootstrap-c38deda30895059837cf.css" />\n) +
+      %(<link rel="stylesheet" media="all" href="/packs/application-dd6b1cd38bfa093df600.css" />)
+    assert_equal @view.stylesheet_pack_tag("bootstrap.css", "application.css", media: "all"), style
   end
 end

--- a/test/test_app/public/packs/manifest.json
+++ b/test/test_app/public/packs/manifest.json
@@ -1,4 +1,6 @@
 {
   "bootstrap.css": "/packs/bootstrap-c38deda30895059837cf.css",
-  "bootstrap.js": "/packs/bootstrap-300631c4f0e0f9c865bc.js"
+  "application.css": "/packs/application-dd6b1cd38bfa093df600.css",
+  "bootstrap.js": "/packs/bootstrap-300631c4f0e0f9c865bc.js",
+  "application.js": "/packs/application-k344a6d59eef8632c9d1.js"
 }


### PR DESCRIPTION
These changes make the API to the javascript and stylesheet pack tag helpers consistent with the Rails helpers for `javascript_include_tag` and `stylesheet_link_tag`, respectively.