### PR TITLE
Cache control

### DIFF
--- a/lib/webpacker/cache_control.rb
+++ b/lib/webpacker/cache_control.rb
@@ -1,0 +1,51 @@
+class Webpacker::CacheControl
+  ALLOWED_REQUEST_METHODS = ["GET", "HEAD"].freeze
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if env["PATH_INFO"] =~ /#{public_output_uri_path}/
+      status, headers, body = @app.call(env)
+
+      unless ALLOWED_REQUEST_METHODS.include?(env["REQUEST_METHOD"])
+        return method_not_allowed_response
+      end
+
+      etag, new_body = Rack::ETag.new(env).send(:digest_body, body)
+
+      # Set caching headers
+      headers["Cache-Control"] = String.new("public")
+      headers["ETag"]          = %("#{etag}")
+
+      # If the request url contains a fingerprint, set a long
+      # expires on the response
+      if path_fingerprint(env["PATH_INFO"])
+        headers["Cache-Control"] << ", max-age=31536000, immutable"
+
+      # Otherwise set `must-revalidate` since the asset could be modified.
+      else
+        headers["Cache-Control"] << ", must-revalidate"
+        headers["Vary"] = "Accept-Encoding"
+      end
+
+      [status, headers, new_body]
+    else
+      @app.call(env)
+    end
+  end
+
+  private
+    def public_output_uri_path
+      Webpacker.config.public_output_path.relative_path_from(Webpacker.config.public_path)
+    end
+
+    def method_not_allowed_response
+      [ 405, { "Content-Type" => "text/plain", "Content-Length" => "18" }, [ "Method Not Allowed" ] ]
+    end
+
+    def path_fingerprint(path)
+      path[/-([0-9a-f]{7,128})\.[^.]+\z/, 1]
+    end
+end

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -2,6 +2,7 @@ require "rails/railtie"
 
 require "webpacker/helper"
 require "webpacker/dev_server_proxy"
+require "webpacker/cache_control"
 
 class Webpacker::Engine < ::Rails::Engine
   initializer "webpacker.proxy" do |app|
@@ -10,6 +11,12 @@ class Webpacker::Engine < ::Rails::Engine
         Rails::VERSION::MAJOR >= 5 ?
           Webpacker::DevServerProxy : "Webpacker::DevServerProxy"
     end
+  end
+
+  initializer "webpacker.cache_control" do |app|
+    app.middleware.insert_before 0,
+      Rails::VERSION::MAJOR >= 5 ?
+        Webpacker::CacheControl : "Webpacker::CacheControl"
   end
 
   initializer "webpacker.helper" do |app|


### PR DESCRIPTION
Fixes: #550 (2)

This PR adds a middleware that adds `cache-control` and `etag` header on webpacker assets when served from file system. We already added hashes to the assets in all env however absence of the `Cache-Control` header might evict the assets prematurely (when sharing CDN or in browser). 

Previously: 
![screen shot 2017-08-18 at 22 26 15](https://user-images.githubusercontent.com/771039/29478440-cd3fc8c6-8464-11e7-83e2-738b02782682.png)

Now: 
![screen shot 2017-08-18 at 22 22 44](https://user-images.githubusercontent.com/771039/29478449-d2aae1c4-8464-11e7-94c0-5577c1c39566.png)

cc// @richardvenneman @terracatta
