### PR TITLE
Fix webpacker:compile exit on failure

### DIFF
--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -16,7 +16,8 @@ class Webpacker::Commands
   end
 
   def compile
-    compiler.compile
-    manifest.refresh
+    compiler.compile.tap do |success|
+      manifest.refresh if success
+    end
   end
 end

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -20,6 +20,8 @@ class Webpacker::Compiler
     if stale?
       record_compilation_digest
       run_webpack
+    else
+      true
     end
   end
 

--- a/test/command_test.rb
+++ b/test/command_test.rb
@@ -1,0 +1,27 @@
+require "webpacker_test_helper"
+
+class CommandTest < Minitest::Test
+  def test_compile_command_returns_success_status_when_stale
+    Webpacker.compiler.stub :stale?, true do
+      Webpacker.compiler.stub :run_webpack, true do
+        assert_equal true, Webpacker.commands.compile
+      end
+    end
+  end
+
+  def test_compile_command_returns_success_status_when_fresh
+    Webpacker.compiler.stub :stale?, false do
+      Webpacker.compiler.stub :run_webpack, true do
+        assert_equal true, Webpacker.commands.compile
+      end
+    end
+  end
+
+  def test_compile_command_returns_failure_status_when_stale
+    Webpacker.compiler.stub :stale?, true do
+      Webpacker.compiler.stub :run_webpack, false do
+        assert_equal false, Webpacker.commands.compile
+      end
+    end
+  end
+end


### PR DESCRIPTION
`Webpacker.compile` would always return `manifest.refresh` even if `compiler.compile` failed. This means deploys would succeed even if compiling failed.