### PR TITLE
docs(typescript) Ignore vendor folder

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -28,6 +28,7 @@ yarn add ts-loader typescript @types/react @types/react-dom
   "exclude": [
     "**/*.spec.ts",
     "node_modules",
+    "vendor"
     "public"
   ],
   "compileOnSave": false


### PR DESCRIPTION
Without this change, typescript will try to compile the hello_angular example.
If you are using typescript without angular, your package.json will (and should) not include all the @angular deps and the compilation will fail.