### PR TITLE
Use [contenthash] instead of [hash] for CSS

### DIFF
--- a/lib/install/config/webpack/shared.js
+++ b/lib/install/config/webpack/shared.js
@@ -37,7 +37,7 @@ module.exports = {
 
   plugins: [
     new webpack.EnvironmentPlugin(JSON.parse(JSON.stringify(env))),
-    new ExtractTextPlugin(env.NODE_ENV === 'production' ? '[name]-[hash].css' : '[name].css'),
+    new ExtractTextPlugin(env.NODE_ENV === 'production' ? '[name]-[contenthash].css' : '[name].css'),
     new ManifestPlugin({
       publicPath: output.publicPath,
       writeToFileEmit: true


### PR DESCRIPTION
Where I work we've been using Webpacker with Rails 5.1 for some time and it's working great for us. Thank you all for the hard work! 👏 

Recently we changed our CSS to also be compiled with Webpacker and we had an issue. Our assets are served from the same server as the app, which is behind a load balancer. While JS and assets (such as fonts and images) were getting the same hashes in both machines, CSS was occasionally getting different hashes (for the same git commit).

Webpacker's generated config does the following:

```js
new ExtractTextPlugin(env.NODE_ENV === 'production' ? '[name]-[hash].css' : '[name].css')
```

While I don't understand why different hashes are generated for the same content, ExtractTextPlugin [provides `contenthash`](https://github.com/webpack-contrib/extract-text-webpack-plugin#options) which is a hash based on the content of the extracted file (in their [readme](https://github.com/webpack-contrib/extract-text-webpack-plugin#options), they don't mention using `hash` as an option). By changing `[hash]` to `[contenthash]` we were able to solve our problem.