### PR TITLE
Remove unknown uglify option 'minimize'

### DIFF
--- a/lib/install/config/webpack/production.js
+++ b/lib/install/config/webpack/production.js
@@ -14,7 +14,6 @@ module.exports = merge(sharedConfig, {
 
   plugins: [
     new webpack.optimize.UglifyJsPlugin({
-      minimize: true,
       sourceMap: true,
 
       compress: {


### PR DESCRIPTION
There is no such documented option in either uglifyjs or
uglifyjs-webpack-plugin. Flipping the option value between true and
false resulted in no diff in the output JS bundle.