### PR TITLE
Fix dev_server HMR reference and refresh after compile

### DIFF
--- a/lib/install/config/loaders/core/sass.js
+++ b/lib/install/config/loaders/core/sass.js
@@ -4,7 +4,7 @@ const { env, settings } = require('../configuration.js')
 
 const postcssConfigPath = path.resolve(process.cwd(), '.postcssrc.yml')
 const isProduction = env.NODE_ENV === 'production'
-const extractCSS = !settings.dev_server.hmr
+const extractCSS = !(settings.dev_server && settings.dev_server.hmr)
 
 const extractOptions = {
   fallback: 'style-loader',

--- a/lib/install/config/loaders/installers/vue.js
+++ b/lib/install/config/loaders/installers/vue.js
@@ -1,7 +1,7 @@
 const { env, settings } = require('../configuration.js')
 
 const isProduction = env.NODE_ENV === 'production'
-const extractCSS = !settings.dev_server.hmr
+const extractCSS = !(settings.dev_server && settings.dev_server.hmr)
 
 module.exports = {
   test: /\.vue$/,

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -10,6 +10,10 @@ default: &default
   # ['app/assets', 'engine/foo/app/assets']
   resolved_paths: []
 
+  # Makes sure manifest.json is reloaded on
+  # all requests so we can load latest packs
+  reload_manifest: true
+
   extensions:
     - .coffee
     - .erb
@@ -38,6 +42,8 @@ development:
 test:
   <<: *default
   compile: true
+
+  # Compile test packs to a separate directory
   public_output_path: packs-test
 
 production:
@@ -45,3 +51,6 @@ production:
 
   # Production demands on precompilation of packs prior to booting for performance.
   compile: false
+
+  # Don't reload in production since assets are precompiled for performance
+  reload_manifest: false

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -10,9 +10,8 @@ default: &default
   # ['app/assets', 'engine/foo/app/assets']
   resolved_paths: []
 
-  # Makes sure manifest.json is reloaded on
-  # all requests so we can load latest packs
-  reload_manifest: true
+  # Reload manifest.json on all requests so we reload latest compiled packs
+  cache_manifest: false
 
   extensions:
     - .coffee
@@ -52,5 +51,5 @@ production:
   # Production demands on precompilation of packs prior to booting for performance.
   compile: false
 
-  # Don't reload in production since assets are precompiled for performance
-  reload_manifest: false
+  # Cache manifest.json for performance
+  cache_manifest: true

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -37,8 +37,8 @@ class Webpacker::Configuration
     public_output_path.join("manifest.json")
   end
 
-  def reload_manifest?
-    fetch(:reload_manifest)
+  def cache_manifest?
+    fetch(:cache_manifest)
   end
 
   def cache_path

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -37,6 +37,10 @@ class Webpacker::Configuration
     public_output_path.join("manifest.json")
   end
 
+  def reload_manifest?
+    fetch(:reload_manifest)
+  end
+
   def cache_path
     root_path.join(fetch(:cache_path))
   end
@@ -47,11 +51,7 @@ class Webpacker::Configuration
     end
 
     def data
-      if env.production?
-        @data ||= load
-      else
-        refresh
-      end
+      @data ||= load
     end
 
     def load

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -47,10 +47,10 @@ class Webpacker::Configuration
     end
 
     def data
-      if env.development?
-        refresh
-      else
+      if env.production?
         @data ||= load
+      else
+        refresh
       end
     end
 

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -34,7 +34,6 @@ class Webpacker::Manifest
 
     def compile
       Webpacker.logger.tagged("Webpacker") { compiler.compile }
-      refresh
     end
 
     def find(name)
@@ -47,7 +46,11 @@ class Webpacker::Manifest
     end
 
     def data
-      @data ||= load
+      if env.production?
+        @data ||= load
+      else
+        refresh
+      end
     end
 
     def load

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -34,6 +34,7 @@ class Webpacker::Manifest
 
     def compile
       Webpacker.logger.tagged("Webpacker") { compiler.compile }
+      refresh
     end
 
     def find(name)
@@ -46,11 +47,7 @@ class Webpacker::Manifest
     end
 
     def data
-      if env.development?
-        refresh
-      else
-        @data ||= load
-      end
+      @data ||= load
     end
 
     def load

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -46,10 +46,10 @@ class Webpacker::Manifest
     end
 
     def data
-      if env.production?
-        @data ||= load
-      else
+      if config.reload_manifest?
         refresh
+      else
+        @data ||= load
       end
     end
 

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -12,7 +12,7 @@
 class Webpacker::Manifest
   class MissingEntryError < StandardError; end
 
-  delegate :config, :compiler, :env, :dev_server, to: :@webpacker
+  delegate :config, :compiler, :dev_server, to: :@webpacker
 
   def initialize(webpacker)
     @webpacker = webpacker
@@ -46,10 +46,10 @@ class Webpacker::Manifest
     end
 
     def data
-      if config.reload_manifest?
-        refresh
-      else
+      if config.cache_manifest?
         @data ||= load
+      else
+        refresh
       end
     end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -26,6 +26,20 @@ class ConfigurationTest < Webpacker::Test
     assert_equal Webpacker.config.cache_path.to_s, cache_path
   end
 
+  def test_reload_manifest?
+    with_node_env("development") do
+      assert reloaded_config.reload_manifest?
+    end
+
+    with_node_env("test") do
+      assert reloaded_config.reload_manifest?
+    end
+
+    with_node_env("production") do
+      refute reloaded_config.reload_manifest?
+    end
+  end
+
   def test_compile?
     with_node_env("development") do
       assert reloaded_config.compile?

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -26,17 +26,17 @@ class ConfigurationTest < Webpacker::Test
     assert_equal Webpacker.config.cache_path.to_s, cache_path
   end
 
-  def test_reload_manifest?
+  def test_cache_manifest?
     with_node_env("development") do
-      assert reloaded_config.reload_manifest?
+      refute reloaded_config.cache_manifest?
     end
 
     with_node_env("test") do
-      assert reloaded_config.reload_manifest?
+      refute reloaded_config.cache_manifest?
     end
 
     with_node_env("production") do
-      refute reloaded_config.reload_manifest?
+      assert reloaded_config.cache_manifest?
     end
   end
 


### PR DESCRIPTION
Fixes #651

This PR fixes a bug where `dev_server` is only available in development env but the JS is trying to reference HMR without checking if dev_server object is available.

Also it moves refresh to compile call so that the manifest is refreshed after each compile and not just in development. 