### PR TITLE
Change coffee-script npm dep to coffeescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "coffee-loader": "^0.8.0",
-    "coffee-script": "^1.12.7",
+    "coffeescript": "^1.12.7",
     "compression-webpack-plugin": "^1.0.0",
     "css-loader": "^0.28.5",
     "extract-text-webpack-plugin": "^3.0.0",


### PR DESCRIPTION
coffee-loader depends on coffeescript so this stops yarn from complaining. The coffeescript & coffee-script packages are the same, and without this change yarn complains like so on every run `warning "coffee-loader@0.8.0" has unmet peer dependency "coffeescript@>= 1.8.x".`