### PR TITLE
Allow webpack dev server to serve via hostnames

### DIFF
--- a/lib/install/config/webpack/development.js
+++ b/lib/install/config/webpack/development.js
@@ -23,6 +23,7 @@ module.exports = merge(sharedConfig, {
     compress: true,
     headers: { 'Access-Control-Allow-Origin': '*' },
     historyApiFallback: true,
+    disableHostCheck: true,
     watchOptions: {
       ignored: /node_modules/
     },


### PR DESCRIPTION
AFAICT, `disableHostCheck` is not documented, but it's at least [intentionally there as a public option](https://github.com/webpack/webpack-dev-server/releases/tag/v2.4.3)

Setting this option brings the default settings for webpack-dev-server (WDS) into alignment with `rails server` in development mode. 

Namely, if I've bound to `0.0.0.0`, the webpacker default, I would expect to be able to load assets on a LAN like `http://searls.local:8080/packs/application.js` (or even if I'm connecting over a WAN). Because WDS ships with a default header check (to ensure the header came from the configured `devServer.host`), those sorts of requests would succeed to Rails server and fail to WDS, which is almost certainly not what we want.

Note that if the user has configured the `dev_server.host` to something else (like `localhost`), any attempted connection via a different hostname will fail, prior to this check.