### PR TITLE
set explicit path on postcssConfig file

### DIFF
--- a/lib/install/config/loaders/core/sass.js
+++ b/lib/install/config/loaders/core/sass.js
@@ -1,10 +1,8 @@
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
-
 const path = require('path')
-
 const { env } = require('../configuration.js')
 
-const postcssConfig = path.resolve(process.cwd(), '.postcssrc.yml')
+const postcssConfigPath = path.resolve(process.cwd(), '.postcssrc.yml')
 
 module.exports = {
   test: /\.(scss|sass|css)$/i,
@@ -12,7 +10,7 @@ module.exports = {
     fallback: 'style-loader',
     use: [
       { loader: 'css-loader', options: { minimize: env.NODE_ENV === 'production' } },
-      { loader: 'postcss-loader', options: { sourceMap: true, config: { path: postcssConfig } } },
+      { loader: 'postcss-loader', options: { sourceMap: true, config: { path: postcssConfigPath } } },
       'resolve-url-loader',
       { loader: 'sass-loader', options: { sourceMap: true } }
     ]

--- a/lib/install/config/loaders/core/sass.js
+++ b/lib/install/config/loaders/core/sass.js
@@ -1,5 +1,10 @@
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
+
+const path = require('path')
+
 const { env } = require('../configuration.js')
+
+const postcssConfig = path.resolve(process.cwd(), '.postcssrc.yml')
 
 module.exports = {
   test: /\.(scss|sass|css)$/i,
@@ -7,7 +12,7 @@ module.exports = {
     fallback: 'style-loader',
     use: [
       { loader: 'css-loader', options: { minimize: env.NODE_ENV === 'production' } },
-      { loader: 'postcss-loader', options: { sourceMap: true } },
+      { loader: 'postcss-loader', options: { sourceMap: true, config: { path: postcssConfig } } },
       'resolve-url-loader',
       { loader: 'sass-loader', options: { sourceMap: true } }
     ]


### PR DESCRIPTION
Based on issue #542  

Without the explicit path the application.css wasn't able to be created when the sass loader started. 

This update provided by @gauravtiwari will fix the problem. 