### PR TITLE
Fix: updated Gemfile.lock to match master

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    webpacker (2.0)
+    webpacker (3.0.0)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
@@ -141,4 +141,4 @@ DEPENDENCIES
   webpacker!
 
 BUNDLED WITH
-   1.15.3
+   1.15.4


### PR DESCRIPTION
The current Gemfile.lock file is out-of-sync with the release of the 3.0.0 version of this gem.  This updates the Gemfile.lock to current levels.