### PR TITLE
Move actual compilation to the Compiler and call that from the rake task

### DIFF
--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -3,13 +3,13 @@ $stdout.sync = true
 namespace :webpacker do
   desc "Compile javascript packs using webpack for production with digests"
   task compile: ["webpacker:verify_install", :environment] do
-    Rails.logger = Logger.new(STDOUT)
-
-    if Webpacker::Compiler.compile
-      # Successful compilation!
-    else
-      # Failed compilation
-      exit!
+    Webpacker.ensure_log_goes_to_stdout do
+      if Webpacker::Compiler.compile
+        # Successful compilation!
+      else
+        # Failed compilation
+        exit!
+      end
     end
   end
 end

--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -1,26 +1,14 @@
 $stdout.sync = true
 
-require "open3"
-require "webpacker/env"
-require "webpacker/configuration"
-
 namespace :webpacker do
   desc "Compile javascript packs using webpack for production with digests"
   task compile: ["webpacker:verify_install", :environment] do
-    $stdout.puts "[Webpacker] Compiling assets 🎉"
+    Rails.logger = Logger.new(STDOUT)
 
-    asset_host = ActionController::Base.helpers.compute_asset_host
-    env = { "NODE_ENV" => Webpacker.env, "ASSET_HOST" => asset_host }.freeze
-
-    stdout_str, stderr_str, status = Open3.capture3(env, "#{RbConfig.ruby} ./bin/webpack")
-
-    if status.success?
-      $stdout.puts "\e[32m[Webpacker] Compiled digests for all packs in #{Webpacker::Configuration.entry_path}:\e[0m"
-      $stdout.puts "\e[32m#{JSON.parse(File.read(Webpacker::Configuration.manifest_path))}\e[0m"
+    if Webpacker::Compiler.compile
+      # Successful compilation!
     else
-      $stdout.puts "[Webpacker] Compilation Failed"
-      $stdout.puts "\e[31m#{stdout_str}\e[0m"
-      $stderr.puts "\e[31m#{stderr_str}\e[0m"
+      # Failed compilation
       exit!
     end
   end

--- a/lib/webpacker.rb
+++ b/lib/webpacker.rb
@@ -17,6 +17,7 @@ module Webpacker
   end
 end
 
+require "webpacker/logger"
 require "webpacker/env"
 require "webpacker/configuration"
 require "webpacker/manifest"

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -6,6 +6,7 @@ module Webpacker::Compiler
   extend self
 
   delegate :cache_path, :output_path, :source, to: Webpacker::Configuration
+  delegate :logger, to: Webpacker
 
   # Additional paths that test compiler needs to watch
   # Webpacker::Compiler.watched_paths << 'bower_components'
@@ -16,7 +17,7 @@ module Webpacker::Compiler
       cache_source_timestamp
       run_webpack
     else
-      Rails.logger.debug "[Webpacker] All assets are fresh, no compiling needed"
+      logger.debug "[Webpacker] All assets are fresh, no compiling needed"
     end
   end
 
@@ -60,12 +61,10 @@ module Webpacker::Compiler
       sterr, stdout, status = Open3.capture3(webpack_env, "#{RbConfig.ruby} ./bin/webpack")
 
       if status.success?
-        Rails.logger.info \
-          "[Webpacker] Compiled digests for all packs in #{Webpacker::Configuration.entry_path}: " +
-          JSON.parse(File.read(Webpacker::Configuration.manifest_path)).to_s
+        logger.info "[Webpacker] Compiled all packs in #{Webpacker::Configuration.entry_path}"
         true
       else
-        Rails.logger.error "[Webpacker] Compilation Failed:\n#{sterr}\n#{stdout}"
+        logger.error "[Webpacker] Compilation Failed:\n#{sterr}\n#{stdout}"
         false
       end
     end

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -24,7 +24,7 @@ module Webpacker::Compiler
   # Returns true if all the compiled packs are up to date with the underlying asset files.
   def fresh?
     if cached_timestamp_path.exist? && output_path.exist?
-      cached_timestamp_path.read != current_source_timestamp
+      cached_timestamp_path.read == current_source_timestamp
     else
       false
     end

--- a/lib/webpacker/logger.rb
+++ b/lib/webpacker/logger.rb
@@ -1,0 +1,17 @@
+require "active_support/core_ext/module/attribute_accessors"
+require "active_support/logger"
+require "active_support/tagged_logging"
+
+module Webpacker::Logger
+  mattr_accessor(:logger) { ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT)) }
+
+  def ensure_log_goes_to_stdout
+    old_logger = logger
+    self.logger = ActiveSupport::Logger.new(STDOUT)
+    yield
+  ensure
+    self.logger = old_logger
+  end
+end
+
+Webpacker.extend Webpacker::Logger

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -3,7 +3,7 @@ require "rails/railtie"
 require "webpacker/helper"
 
 class Webpacker::Engine < ::Rails::Engine
-  initializer :webpacker do |app|
+  initializer "webpacker.helper" do |app|
     ActiveSupport.on_load :action_controller do
       ActionController::Base.helper Webpacker::Helper
     end
@@ -11,7 +11,15 @@ class Webpacker::Engine < ::Rails::Engine
     ActiveSupport.on_load :action_view do
       include Webpacker::Helper
     end
+  end
 
+  initializer "webpacker.logger" do
+    config.after_initialize do |app|
+      Webpacker.logger = ::Rails.logger
+    end
+  end
+
+  initializer "webpacker.bootstrap" do
     Webpacker.bootstrap
     Spring.after_fork { Webpacker.bootstrap } if defined?(Spring)
   end


### PR DESCRIPTION
Before this on-demand compilation would exit the process if it failed. Doesn’t work for on-demand compilation in development.