### PR TITLE
Change inquiry method to explicit call to StringInquirer

### DIFF
--- a/lib/webpacker/instance.rb
+++ b/lib/webpacker/instance.rb
@@ -8,9 +8,10 @@ class Webpacker::Instance
   end
 
   def env
-    (ENV["NODE_ENV"].presence_in(available_environments) ||
-      Rails.env.presence_in(available_environments) ||
-        "production".freeze).inquiry
+    ActiveSupport::StringInquirer.new(
+      ENV["NODE_ENV"].presence_in(available_environments) ||
+        Rails.env.presence_in(available_environments) ||
+          "production".freeze)
   end
 
   def config


### PR DESCRIPTION
webpacker can be used in a less than full installation of rails which does not
have the <string>.inquiry helper.