### PR TITLE
Add lookup path for looking up pack paths for server rendering

### DIFF
--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -27,6 +27,10 @@ class Webpacker::Manifest
     find name
   end
 
+  def lookup_path(name)
+    Rails.root.join(File.join(Webpacker.config.public_path, lookup(name)))
+  end
+
   private
     def compiling?
       config.compile? && !dev_server.running?

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -27,6 +27,7 @@ class Webpacker::Manifest
     find name
   end
 
+  # Useful for looking up packs directly on disk for server rendering
   def lookup_path(name)
     Rails.root.join(File.join(Webpacker.config.public_path, lookup(name)))
   end


### PR DESCRIPTION
@dhh We accidentally removed this method yesterday, this is being used here for server rendering packs - https://github.com/reactjs/react-rails/blob/f3f9576345dae018dd7d7e96466824d78b19919d/lib/react/server_rendering/webpacker_manifest_container.rb#L24
