### PR TITLE
Fix webpacker:check_node to display version error

### DIFF
--- a/lib/tasks/webpacker/check_node.rake
+++ b/lib/tasks/webpacker/check_node.rake
@@ -2,9 +2,12 @@ namespace :webpacker do
   desc "Verifies if Node.js is installed"
   task :check_node do
     begin
-      node_version = `node -v`
-      node_version = `nodejs -v` if node_version.blank?
-      raise Errno::ENOENT if node_version.blank?
+      begin
+        node_version = `node -v`
+      rescue Errno::EONENT
+        node_version = `nodejs -v`
+        raise Errno::ENOENT if node_version.blank?
+      end
 
       pkg_path = Pathname.new("#{__dir__}/../../../package.json").realpath
       node_requirement = JSON.parse(pkg_path.read)["engines"]["node"]


### PR DESCRIPTION
Currently, if you have an older version of node installed that is referenced by `nodejs` instead of `node`, this code receives an Errno::ENOENT exception from the `node -v` command, bypassing the `node_version.blank?` check and telling the user Node is not installed. Instead, we should catch that exception and check for `nodejs -v` and let them know they need to upgrade versions.