### PR TITLE
Fix 534

### DIFF
--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -21,7 +21,6 @@ chmod "bin", 0755 & ~File.umask, verbose: false
 
 if File.exists?(".gitignore")
   append_to_file ".gitignore", <<-EOS
-/public/packs
 /public/packs-test
 /node_modules
 EOS


### PR DESCRIPTION
This fixes #534 by removing `/public/packs` from .gitignore. More details are in the issue report.