### PR TITLE
Update forwarded header to match dev server host and port

### DIFF
--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -10,12 +10,7 @@ class Webpacker::DevServerProxy < Rack::Proxy
 
   def perform_request(env)
     if env["PATH_INFO"] =~ /#{public_output_uri_path}/ && Webpacker.dev_server.running?
-      env["HTTP_HOST"] = Webpacker.dev_server.host_with_port
-
-      if env["HTTP_X_FORWARDED_HOST"]
-        env["HTTP_X_FORWARDED_HOST"] = Webpacker.dev_server.host_with_port
-        env["HTTP_X_FORWARDED_SERVER"] = Webpacker.dev_server.host_with_port
-      end
+      env["HTTP_HOST"] = env["HTTP_X_FORWARDED_HOST"] = env["HTTP_X_FORWARDED_SERVER"] = Webpacker.dev_server.host_with_port
 
       super(env)
     else

--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -11,6 +11,12 @@ class Webpacker::DevServerProxy < Rack::Proxy
   def perform_request(env)
     if env["PATH_INFO"] =~ /#{public_output_uri_path}/ && Webpacker.dev_server.running?
       env["HTTP_HOST"] = Webpacker.dev_server.host_with_port
+
+      if env["HTTP_X_FORWARDED_HOST"]
+        env["HTTP_X_FORWARDED_HOST"] = Webpacker.dev_server.host_with_port
+        env["HTTP_X_FORWARDED_SERVER"] = Webpacker.dev_server.host_with_port
+      end
+
       super(env)
     else
       @app.call(env)


### PR DESCRIPTION
This PR fixes when dev server is used under another proxy (example: pow or nginx), which uses `HTTP_X_FORWARDED_HOST` resulting in `404`

Fixes #723 