### PR TITLE
Prefix static assets path relative to source

### DIFF
--- a/lib/install/config/loaders/core/assets.js
+++ b/lib/install/config/loaders/core/assets.js
@@ -1,13 +1,15 @@
-const { output } = require('../configuration.js')
+const { join } = require('path')
+const { output, settings } = require('../configuration.js')
 
 module.exports = {
   test: /\.(jpg|jpeg|png|gif|svg|eot|ttf|woff|woff2)$/i,
   use: [{
     loader: 'file-loader',
     options: {
+      context: join(settings.source_path),
       // Set publicPath with ASSET_HOST env if available so internal assets can use CDN
       publicPath: output.publicPathWithHost,
-      name: '[name]-[hash].[ext]'
+      name: '[path][name]-[hash].[ext]'
     }
   }]
 }


### PR DESCRIPTION
Fixes: https://github.com/rails/webpacker/issues/688

This PR adds path prefixing to static assets like images and fonts so they can be name-spaced using directories. 

```yml
app/assets/javascript: 
  - images
   -  clock.png
```
 
```erb
<%= image_tag asset_pack_path('images/clock.png') %>
```

```json
{
  "application.js": "/entries/application-d494bfd162076577d1fe.js",
  "hello_react.css": "/entries/hello_react-bc9ff961ac7edfce12268783e691e1f3.css",
  "hello_react.js": "/entries/hello_react-1e0011403dce34c85c4d.js",
  "hello_vue.css": "/entries/hello_vue-cd9664a0d42f84e0e900b6781667cb1d.css",
  "hello_vue.js": "/entries/hello_vue-2044072103042b8978d5.js",
  "images/clock.png": "/entries/images/clock-fc31531de5cc3518c7c658d5b83faa72.png"
}
```
