### PR TITLE
Rename public_manifest_path and fetch manifest_filename from config

### DIFF
--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -5,6 +5,7 @@ default: &default
   source_entry_path: packs
   public_output_path: packs
   cache_path: tmp/cache/webpacker
+  manifest_filename: manifest.json
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -37,7 +37,7 @@ class Webpacker::Compiler
 
   private
     def last_compilation_digest
-      compilation_digest_path.read if compilation_digest_path.exist? && config.public_manifest_path.exist?
+      compilation_digest_path.read if compilation_digest_path.exist? && config.public_manifest_file.exist?
     end
 
     def watched_files_digest

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -33,8 +33,8 @@ class Webpacker::Configuration
     public_path.join(fetch(:public_output_path))
   end
 
-  def public_manifest_path
-    public_output_path.join("manifest.json")
+  def public_manifest_file
+    public_output_path.join(fetch(:manifest_filename))
   end
 
   def cache_manifest?

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -46,7 +46,7 @@ class Webpacker::Manifest
 
     def missing_file_from_manifest_error(bundle_name)
       msg = <<-MSG
-Webpacker can't find #{bundle_name} in #{config.public_manifest_path}. Possible causes:
+Webpacker can't find #{bundle_name} in #{config.public_manifest_file}. Possible causes:
 1. You want to set webpacker.yml value of compile to true for your environment
    unless you are using the `webpack -w` or the webpack-dev-server.
 2. Webpack has not yet re-run to reflect updates.
@@ -66,8 +66,8 @@ Your manifest contains:
     end
 
     def load
-      if config.public_manifest_path.exist?
-        JSON.parse config.public_manifest_path.read
+      if config.public_manifest_file.exist?
+        JSON.parse config.public_manifest_file.read
       else
         {}
       end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -16,9 +16,9 @@ class ConfigurationTest < Webpacker::Test
     assert_equal Webpacker.config.public_output_path.to_s, public_output_path
   end
 
-  def test_public_manifest_path
-    public_manifest_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/public/packs", "manifest.json").to_s
-    assert_equal Webpacker.config.public_manifest_path.to_s, public_manifest_path
+  def test_public_manifest_file
+    public_manifest_file = File.expand_path File.join(File.dirname(__FILE__), "test_app/public/packs", "manifest.json").to_s
+    assert_equal Webpacker.config.public_manifest_file.to_s, public_manifest_file
   end
 
   def test_cache_path


### PR DESCRIPTION
I have a project where we are implementing webpacker and the devops person asked if we could rename the manifest file to something other than just `manifest.json`. I thought we would be able to but then after messing around with it for a bit realized it wasn't possible since `manifest.json` was hard-coded.

This PR fixes that by allowing a `manifest_filename` option to be set in the `webpacker.yml` config file.

Also while I was in there I renamed the `public_manifest_path` method to `public_manifest_file` since it is actually returning the path to a file, not just a path.