### PR TITLE
Use sha digest to track recompilation

### DIFF
--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -2,7 +2,7 @@ require "webpacker_test_helper"
 
 class CompilerTest < Minitest::Test
   def setup
-    Webpacker.compiler.send(:compilation_timestamp_path).tap do |path|
+    Webpacker.compiler.send(:compilation_digest_path).tap do |path|
       path.delete if path.exist?
     end
   end


### PR DESCRIPTION
This PR fixes a bug when the on demand compiler won't trigger a recompile if an older file (`mtime`) is moved to the source directory. The new implementation uses SHA digest to calculate a digest based on file name and `mtime`, which would allow us to track all types of changes that should trigger a recompilation. 