### PR TITLE
Add back Https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@
 
 - Add new `HMR` option for hot-module-replacement
 
+- HTTPS ssl settings to webpack-dev-server config
+  ```yml
+    # Absolute paths to ssl key and certificate
+    ssl_key_path:
+    ssl_cert_path:
+  ```
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 - Add new `HMR` option for hot-module-replacement
 
-- HTTPS ssl settings to webpack-dev-server config
+- Configurable HTTPS ssl key and cert settings
   ```yml
     # Absolute paths to ssl key and certificate
     ssl_key_path:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,12 +29,7 @@
 
 - Add new `HMR` option for hot-module-replacement
 
-- Configurable HTTPS ssl key and cert settings
-  ```yml
-    # Absolute paths to ssl key and certificate
-    ssl_key_path:
-    ssl_cert_path:
-  ```
+- Add HTTPS
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -408,15 +408,12 @@ then start the dev server as usual with `./bin/webpack-dev-server`.
 Please note that the `webpack-dev-server` will use a self-signed certificate,
 so your web browser will display a warning upon accessing the page. To ensure there
 is no conflict between Rails server SSL certificate and `webpack-dev-server` you can
-supply same certificates to `webpack-dev-server` too using following setting.
+supply same key and certificate to `webpack-dev-server`:
 
-```
-- HTTPS ssl settings to webpack-dev-server config
-  ```yml
-    # Absolute paths to ssl key and certificate
-    ssl_key_path:
-    ssl_cert_path:
-  ```
+```yml
+  # Absolute paths to ssl key and certificate
+  ssl_key_path:
+  ssl_cert_path:
 ```
 
 ### Hot module replacement

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ then start the dev server as usual with `./bin/webpack-dev-server`.
 Please note that the `webpack-dev-server` will use a self-signed certificate,
 so your web browser will display a warning upon accessing the page. To ensure there
 is no conflict between Rails server SSL certificate and `webpack-dev-server` you can
-supply came certificates to dev-server.
+supply same certificates to `webpack-dev-server` too using following setting.
 
 ```
 - HTTPS ssl settings to webpack-dev-server config

--- a/README.md
+++ b/README.md
@@ -401,20 +401,15 @@ you don't need to do anything extra for webpacker, it just works.
 
 ### HTTPS in development
 
-If you're using the `webpack-dev-server` in development, you can serve views over HTTPS
+If you're using the `webpack-dev-server` in development, you can serve your packs over HTTPS
 by setting the `https` option for `webpack-dev-server` to `true` in `config/webpacker.yml`,
 then start the dev server as usual with `./bin/webpack-dev-server`.
 
 Please note that the `webpack-dev-server` will use a self-signed certificate,
-so your web browser will display a warning upon accessing the page. To ensure there
-is no conflict between Rails server SSL certificate and `webpack-dev-server` you can
-supply same key and certificate to `webpack-dev-server`:
-
-```yml
-  # Absolute paths to ssl key and certificate
-  ssl_key_path:
-  ssl_cert_path:
-```
+so your web browser will display a warning/exception upon accessing the page. If you get
+`https://localhost:3035/sockjs-node/info?t=1503127986584 net::ERR_INSECURE_RESPONSE`
+in your console, simply open the link in your browser and accept the SSL exception.
+Now if you refresh your rails view everything should work as expected.  
 
 ### Hot module replacement
 

--- a/README.md
+++ b/README.md
@@ -399,6 +399,26 @@ plugins:
 Webpacker out-of-the-box provides CDN support using your Rails app `config.action_controller.asset_host` setting. If you already have [CDN](http://guides.rubyonrails.org/asset_pipeline.html#cdns) added in your rails app
 you don't need to do anything extra for webpacker, it just works.
 
+### HTTPS in development
+
+If you're using the `webpack-dev-server` in development, you can serve views over HTTPS
+by setting the `https` option for `webpack-dev-server` to `true` in `config/webpacker.yml`,
+then start the dev server as usual with `./bin/webpack-dev-server`.
+
+Please note that the `webpack-dev-server` will use a self-signed certificate,
+so your web browser will display a warning upon accessing the page. To ensure there
+is no conflict between Rails server SSL certificate and `webpack-dev-server` you can
+supply came certificates to dev-server.
+
+```
+- HTTPS ssl settings to webpack-dev-server config
+  ```yml
+    # Absolute paths to ssl key and certificate
+    ssl_key_path:
+    ssl_cert_path:
+  ```
+```
+
 ### Hot module replacement
 
 Webpacker out-of-the-box supports HMR with `webpack-dev-server` and
@@ -636,7 +656,7 @@ Now, modify your Vue app to expect the properties.
     // A child component needs to explicitly declare
     // the props it expects to receive using the props option
     // See https://vuejs.org/v2/guide/components.html#Props
-    props: ["message","name"], 
+    props: ["message","name"],
     data: function () {
       return {
           test: 'This will display: ',

--- a/lib/install/bin/webpack-dev-server.tt
+++ b/lib/install/bin/webpack-dev-server.tt
@@ -28,7 +28,8 @@ begin
 
   HOSTNAME        = args('--host') || dev_server["host"]
   PORT            = args('--port') || dev_server["port"]
-  DEV_SERVER_ADDR = "http://#{HOSTNAME}:#{PORT}"
+  HTTPS           = ARGV.include?('--https') || dev_server["https"]
+  DEV_SERVER_ADDR = "http#{"s" if HTTPS}://#{HOSTNAME}:#{PORT}"
 
 rescue Errno::ENOENT, NoMethodError
   $stdout.puts "Webpack dev_server configuration not found in #{CONFIG_FILE}."

--- a/lib/install/config/webpack/development.js
+++ b/lib/install/config/webpack/development.js
@@ -5,8 +5,6 @@ const merge = require('webpack-merge')
 const sharedConfig = require('./shared.js')
 const { settings, output } = require('./configuration.js')
 
-const { dev_server: devServer } = settings
-
 module.exports = merge(sharedConfig, {
   devtool: 'cheap-eval-source-map',
 
@@ -16,10 +14,10 @@ module.exports = merge(sharedConfig, {
 
   devServer: {
     clientLogLevel: 'none',
-    host: devServer.host,
-    port: devServer.port,
-    https: devServer.https,
-    hot: devServer.hmr,
+    host: settings.dev_server.host,
+    port: settings.dev_server.port,
+    https: settings.dev_server.https,
+    hot: settings.dev_server.hmr,
     contentBase: output.path,
     publicPath: output.publicPath,
     compress: true,

--- a/lib/install/config/webpack/development.js
+++ b/lib/install/config/webpack/development.js
@@ -2,8 +2,20 @@
 
 const webpack = require('webpack')
 const merge = require('webpack-merge')
+const { readFileSync } = require('fs')
 const sharedConfig = require('./shared.js')
 const { settings, output } = require('./configuration.js')
+
+const { dev_server: devServer } = settings
+let https = devServer.https
+
+// Set ssl key and certificates if supplied
+if (devServer.ssl_key_path && devServer.ssl_cert_path) {
+  https = {
+    key: readFileSync(devServer.ssl_key_path),
+    cert: readFileSync(devServer.ssl_cert_path)
+  }
+}
 
 module.exports = merge(sharedConfig, {
   devtool: 'cheap-eval-source-map',
@@ -14,9 +26,10 @@ module.exports = merge(sharedConfig, {
 
   devServer: {
     clientLogLevel: 'none',
-    host: settings.dev_server.host,
-    port: settings.dev_server.port,
-    hot: settings.dev_server.hmr,
+    host: devServer.host,
+    port: devServer.port,
+    https,
+    hot: devServer.hmr,
     contentBase: output.path,
     publicPath: output.publicPath,
     compress: true,

--- a/lib/install/config/webpack/development.js
+++ b/lib/install/config/webpack/development.js
@@ -10,7 +10,7 @@ const { dev_server: devServer } = settings
 let https = devServer.https
 
 // Set ssl key and certificates if supplied
-if (devServer.ssl_key_path && devServer.ssl_cert_path) {
+if (https && devServer.ssl_key_path && devServer.ssl_cert_path) {
   https = {
     key: readFileSync(devServer.ssl_key_path),
     cert: readFileSync(devServer.ssl_cert_path)

--- a/lib/install/config/webpack/development.js
+++ b/lib/install/config/webpack/development.js
@@ -2,20 +2,10 @@
 
 const webpack = require('webpack')
 const merge = require('webpack-merge')
-const { readFileSync } = require('fs')
 const sharedConfig = require('./shared.js')
 const { settings, output } = require('./configuration.js')
 
 const { dev_server: devServer } = settings
-let https = devServer.https
-
-// Set ssl key and certificates if supplied
-if (https && devServer.ssl_key_path && devServer.ssl_cert_path) {
-  https = {
-    key: readFileSync(devServer.ssl_key_path),
-    cert: readFileSync(devServer.ssl_cert_path)
-  }
-}
 
 module.exports = merge(sharedConfig, {
   devtool: 'cheap-eval-source-map',
@@ -28,7 +18,7 @@ module.exports = merge(sharedConfig, {
     clientLogLevel: 'none',
     host: devServer.host,
     port: devServer.port,
-    https,
+    https: devServer.https,
     hot: devServer.hmr,
     contentBase: output.path,
     publicPath: output.publicPath,

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -37,14 +37,7 @@ development:
     host: localhost
     port: 3035
     hmr: false
-
-    # Enable HTTPS
     https: false
-
-    # Absolute paths to ssl key and certificate
-    # Use same key and certs as your rails server
-    ssl_key_path:
-    ssl_cert_path:
 
 test:
   <<: *default

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -38,6 +38,14 @@ development:
     port: 3035
     hmr: false
 
+    # Enable HTTPS
+    https: false
+
+    # Absolute paths to ssl key and certificate
+    # Use same key and certs as your rails server
+    ssl_key_path:
+    ssl_cert_path:
+
 test:
   <<: *default
   compile: true

--- a/lib/webpacker/dev_server.rb
+++ b/lib/webpacker/dev_server.rb
@@ -24,6 +24,14 @@ class Webpacker::DevServer
     fetch(:port)
   end
 
+  def https?
+    fetch(:https)
+  end
+
+  def protocol
+    https? ? "https" : "http"
+  end
+
   def host_with_port
     "#{host}:#{port}"
   end

--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -4,6 +4,7 @@ class Webpacker::DevServerProxy < Rack::Proxy
   def rewrite_response(response)
     status, headers, body = response
     headers.delete "transfer-encoding"
+    headers.delete "content-length" if Webpacker.dev_server.https?
     response
   end
 

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -8,7 +8,7 @@ class Webpacker::Engine < ::Rails::Engine
     if Rails.env.development?
       app.middleware.insert_before 0,
         Rails::VERSION::MAJOR >= 5 ?
-          Webpacker::DevServerProxy : "Webpacker::DevServerProxy"
+          Webpacker::DevServerProxy : "Webpacker::DevServerProxy", ssl_verify_none: true
     end
   end
 

--- a/test/dev_server_test.rb
+++ b/test/dev_server_test.rb
@@ -14,4 +14,11 @@ class DevServerTest < Webpacker::Test
       assert_equal Webpacker.dev_server.port, 3035
     end
   end
+
+  def test_https?
+    with_node_env("development") do
+      reloaded_config
+      assert_equal Webpacker.dev_server.https?, false
+    end
+  end
 end


### PR DESCRIPTION
This PR adds  back `https` option for `webpack-dev-server` since we now have a proxy and people seems to be using `https` in development. Sadly, we can't terminate SSL since webpack-dev-server uses websockets, which won't connect until it's using same protocol. 

Fixes: https://github.com/rails/webpacker/issues/660
Supersedes: https://github.com/rails/webpacker/pull/658