### PR TITLE
Fix extensionGlob suffix in webpack/shared.js

### DIFF
--- a/lib/install/config/webpack/shared.js
+++ b/lib/install/config/webpack/shared.js
@@ -11,14 +11,14 @@ const ManifestPlugin = require('webpack-manifest-plugin')
 const extname = require('path-complete-extname')
 const { env, settings, output, loadersDir, resolvedModules } = require('./configuration.js')
 
-const numberOfExtensions = settings.extensions && settings.extensions.length
+const extensions = settings.extensions
 
-if (numberOfExtensions === undefined || numberOfExtensions === 0) {
+if (!extensions || extensions.length === 0) {
   throw new Error('You must configure at least one extension to compile in webpacker.yml')
 }
 
 const extensionGlobSuffix =
-  numberOfExtensions === 1 ? settings.extensions[0] : `{${settings.extensions.join(',')}}`
+  extensions.length === 1 ? extensions[0] : `{${extensions.join(',')}}`
 
 const extensionGlob = `**/*${extensionGlobSuffix}`
 const entryPath = join(settings.source_path, settings.source_entry_path)
@@ -56,7 +56,7 @@ module.exports = {
   ],
 
   resolve: {
-    extensions: settings.extensions,
+    extensions,
     modules: resolvedModules
   },
 

--- a/lib/install/config/webpack/shared.js
+++ b/lib/install/config/webpack/shared.js
@@ -11,7 +11,16 @@ const ManifestPlugin = require('webpack-manifest-plugin')
 const extname = require('path-complete-extname')
 const { env, settings, output, loadersDir, resolvedModules } = require('./configuration.js')
 
-const extensionGlob = `**/*{${settings.extensions.join(',')}}`
+const numberOfExtensions = settings.extensions && settings.extensions.length
+
+if (numberOfExtensions === undefined || numberOfExtensions === 0) {
+  throw new Error('You must configure at least one extension to compile in webpacker.yml')
+}
+
+const extensionGlobSuffix =
+  numberOfExtensions === 1 ? settings.extensions[0] : `{${settings.extensions.join(',')}}`
+
+const extensionGlob = `**/*${extensionGlobSuffix}`
 const entryPath = join(settings.source_path, settings.source_entry_path)
 const packPaths = sync(join(entryPath, extensionGlob))
 const isHMR = settings.dev_server && settings.dev_server.hmr


### PR DESCRIPTION
Fixes #689

Prior to this change, the extensionGlob only supported webpacker configurations that had more than one extension. If there was only extension configured, the glob generated wouldn't match anything because it was hardcoded to include a [brace expansion] which requires at least two comma-separated strings. So, to fix it, we do not include a brace expansion if there is only one configured extension.

This change also adds an explicit error message if _no_ extensions are configured.

[brace expansion]: https://www.gnu.org/software/bash/manual/html_node/Brace-Expansion.html