### PR TITLE
add sass to vue loader option

### DIFF
--- a/package/loaders/vue.js
+++ b/package/loaders/vue.js
@@ -7,6 +7,10 @@ module.exports = {
   test: /\.vue(\.erb)?$/,
   loader: 'vue-loader',
   options: {
-    extractCSS: isProduction || extractCSS
+    extractCSS: isProduction || extractCSS,
+    loaders: {
+      scss: 'vue-style-loader!css-loader!sass-loader'
+      sass: 'vue-style-loader!css-loader!sass-loader?indentedSyntax'
+    }
   }
 }


### PR DESCRIPTION
Hi!

There is `@rails / webpacker` in the default setting of package.json.
There is sass-loader in this package.json.

I misunderstood that sass can be used even in .vue file by default.
I thought it was better to keep it in use by default, but how about it?