### PR TITLE
WIP: Run webpack compiler as subprocess

### DIFF
--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -13,6 +13,12 @@ default: &default
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false
 
+  # Enable on-demand compilation
+  compile: true
+
+  # Default compiler
+  compiler: './bin/webpack-dev-server'
+
   extensions:
     - .coffee
     - .erb
@@ -31,7 +37,6 @@ default: &default
 
 development:
   <<: *default
-  compile: true
 
   dev_server:
     host: localhost
@@ -40,7 +45,6 @@ development:
 
 test:
   <<: *default
-  compile: true
 
   # Compile test packs to a separate directory
   public_output_path: packs-test
@@ -50,6 +54,7 @@ production:
 
   # Production demands on precompilation of packs prior to booting for performance.
   compile: false
+  compiler: false
 
   # Cache manifest.json for performance
   cache_manifest: true

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -9,6 +9,10 @@ class Webpacker::Configuration
     @data = load
   end
 
+  def compiler
+    fetch(:compiler)
+  end
+
   def dev_server
     fetch(:dev_server)
   end

--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -2,7 +2,7 @@ require "rack/proxy"
 
 class Webpacker::DevServerProxy < Rack::Proxy
   def rewrite_response(response)
-    status, headers, body = response
+    _status, headers, _body = response
     headers.delete "transfer-encoding"
     response
   end

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -29,7 +29,7 @@ class Webpacker::Manifest
 
   private
     def compiling?
-      config.compile? && !dev_server.running?
+      config.compile? && !config.compiler && !dev_server.running?
     end
 
     def compile

--- a/lib/webpacker/process.rb
+++ b/lib/webpacker/process.rb
@@ -1,0 +1,12 @@
+require "rack/server"
+
+class Webpacker::Process < ::Rack::Server
+  def start
+    puts "Starting #{Webpacker.config.compiler}"
+    system(Webpacker.config.compiler)
+    super
+
+  ensure
+    puts "Exiting #{Webpacker.config.compiler}"
+  end
+end

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -2,6 +2,7 @@ require "rails/railtie"
 
 require "webpacker/helper"
 require "webpacker/dev_server_proxy"
+require "webpacker/process"
 
 class Webpacker::Engine < ::Rails::Engine
   initializer "webpacker.proxy" do |app|
@@ -25,6 +26,14 @@ class Webpacker::Engine < ::Rails::Engine
   initializer "webpacker.logger" do
     config.after_initialize do |app|
       Webpacker.logger = ::Rails.logger
+    end
+  end
+
+  initializer "webpacker.subprocess" do
+    if Webpacker.config.compiler && !Webpacker.config.compile?
+      config.after_initialize do |app|
+        Webpacker::Process.new.start
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds subprocess support so we can fork a new webpack compiler when running `rails s` using `::Rails::Server`, which also kills the subprocess properly on exit (CTRL+C).

Not sure about the config setup though, like how we should wire this together since we have a on-demand compiler too. 

![screen shot 2017-08-19 at 00 04 28](https://user-images.githubusercontent.com/771039/29480774-ca703762-8472-11e7-8abc-f86509bc8749.png)
![screen shot 2017-08-19 at 00 04 47](https://user-images.githubusercontent.com/771039/29480775-ca72e26e-8472-11e7-850a-85851c447735.png)
![screen shot 2017-08-19 at 00 03 31](https://user-images.githubusercontent.com/771039/29480796-f68dc27e-8472-11e7-8952-d64a14ba5a5f.png)

Or with WebRick:

![screen shot 2017-08-19 at 00 37 40](https://user-images.githubusercontent.com/771039/29481230-ae718094-8476-11e7-98bb-851c324c78b9.png)

