### PR TITLE
Allow to use environments not present by default

### DIFF
--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -60,6 +60,6 @@ class Webpacker::Configuration
 
     def defaults
       @defaults ||= \
-        YAML.load(File.read(File.expand_path("../../install/config/webpacker.yml", __FILE__)))[env].deep_symbolize_keys
+        HashWithIndifferentAccess.new(YAML.load(File.read(File.expand_path("../../install/config/webpacker.yml", __FILE__)))[env])
     end
 end


### PR DESCRIPTION
This commit allows to define non standard environments. Before it failed
to load defaults for environments not existing in the default yaml
because it tried to do a `.deep_symbolize_keys` on `nil`. By using the
constructor form it returns an empty hash now.

---

I tried to write a simple test but it got more and more complicated (because custom and default config are the same in the tests, and one would need one custom config to test it in that case.)