### PR TITLE
allow devtool settings to override defaults

### DIFF
--- a/package/environment.js
+++ b/package/environment.js
@@ -66,7 +66,7 @@ module.exports = class Environment {
   }
 
   toWebpackConfig() {
-    return {
+    const result = {
       entry: getEntryObject(),
 
       output: {
@@ -91,5 +91,11 @@ module.exports = class Environment {
         modules: ['node_modules']
       }
     }
+
+    if (this.devtool) {
+      result.devtool = this.devtool
+    }
+
+    return result
   }
 }

--- a/package/environments/development.js
+++ b/package/environments/development.js
@@ -19,7 +19,7 @@ module.exports = class extends Environment {
       result.output.filename = '[name]-[hash].js'
     }
     result.output.pathinfo = true
-    result.devtool = 'cheap-eval-source-map'
+    result.devtool = result.devtool || 'cheap-eval-source-map'
     result.devServer = {
       host: dev_server.host,
       port: dev_server.port,

--- a/package/environments/production.js
+++ b/package/environments/production.js
@@ -27,7 +27,7 @@ module.exports = class extends Environment {
 
   toWebpackConfig() {
     const result = super.toWebpackConfig()
-    result.devtool = 'source-map'
+    result.devtool = result.devtool || 'source-map'
     result.stats = 'normal'
     return result
   }


### PR DESCRIPTION
Prior to config files being pulled into the package with the v3 update, I was able to override the `devtool` setting in my `config/webpack/environment.js` file to fix source maps not working in development. (Similar to issues #505 and #390) However, now it seems any `devtool` I set is being ignored. The environments are hard coded to the defaults now. https://github.com/rails/webpacker/blob/master/package/environments/development.js#L22

Thanks!