### PR TITLE
Yarn engine requirement

### DIFF
--- a/lib/tasks/webpacker/check_node.rake
+++ b/lib/tasks/webpacker/check_node.rake
@@ -4,12 +4,16 @@ namespace :webpacker do
     begin
       node_version = `node -v`
       node_version = `nodejs -v` if node_version.blank?
-      required_node_version = "6.0"
-
       raise Errno::ENOENT if node_version.blank?
 
-      if Gem::Version.new(node_version.strip.tr("v", "")) < Gem::Version.new(required_node_version)
-        $stderr.puts "Webpacker requires Node.js >= v#{required_node_version} and you are using #{node_version}"
+      pkg_path = Pathname.new("#{__dir__}/../../../package.json").realpath
+      node_requirement = JSON.parse(pkg_path.read)["engines"]["node"]
+
+      requirement = Gem::Requirement.new(node_requirement)
+      version = Gem::Version.new(node_version.strip.tr("v", ""))
+
+      unless requirement.satisfied_by?(version)
+        $stderr.puts "Webpacker requires Node.js #{requirement} and you are using #{version}"
         $stderr.puts "Please upgrade Node.js https://nodejs.org/en/download/"
         $stderr.puts "Exiting!" && exit!
       end

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "package"
   ],
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">=6.0.0",
+    "yarn": ">=0.25.2"
   },
   "dependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
Adds yarn requirement to `package.json`s engines:
https://github.com/rails/webpacker/blob/09247aaf8efc093d5527a58da0ab22a90a5a9c7e/package.json#L9-L11

Updates `webpacker:check_yarn` and `webpacker:check_node` to read requirements from `package.json` so they're not duplicated (and easily forgotten):
https://github.com/rails/webpacker/blob/09247aaf8efc093d5527a58da0ab22a90a5a9c7e/lib/tasks/webpacker/check_yarn.rake#L8-L14