### PR TITLE
List possible causes of not finding a file in the manifest.

### DIFF
--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -41,8 +41,20 @@ class Webpacker::Manifest
     end
 
     def handle_missing_entry(name)
-      raise Webpacker::Manifest::MissingEntryError,
-        "Can't find #{name} in #{config.public_manifest_path}. Is webpack still compiling?"
+      raise Webpacker::Manifest::MissingEntryError, missing_file_from_manifest_error(name)
+    end
+
+    def missing_file_from_manifest_error(bundle_name)
+      msg = <<-MSG
+Webpacker can't find #{bundle_name} in #{config.public_manifest_path}. Possible causes:
+1. You want to set wepbacker.yml value of compile to true for your environment
+   unless you are using the `webpack -w` or the webpack-dev-server.
+2. Webpack has not yet re-run to reflect updates.
+3. You have misconfigured Webpacker's config/webpacker.yml file.
+4. Your Webpack configuration is not creating a manifest.
+Your manifest contains:
+#{JSON.pretty_generate(@data)}
+      MSG
     end
 
     def data

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -10,7 +10,23 @@ class ManifestTest < Minitest::Test
         Webpacker.manifest.lookup(asset_file)
       end
 
-      assert_equal "Can't find #{asset_file} in #{manifest_path}. Is webpack still compiling?", error.message
+      expected = <<-MSG
+Webpacker can't find #{asset_file} in #{manifest_path}. Possible causes:
+1. You want to set wepbacker.yml value of compile to true for your environment
+   unless you are using the `webpack -w` or the webpack-dev-server.
+2. Webpack has not yet re-run to reflect updates.
+3. You have misconfigured Webpacker's config/webpacker.yml file.
+4. Your Webpack configuration is not creating a manifest.
+Your manifest contains:
+{
+  "bootstrap.css": "/packs/bootstrap-c38deda30895059837cf.css",
+  "application.css": "/packs/application-dd6b1cd38bfa093df600.css",
+  "bootstrap.js": "/packs/bootstrap-300631c4f0e0f9c865bc.js",
+  "application.js": "/packs/application-k344a6d59eef8632c9d1.js"
+}
+     MSG
+
+      assert_equal expected, error.message
     end
   end
 


### PR DESCRIPTION
Using these reasons:
1. You want to set wepbacker.yml value of compile to true for your
   environment unless you are using the `webpack -w` or the webpack-dev-server.
2. Webpack has not yet re-run to reflect updates.
3. You have misconfigured Webpacker's config/webpacker.yml file.
4. Your Webpack configuration is not creating a manifest.

Broken out of #656 [per comment from @dhh](https://github.com/rails/webpacker/pull/656/files#r133791005)

We may want to adjust the possible reasons.