### PR TITLE
Restricts the source maps generated for production

### DIFF
--- a/package/environments/production.js
+++ b/package/environments/production.js
@@ -27,7 +27,7 @@ module.exports = class extends Environment {
 
   toWebpackConfig() {
     const result = super.toWebpackConfig()
-    result.devtool = 'source-map'
+    result.devtool = 'nosources-source-map'
     result.stats = 'normal'
     return result
   }


### PR DESCRIPTION
This will generate source maps only to the extent required for stack
trace reporting tools like Sentry and Rollbar. It should result in build
time savings and prevent people's unobfuscated source code from
"leaking" with every production build. 

Fixes #769