### PR TITLE
fix(configuration): fix initialization error when default config file is not existed

### DIFF
--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -55,7 +55,8 @@ class Webpacker::Configuration
     end
 
     def load
-      YAML.load(config_path.read)[env].deep_symbolize_keys
+      path = config_path.exist? ? config_path : File.expand_path("../../install/config/webpacker.yml", __FILE__)
+      YAML.load(File.read(path))[env].deep_symbolize_keys
     end
 
     def defaults


### PR DESCRIPTION
`config_path` variable is pointed at `config/webpacker.yml` defaultly, but there are no webpacker.yml configuration file before executing install command, which makes any operation will cause error.

A serious mistake, fix it now. Otherwise, the latest master branch does not work...