### PR TITLE
Fix broken react-hot-loader guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Checkout this guide for more information:
 To support HMR with React you would need to add `react-hot-loader`. Checkout this guide for
 more information:
 
-- https://webpack.js.org/guides/hmr-react/
+- https://gaearon.github.io/react-hot-loader/getstarted/
 
 **Note:** Don't forget to disable `HMR` if you are not running `webpack-dev-server`
 otherwise you will get not found error for stylesheets.


### PR DESCRIPTION
The guide currently in the README was recently removed: https://github.com/webpack/webpack.js.org/pull/1251/files#diff-d6bc3b673e89ae46bca8b389216726cd

I recently set up HMR & React Hot Loader with Webpacker and Dan Abramov's guide was very helpful.