### PR TITLE
Skip configuration bootstrap if no config

### DIFF
--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -11,6 +11,7 @@ class Webpacker::Commands
   end
 
   def bootstrap
+    return unless config.config_path.exist?
     config.refresh
     manifest.refresh
   end


### PR DESCRIPTION
* Allows having gem in gemfile with no config file.

Might fix this error https://travis-ci.org/shakacode/react_on_rails/jobs/266728544

In React on Rails CI, we add the gems, and then we run the React on Rails Generator which creates the webpacker.yml file.

```
/home/travis/.rvm/gems/ruby-2.3.1/bundler/gems/webpacker-f14935f7d343/lib/webpacker/configuration.rb:62:in `read': No such file or directory @ rb_sysopen - /home/travis/build/shakacode/react_on_rails/gen-examples/examples/basic/config/webpacker.yml (Errno::ENOENT)
	from /home/travis/.rvm/gems/ruby-2.3.1/bundler/gems/webpacker-f14935f7d343/lib/webpacker/configuration.rb:62:in `read'
	from /home/travis/.rvm/gems/ruby-2.3.1/bundler/gems/webpacker-f14935f7d343/lib/webpacker/configuration.rb:62:in `load'
	from /home/travis/.rvm/gems/ruby-2.3.1/bundler/gems/webpacker-f14935f7d343/lib/webpacker/configuration.rb:9:in `refresh'
	from /home/travis/.rvm/gems/ruby-2.3.1/bundler/gems/webpacker-f14935f7d343/lib/webpacker/commands.rb:14:in `bootstrap'
	from /home/travis/.rvm/gems/ruby-2.3.1/bundler/gems/webpacker-f14935f7d343/lib/webpacker.rb:18:in `bootstrap'
	from /home/travis/.rvm/gems/ruby-2.3.1/bundler/gems/webpacker-f14935f7d343/lib/webpacker/railtie.rb:32:in `block in <class:Engine>'
	from /home/travis/.rvm/gems/ruby-2.3.1/gems/railties-5.1.2/lib/rails/initializable.rb:30:in `instance_exec'
	from /home/travis/.rvm/gems/ruby-2.3.1/gems/railties-5.1.2/lib/rails/initializable.rb:30:in `run'
	from /home/travis/.rvm/gems/ruby-2.3.1/gems/railties-5.1.2/lib/rails/initializable.rb:59:in `block in run_initializers'
	from /home/travis/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:228:in `block in tsort_each'
	from /home/travis/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /home/travis/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /home/travis/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /home/travis/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:347:in `each'
	from /home/travis/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:347:in `call'
	from /home/travis/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:347:in `each_strongly_connected_component'
	from /home/travis/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:226:in `tsort_each'
	from /home/travis/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:205:in `tsort_each'
	from /home/travis/.rvm/gems/ruby-2.3.1/gems/railties-5.1.2/lib/rails/initializable.rb:58:in `run_initializers'
	from /home/travis/.rvm/gems/ruby-2.3.1/gems/railties-5.1.2/lib/rails/application.rb:353:in `initialize!'
	from /home/travis/build/shakacode/react_on_rails/gen-examples/examples/basic/config/environment.rb:5:in `<top (required)>'
	from /home/travis/.rvm/gems/ruby-2.3.1/gems/railties-5.1.2/lib/rails/application.rb:329:in `require'
	from /home/travis/.rvm/gems/ruby-2.3.1/gems/railties-5.1.2/lib/rails/application.rb:329:in `require_environment!'
	from /home/travis/.rvm/gems/ruby-2.3.1/gems/railties-5.1.2/lib/rails/command/actions.rb:16:in `require_application_and_environment!'
	from /home/travis/.rvm/gems/ruby-2.3.1/gems/railties-5.1.2/lib/rails/commands/generate/generate_command.rb:19:in `perform'
	from /home/travis/.rvm/gems/ruby-2.3.1/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /home/travis/.rvm/gems/ruby-2.3.1/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /home/travis/.rvm/gems/ruby-2.3.1/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /home/travis/.rvm/gems/ruby-2.3.1/gems/railties-5.1.2/lib/rails/command/base.rb:63:in `perform'
	from /home/travis/.rvm/gems/ruby-2.3.1/gems/railties-5.1.2/lib/rails/command.rb:44:in `invoke'
	from /home/travis/.rvm/gems/ruby-2.3.1/gems/railties-5.1.2/lib/rails/commands.rb:16:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'
```