### PR TITLE
Remove `multi_json` dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     webpacker (2.0)
       activesupport (>= 4.2)
-      multi_json (~> 1.2)
       railties (>= 4.2)
 
 GEM
@@ -64,7 +63,6 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
-    multi_json (1.12.1)
     nio4r (1.2.1)
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)

--- a/webpacker.gemspec
+++ b/webpacker.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.9.3"
 
   s.add_dependency "activesupport", ">= 4.2"
-  s.add_dependency "multi_json",    "~> 1.2"
   s.add_dependency "railties",      ">= 4.2"
 
   s.add_development_dependency "bundler", "~> 1.12"


### PR DESCRIPTION
`MultiJson` is not used anywhere in the gem's code.