### PR TITLE
Check dev server running first before checking for https?

### DIFF
--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -4,7 +4,7 @@ class Webpacker::DevServerProxy < Rack::Proxy
   def rewrite_response(response)
     status, headers, body = response
     headers.delete "transfer-encoding"
-    headers.delete "content-length" if https?
+    headers.delete "content-length" if Webpacker.dev_server.running? && Webpacker.dev_server.https?
     response
   end
 
@@ -20,9 +20,5 @@ class Webpacker::DevServerProxy < Rack::Proxy
   private
     def public_output_uri_path
       Webpacker.config.public_output_path.relative_path_from(Webpacker.config.public_path)
-    end
-
-    def https?
-      Webpacker.dev_server.running? && Webpacker.dev_server.https?
     end
 end

--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -4,7 +4,7 @@ class Webpacker::DevServerProxy < Rack::Proxy
   def rewrite_response(response)
     status, headers, body = response
     headers.delete "transfer-encoding"
-    headers.delete "content-length" if Webpacker.dev_server.https?
+    headers.delete "content-length" if https?
     response
   end
 
@@ -20,5 +20,9 @@ class Webpacker::DevServerProxy < Rack::Proxy
   private
     def public_output_uri_path
       Webpacker.config.public_output_path.relative_path_from(Webpacker.config.public_path)
+    end
+
+    def https?
+      Webpacker.dev_server.running? && Webpacker.dev_server.https?
     end
 end


### PR DESCRIPTION
Since `dev_server` config is scoped to development we need to check for dev_server running before accessing any config. 