### PR TITLE
Enable babel-loader cache

### DIFF
--- a/lib/install/config/loaders/core/babel.js
+++ b/lib/install/config/loaders/core/babel.js
@@ -1,5 +1,11 @@
+const { join } = require('path')
+const { settings } = require('../configuration.js')
+
 module.exports = {
   test: /\.js(\.erb)?$/,
   exclude: /node_modules/,
-  loader: 'babel-loader'
+  loader: 'babel-loader',
+  options: {
+    cacheDirectory: join(settings.cache_path, 'babel-loader')
+  }
 }

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -4,6 +4,7 @@ default: &default
   source_path: app/javascript
   source_entry_path: packs
   public_output_path: packs
+  cache_path: tmp/cache/webpacker
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
@@ -40,6 +41,6 @@ test:
 
 production:
   <<: *default
-  
+
   # Production demands on precompilation of packs prior to booting for performance.
   compile: false

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -32,6 +32,10 @@ class Webpacker::Configuration < Webpacker::FileLoader
       file_path(root: Pathname.new(__dir__).join("../install"))
     end
 
+    def cache_path
+      Rails.root.join(fetch(:cache_path))
+    end
+
     def source
       fetch(:source_path)
     end

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -15,10 +15,6 @@ class CompilerTest < Minitest::Test
     end
   end
 
-  def test_cache_dir
-    assert_equal Webpacker::Compiler.cache_dir, "tmp/webpacker"
-  end
-
   def test_freshness
     assert Webpacker::Compiler.stale?
     assert !Webpacker::Compiler.fresh?

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -30,6 +30,11 @@ class ConfigurationTest < Minitest::Test
     assert_equal Webpacker::Configuration.source_path.to_s, source_path
   end
 
+  def test_cache_path
+    cache_path = File.join(File.dirname(__FILE__), "test_app/tmp/cache/webpacker").to_s
+    assert_equal Webpacker::Configuration.cache_path.to_s, cache_path
+  end
+
   def test_compile?
     refute Webpacker::Configuration.compile?
   end


### PR DESCRIPTION
> You can also speed up babel-loader by as much as 2x by using the cacheDirectory option. This will cache transformations to the filesystem.

– https://github.com/babel/babel-loader#babel-loader-is-slow

Shaves ~1s off Basecamp's compile time.