### PR TITLE
React on Rails: last issue is the check for the binstubs crashes if the binstub does not exist

### DIFF
--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -5,6 +5,7 @@ default: &default
   source_entry_path: packs
   public_output_path: packs
   cache_path: tmp/cache/webpacker
+  custom_compile: false
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']

--- a/lib/tasks/webpacker/check_binstubs.rake
+++ b/lib/tasks/webpacker/check_binstubs.rake
@@ -1,7 +1,8 @@
 namespace :webpacker do
   desc "Verifies that bin/webpack & bin/webpack-dev-server are present."
   task :check_binstubs do
-    unless File.exist?("bin/webpack") && File.exist?("bin/webpack-dev-server")
+    unless Webpacker.config.custom_compile? ||
+      (File.exist?("bin/webpack") && File.exist?("bin/webpack-dev-server"))
       $stderr.puts "Webpack binstubs not found.\n"\
            "Have you run rails webpacker:install ?\n"\
            "Make sure the bin directory or binstubs are not included in .gitignore\n"\

--- a/lib/tasks/webpacker/verify_install.rake
+++ b/lib/tasks/webpacker/verify_install.rake
@@ -3,14 +3,16 @@ require "webpacker/configuration"
 namespace :webpacker do
   desc "Verifies if webpacker is installed"
   task verify_install: [:check_node, :check_yarn, :check_binstubs] do
-    if Webpacker.config.config_path.exist?
-      $stdout.puts "Webpacker is installed 🎉 🍰"
-      $stdout.puts "Using #{Webpacker.config.config_path} file for setting up webpack paths"
-    else
-      $stderr.puts "Configuration config/webpacker.yml file not found. \n"\
+    unless Webpacker.config.custom_compile?
+      if Webpacker.config.config_path.exist?
+        $stdout.puts "Webpacker is installed 🎉 🍰"
+        $stdout.puts "Using #{Webpacker.config.config_path} file for setting up webpack paths"
+      else
+        $stderr.puts "Configuration config/webpacker.yml file not found. \n"\
            "Make sure webpacker:install is run successfully before " \
            "running dependent tasks"
-      exit!
+        exit!
+      end
     end
   end
 end

--- a/lib/tasks/webpacker/verify_install.rake
+++ b/lib/tasks/webpacker/verify_install.rake
@@ -3,16 +3,14 @@ require "webpacker/configuration"
 namespace :webpacker do
   desc "Verifies if webpacker is installed"
   task verify_install: [:check_node, :check_yarn, :check_binstubs] do
-    unless Webpacker.config.custom_compile?
-      if Webpacker.config.config_path.exist?
-        $stdout.puts "Webpacker is installed 🎉 🍰"
-        $stdout.puts "Using #{Webpacker.config.config_path} file for setting up webpack paths"
-      else
-        $stderr.puts "Configuration config/webpacker.yml file not found. \n"\
+    if Webpacker.config.config_path.exist?
+      $stdout.puts "Webpacker is installed 🎉 🍰"
+      $stdout.puts "Using #{Webpacker.config.config_path} file for setting up webpack paths"
+    else
+      $stderr.puts "Configuration config/webpacker.yml file not found. \n"\
            "Make sure webpacker:install is run successfully before " \
            "running dependent tasks"
-        exit!
-      end
+      exit!
     end
   end
 end

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -17,6 +17,10 @@ class Webpacker::Configuration
     fetch(:compile)
   end
 
+  def custom_compile?
+    fetch(:custom_compile)
+  end
+
   def source_path
     root_path.join(fetch(:source_path))
   end

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -42,7 +42,7 @@ class Webpacker::Manifest
 
     def handle_missing_entry(name)
       raise Webpacker::Manifest::MissingEntryError,
-        "Can't find #{name} in #{config.public_manifest_path}. Manifest contains: #{@data}"
+        "Can't find #{name} in #{config.public_manifest_path}. Manifest contains:\n#{JSON.pretty_generate(@data)}"
     end
 
     def missing_file_from_manifest_error(bundle_name)
@@ -62,6 +62,8 @@ Your manifest contains:
     def data
       if config.cache_manifest?
         @data ||= load
+      else
+        refresh
       end
     end
 

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -42,14 +42,26 @@ class Webpacker::Manifest
 
     def handle_missing_entry(name)
       raise Webpacker::Manifest::MissingEntryError,
-        "Can't find #{name} in #{config.public_manifest_path}. Is webpack still compiling?"
+        "Can't find #{name} in #{config.public_manifest_path}. Manifest contains: #{@data}"
+    end
+
+    def missing_file_from_manifest_error(bundle_name)
+      msg = <<-MSG
+Webpacker can't find #{bundle_name} in #{config.public_manifest_path}. Possible causes:
+1. You are hot reloading.
+2. You want to set Configuration.compile to true for your environment.
+3. Webpack has not re-run to reflect updates.
+4. You have misconfigured Webpacker's config/webpacker.yml file.
+5. Your Webpack configuration is not creating a manifest.
+Your manifest contains:
+#{@data.to_json}
+    MSG
+      raise(Webpacker::FileLoader::NotFoundError.new(msg))
     end
 
     def data
       if config.cache_manifest?
         @data ||= load
-      else
-        refresh
       end
     end
 

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -9,8 +9,17 @@ class ManifestTest < Minitest::Test
       error = assert_raises Webpacker::Manifest::MissingEntryError do
         Webpacker.manifest.lookup(asset_file)
       end
+      expected = <<-MSG.strip
+Can't find calendar.js in #{manifest_path}. Manifest contains:
+{
+  "bootstrap.css": "/packs/bootstrap-c38deda30895059837cf.css",
+  "application.css": "/packs/application-dd6b1cd38bfa093df600.css",
+  "bootstrap.js": "/packs/bootstrap-300631c4f0e0f9c865bc.js",
+  "application.js": "/packs/application-k344a6d59eef8632c9d1.js"
+}
+      MSG
 
-      assert_equal "Can't find #{asset_file} in #{manifest_path}. Is webpack still compiling?", error.message
+      assert_equal expected, error.message
     end
   end
 


### PR DESCRIPTION
Small changes for React on Rails based on master branch of rails/webpacker

I can move the better error message part to a separate PR tomorrow.

The only issue is the check for the binstubs crashes if the binstub does not exist.

I have updated https://github.com/shakacode/react_on_rails/pull/908
