### PR TITLE
Speed up `bin/webpack*` executables by dropping `yarn run` overhead

### DIFF
--- a/lib/install/bin/webpack-dev-server.tt
+++ b/lib/install/bin/webpack-dev-server.tt
@@ -51,20 +51,19 @@ end
   ARGV.delete(arg)
 end
 
-newenv = {
+env = {
   "NODE_PATH" => NODE_MODULES_PATH.shellescape,
   "ASSET_HOST" => DEV_SERVER_ADDR.shellescape
-}.freeze
+}
 
-options = ["--progress", "--color", "--config", WEBPACK_CONFIG, "--host", LISTEN_HOST_ADDR, "--public", "#{HOSTNAME}:#{PORT}", "--port", PORT.to_s]
-
-if Gem.win_platform?
-  # Workaround for yarn not playing nicely with path separators
-  cmdline = ["#{NODE_MODULES_PATH}/.bin/webpack-dev-server", *options] + ARGV
-else
-  cmdline = ["yarn", "run", "webpack-dev-server", "--", *options] + ARGV
-end
+cmd = [
+  "#{NODE_MODULES_PATH}/.bin/webpack-dev-server", "--progress", "--color",
+  "--config", WEBPACK_CONFIG,
+  "--host", LISTEN_HOST_ADDR,
+  "--public", "#{HOSTNAME}:#{PORT}",
+  "--port", PORT.to_s
+] + ARGV
 
 Dir.chdir(APP_PATH) do
-  exec newenv, *cmdline
+  exec env, *cmd
 end

--- a/lib/install/bin/webpack.tt
+++ b/lib/install/bin/webpack.tt
@@ -19,14 +19,9 @@ unless File.exist?(WEBPACK_CONFIG)
   exit!
 end
 
-newenv  = { "NODE_PATH" => NODE_MODULES_PATH.shellescape }
-if Gem.win_platform?
-  # Workaround for yarn not playing nicely with path separators
-  cmdline = ["#{NODE_MODULES_PATH}/.bin/webpack", "--config", WEBPACK_CONFIG] + ARGV
-else
-  cmdline = ["yarn", "run", "webpack", "--", "--config", WEBPACK_CONFIG] + ARGV
-end
+env = { "NODE_PATH" => NODE_MODULES_PATH.shellescape }
+cmd = [ "#{NODE_MODULES_PATH}/.bin/webpack", "--config", WEBPACK_CONFIG ] + ARGV
 
 Dir.chdir(APP_PATH) do
-  exec newenv, *cmdline
+  exec env, *cmd
 end


### PR DESCRIPTION
We were already doing this on Windows only (https://github.com/rails/webpacker/pull/584). Just do it.

Before
```sh
$ time bin/webpack
yarn run v0.27.5
$ "/Users/javan/Desktop/myapp/node_modules/.bin/webpack" "--config" "/Users/javan/Desktop/myapp/config/webpack/development.js"
Hash: 9a50a6710c2068693890
Version: webpack 3.5.4
Time: 1005ms
         Asset     Size  Chunks                    Chunk Names
hello_react.js  2.05 MB       0  [emitted]  [big]  hello_react
  [82] ./app/javascript/packs/hello_react.jsx 759 bytes {0} [built]
    + 184 hidden modules
Done in 1.77s.

real	0m2.309s
user	0m2.295s
sys	0m0.210s
```

After
```sh
$ time bin/webpack
Hash: 9a50a6710c2068693890
Version: webpack 3.5.4
Time: 958ms
         Asset     Size  Chunks                    Chunk Names
hello_react.js  2.05 MB       0  [emitted]  [big]  hello_react
  [82] ./app/javascript/packs/hello_react.jsx 759 bytes {0} [built]
    + 184 hidden modules

real	0m1.803s
user	0m1.827s
sys	0m0.169s
```