### PR TITLE
Do not force SASS indented syntax in sass-loader

### DIFF
--- a/lib/install/config/loaders/core/sass.js
+++ b/lib/install/config/loaders/core/sass.js
@@ -12,7 +12,7 @@ const extractOptions = {
     { loader: 'css-loader', options: { minimize: isProduction } },
     { loader: 'postcss-loader', options: { sourceMap: true, config: { path: postcssConfigPath } } },
     'resolve-url-loader',
-    { loader: 'sass-loader', options: { sourceMap: true, indentedSyntax: true } }
+    { loader: 'sass-loader', options: { sourceMap: true } }
   ]
 }
 


### PR DESCRIPTION
According to https://github.com/sass/node-sass#indentedsyntax, `indentedSyntax` forces `sass-loader` to use SASS indented syntax.
The loader is currently configured to process both SASS and SCSS, but this setting prevents SCSS files to be used, as it results in a syntax error (because the loader tries to process it as SASS).

For reference, the error I was getting is:

```ERROR in ./~/css-loader?{"minimize":false}!./~/postcss-loader/lib?{"sourceMap":true,"config":{"path":"/Users/renchap/dev/Talegraph/.postcssrc.yml"}}!./~/resolve-url-loader!./~/sass-loader/lib/loader.js?{"sourceMap":true,"indentedSyntax":true}!./app/client/components/tale/visibility_dropdown/style.scss
Module build failed:
.visibility-dropdown {
                     ^
      Invalid CSS after "...lity-dropdown {": expected "}", was "{"
      in /Users/renchap/dev/Talegraph/app/client/components/tale/visibility_dropdown/style.scss (line 1, column 23)
```

I tested and it now works with both `.sass` and `.scss` files, with and without using the extension in the import statement.