### PR TITLE
[WIP] Enhance existing rake tasks in a separate file

### DIFF
--- a/lib/tasks/webpacker/clobber.rake
+++ b/lib/tasks/webpacker/clobber.rake
@@ -8,10 +8,3 @@ namespace :webpacker do
     $stdout.puts "Removed webpack output path directory #{output_path}"
   end
 end
-
-# Run clobber if the assets:clobber is run
-if Rake::Task.task_defined?("assets:clobber")
-  Rake::Task["assets:clobber"].enhance do
-    Rake::Task["webpacker:clobber"].invoke
-  end
-end

--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -25,14 +25,3 @@ namespace :webpacker do
     end
   end
 end
-
-# Compile packs after we've compiled all other assets during precompilation
-if Rake::Task.task_defined?("assets:precompile")
-  Rake::Task["assets:precompile"].enhance do
-    unless Rake::Task.task_defined?("yarn:install")
-      # For Rails < 5.1
-      Rake::Task["webpacker:yarn_install"].invoke
-    end
-    Rake::Task["webpacker:compile"].invoke
-  end
-end

--- a/lib/tasks/webpacker/enhancements.rake
+++ b/lib/tasks/webpacker/enhancements.rake
@@ -1,0 +1,17 @@
+# Compile packs after we've compiled all other assets during precompilation
+if Rake::Task.task_defined?("assets:precompile")
+  Rake::Task["assets:precompile"].enhance do
+    unless Rake::Task.task_defined?("yarn:install")
+      # For Rails < 5.1
+      Rake::Task["webpacker:yarn_install"].invoke
+    end
+    Rake::Task["webpacker:compile"].invoke
+  end
+end
+
+# Run clobber if the assets:clobber is run
+if Rake::Task.task_defined?("assets:clobber")
+  Rake::Task["assets:clobber"].enhance do
+    Rake::Task["webpacker:clobber"].invoke
+  end
+end


### PR DESCRIPTION
Right now, there's no way to prevent `webpacker:compile` and `webpacker:clobber` from calling `enhance` on `assets:precompile` and `assets:clobber`.

This splits off those `enhance` calls to a separate file, so that there's no change when all are loaded, but it is possible to skip loading `lib/tasks/webpacker/enhancements.rake` and not get those hooks.