### PR TITLE
Make dev server listen host to be configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+- Allow webpack dev server listen host/ip to be configurable using `--listen-host` option
+
+```bash
+./bin/webpack-dev-server --listen-host 0.0.0.0 --host localhost
+```
+
 ## [3.0.0] - 2017-08-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -162,6 +162,15 @@ precedence over the ones already set in the configuration file.
 ./bin/webpack-dev-server --host example.com --inline true --hot false
 ```
 
+By default, webpack dev server listens on `localhost` in development for security
+but if you want your app to be available over local LAN IP or VM instance like vagrant
+you can pass an additional config option `--listen-host`
+when running `./bin/webpack-dev-server` binstub:
+
+```bash
+./bin/webpack-dev-server --listen-host 0.0.0.0
+```
+
 **Note:** Don't forget to prefix `ruby` when running these binstubs on windows
 
 ## Integrations

--- a/lib/install/bin/webpack-dev-server.tt
+++ b/lib/install/bin/webpack-dev-server.tt
@@ -16,7 +16,7 @@ CONFIG_FILE       = File.join(APP_PATH, "config/webpacker.yml")
 NODE_MODULES_PATH = File.join(APP_PATH, "node_modules")
 WEBPACK_CONFIG    = File.join(APP_PATH, "config/webpack/#{NODE_ENV}.js")
 
-LISTEN_HOST_ADDR = NODE_ENV == 'development' ? 'localhost' : '0.0.0.0'
+DEFAULT_LISTEN_HOST_ADDR = NODE_ENV == 'development' ? 'localhost' : '0.0.0.0'
 
 def args(key)
   index = ARGV.index(key)
@@ -26,10 +26,11 @@ end
 begin
   dev_server = YAML.load_file(CONFIG_FILE)[RAILS_ENV]["dev_server"]
 
-  HOSTNAME        = args('--host') || dev_server["host"]
-  PORT            = args('--port') || dev_server["port"]
-  HTTPS           = ARGV.include?('--https') || dev_server["https"]
-  DEV_SERVER_ADDR = "http#{"s" if HTTPS}://#{HOSTNAME}:#{PORT}"
+  HOSTNAME          = args('--host') || dev_server["host"]
+  PORT              = args('--port') || dev_server["port"]
+  HTTPS             = ARGV.include?('--https') || dev_server["https"]
+  DEV_SERVER_ADDR   = "http#{"s" if HTTPS}://#{HOSTNAME}:#{PORT}"
+  LISTEN_HOST_ADDR  = args('--listen-host') || DEFAULT_LISTEN_HOST_ADDR
 
 rescue Errno::ENOENT, NoMethodError
   $stdout.puts "Webpack dev_server configuration not found in #{CONFIG_FILE}."
@@ -46,8 +47,8 @@ rescue Errno::EADDRINUSE
   exit!
 end
 
-# Delete supplied host and port CLI arguments
-["--host", "--port"].each do |arg|
+# Delete supplied host, port and listen-host CLI arguments
+["--host", "--port", "--listen-host"].each do |arg|
   ARGV.delete(args(arg))
   ARGV.delete(arg)
 end


### PR DESCRIPTION
This PR makes dev server listen host configurable:  

Fixes: https://github.com/rails/webpacker/issues/709
Ref: https://github.com/rails/webpacker/issues/572 

Not sure if this approach is better or using an env variable? 