### PR TITLE
Use babel-polyfill in application.js

### DIFF
--- a/lib/install/javascript/packs/application.js
+++ b/lib/install/javascript/packs/application.js
@@ -6,5 +6,6 @@
 //
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
+import 'babel-polyfill'
 
 console.log('Hello World from Webpacker')


### PR DESCRIPTION
This implies users need `import babel-polyfill` at entry point.

see: https://github.com/rails/webpacker/issues/523

I agree with @adamsanderson's proposal. This is it.

If there is no hint, users like me might misunderstand that polyfill is applied without any additional effort.