### PR TITLE
Fix typo in misc.md [ci skip]

### DIFF
--- a/docs/misc.md
+++ b/docs/misc.md
@@ -14,7 +14,7 @@ and add `ignore-loader` to `config/webpack/environment.js`
 ```js
 // ignores vue~ swap files
 const { environment } = require('@rails/webpacker')
-environment.loaders.add('ignore', {
+environment.loaders.set('ignore', {
   test:  /.vue~$/,
   loader: 'ignore-loader'
 })


### PR DESCRIPTION
I think `add` does not work.

> TypeError: environment.loaders.add is not a function
    at Object.<anonymous> (/xxx/config/webpack/environment.js:3:21)
    at Module._compile (module.js:573:30)
    at Object.Module._extensions..js (module.js:584:10)
    at Module.load (module.js:507:32)
    at tryModuleLoad (module.js:470:12)
    at Function.Module._load (module.js:462:3)
    at Module.require (module.js:517:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/xxx/config/webpack/development.js:1:83)
    at Module._compile (module.js:573:30)
