### PR TITLE
Catch socket timeout and make it configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+- Allow dev server connect timeout(in seconds) to be configurable, default: 0.01
+
+```rb
+# Change to 1s
+Webpacker::DevServer.connect_timeout = 1
+```
+
 ## [3.0.1] - 2017-09-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## Unreleased
 
-- Allow dev server connect timeout(in seconds) to be configurable, default: 0.01
+- Allow dev server connect timeout (in seconds) to be configurable, default: 0.01
 
 ```rb
 # Change to 1s
-Webpacker::DevServer.connect_timeout = 1
+Webpacker.dev_server.connect_timeout = 1
 ```
 
 ## [3.0.1] - 2017-09-01

--- a/lib/webpacker/dev_server.rb
+++ b/lib/webpacker/dev_server.rb
@@ -6,10 +6,14 @@ class Webpacker::DevServer
   end
 
   def running?
-    Socket.tcp(host, port, connect_timeout: 1).close
-    true
-  rescue Errno::ECONNREFUSED, NoMethodError
-    false
+    return @running if defined?(@running)
+
+    @running = begin
+        Socket.tcp(host, port, connect_timeout: 0.1).close
+        true
+      rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, NoMethodError
+        false
+      end
   end
 
   def hot_module_replacing?

--- a/lib/webpacker/dev_server.rb
+++ b/lib/webpacker/dev_server.rb
@@ -1,4 +1,8 @@
 class Webpacker::DevServer
+  # Configure dev server connection timeout(in seconds), default: 0.01
+  # Webpacker::DevServer.connect_timeout = 1
+  mattr_accessor(:connect_timeout) { 0.01 }
+
   delegate :config, to: :@webpacker
 
   def initialize(webpacker)
@@ -6,14 +10,10 @@ class Webpacker::DevServer
   end
 
   def running?
-    return @running if defined?(@running)
-
-    @running = begin
-        Socket.tcp(host, port, connect_timeout: 0.1).close
-        true
-      rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, NoMethodError
-        false
-      end
+    Socket.tcp(host, port, connect_timeout: connect_timeout).close
+    true
+  rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, NoMethodError
+    false
   end
 
   def hot_module_replacing?

--- a/lib/webpacker/dev_server.rb
+++ b/lib/webpacker/dev_server.rb
@@ -1,6 +1,6 @@
 class Webpacker::DevServer
-  # Configure dev server connection timeout(in seconds), default: 0.01
-  # Webpacker::DevServer.connect_timeout = 1
+  # Configure dev server connection timeout (in seconds), default: 0.01
+  # Webpacker.dev_server.connect_timeout = 1
   mattr_accessor(:connect_timeout) { 0.01 }
 
   delegate :config, to: :@webpacker


### PR DESCRIPTION
Fixes: https://github.com/rails/webpacker/issues/745

The only side effect of Memoization here is the compiler can't be switched at runtime i.e. starting webpack-dev-server in the middle whilst it's using on-demand compiler, rails server need to be restarted. 

```rb
# with memoization
0.000000   0.010000   0.010000 (  0.002971)
0.000000   0.000000   0.000000 (  0.003402)

0.000000   0.000000   0.000000 (  0.001943)
0.000000   0.000000   0.000000 (  0.001906)

0.000000   0.000000   0.000000 (  0.004089)
0.000000   0.010000   0.010000 (  0.005296)

0.010000   0.000000   0.010000 (  0.002744)
0.000000   0.000000   0.000000 (  0.002775)

# without memoization
0.010000   0.000000   0.010000 (  0.009734)
0.010000   0.000000   0.010000 (  0.005229)

0.000000   0.000000   0.000000 (  0.005725)
0.000000   0.000000   0.000000 (  0.004190)

0.000000   0.000000   0.000000 (  0.008097)
0.000000   0.000000   0.000000 (  0.004188)

0.000000   0.010000   0.010000 (  0.004776)
0.010000   0.000000   0.010000 (  0.004454)
```