### PR TITLE
Force Rack::Proxy to use http

### DIFF
--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -10,6 +10,8 @@ class Webpacker::DevServerProxy < Rack::Proxy
   def perform_request(env)
     if env["PATH_INFO"] =~ /#{public_output_uri_path}/ && Webpacker.dev_server.running?
       env["HTTP_HOST"] = Webpacker.dev_server.host_with_port
+      env["HTTPS"] = "off"
+      env["rack.url_scheme"] = "http"
       super(env)
     else
       @app.call(env)


### PR DESCRIPTION
Since webpack-dev-server is running as http, force a http connection.

If the frontend server is running https, Rack::Proxy will otherwise
attempt to conenct via https to the backend.

I'm using webpacker with passenger in development behind passenger, with SSL enabled for local development.

Rack::Proxy was attempting to connect to the backend server over SSL, causing nginx to 500.