### PR TITLE
Allow blank public_output_path

### DIFF
--- a/lib/install/config/webpack/configuration.js
+++ b/lib/install/config/webpack/configuration.js
@@ -18,8 +18,8 @@ function formatPublicPath(host = '', path = '') {
   if (formattedHost && !/^http/i.test(formattedHost)) {
     formattedHost = `//${formattedHost}`
   }
-  const formattedPath = removeOuterSlashes(path)
-  return `${formattedHost}/${formattedPath}/`
+  const formattedPath = removeOuterSlashes(`${formattedHost}/${path}`)
+  return `${formattedPath}/`
 }
 
 const output = {


### PR DESCRIPTION
If `public_output_path` is an empty string `public_output_path: ''`, all the packed assets would be prefixed with an extra slash (ex. `https://HOST//service-worker.js`. 

This change would allow public_output_path to be at the root of the host, by applying the outer slash removal on final formatPublicPath to remove the extra slash.

I was running into an issue trying to hook a service worker into the root path of the site to work on other URLs within the site. This might be useful for others doing the same.