### PR TITLE
Bump required yarn version

### DIFF
--- a/lib/tasks/webpacker/check_yarn.rake
+++ b/lib/tasks/webpacker/check_yarn.rake
@@ -1,7 +1,7 @@
 namespace :webpacker do
   desc "Verifies if yarn is installed"
   task :check_yarn do
-    required_yarn_version = "0.20.1"
+    required_yarn_version = "0.25.2"
 
     begin
       yarn_version = `yarn --version`


### PR DESCRIPTION
Yarn < 0.25.2 doesn't correctly install bin files for transitive dependencies so `node_modules/.bin/webpack` will be missing now that it's a dependency of `@rails/webpacker`.

https://github.com/yarnpkg/yarn/pull/3310
https://github.com/yarnpkg/yarn/releases/tag/v0.25.2