### PR TITLE
Add a missing \ to angular.js

### DIFF
--- a/lib/install/config/loaders/installers/angular.js
+++ b/lib/install/config/loaders/installers/angular.js
@@ -1,4 +1,4 @@
 module.exports = {
-  test: /.ts$/,
+  test: /\.ts$/,
   loader: 'ts-loader'
 }


### PR DESCRIPTION
Is this necessary? Seen this in other .js files