### PR TITLE
Fix standard out buffering

### DIFF
--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -1,3 +1,5 @@
+$stdout.sync = true
+
 require "open3"
 require "webpacker/env"
 require "webpacker/configuration"


### PR DESCRIPTION
This change fixes standard output buffering if there is an error when calling `./bin/webpack`.

Previously the continuous integration environment would never display the `[Webpacker] Compilation Failed` line in the event of an error.

I'm not sure what the following line in the webpack binstub is doing or if it is needed:

https://github.com/rails/webpacker/blob/master/lib/install/bin/webpack.tt#L2