### PR TITLE
To use custom dev_server.host configured in webpacker.yml

### DIFF
--- a/lib/install/bin/webpack-dev-server.tt
+++ b/lib/install/bin/webpack-dev-server.tt
@@ -63,7 +63,7 @@ if Gem.win_platform?
 WEBPACK_CONFIG, "--host", LISTEN_IP_ADDR, "--port", PORT.to_s] + ARGV
 else
   cmdline = ["yarn", "run", "webpack-dev-server", "--", "--progress", "--color", "--config",
-WEBPACK_CONFIG, "--host", LISTEN_IP_ADDR, "--port", PORT.to_s] + ARGV
+WEBPACK_CONFIG, "--host", LISTEN_IP_ADDR, "--public", "#{HOSTNAME}:#{PORT}", "--port", PORT.to_s] + ARGV
 end
 
 Dir.chdir(APP_PATH) do


### PR DESCRIPTION
To complete the fix in #482, we need to explicitly configure `webpack-dev-server` with the `--public` option so that custom host in `config/webpacker.yml` will work as intended.

Ref https://github.com/webpack/webpack-dev-server/issues/882#issuecomment-296436511