### PR TITLE
Better messaging for missing config files

### DIFF
--- a/lib/install/bin/webpack.tt
+++ b/lib/install/bin/webpack.tt
@@ -13,9 +13,10 @@ APP_PATH          = File.expand_path("../", __dir__)
 NODE_MODULES_PATH = File.join(APP_PATH, "node_modules")
 WEBPACK_CONFIG    = File.join(APP_PATH, "config/webpack/#{NODE_ENV}.js")
 
+puts "Loading config: #{WEBPACK_CONFIG}"
 unless File.exist?(WEBPACK_CONFIG)
   puts "Webpack configuration not found."
-  puts "Please run bundle exec rails webpacker:install to install webpacker"
+  puts "Please add the missing config file or run 'bundle exec rails webpacker:install' to install webpacker with default config files."
   exit!
 end
 

--- a/lib/install/bin/webpack.tt
+++ b/lib/install/bin/webpack.tt
@@ -13,10 +13,8 @@ APP_PATH          = File.expand_path("../", __dir__)
 NODE_MODULES_PATH = File.join(APP_PATH, "node_modules")
 WEBPACK_CONFIG    = File.join(APP_PATH, "config/webpack/#{NODE_ENV}.js")
 
-puts "Loading config: #{WEBPACK_CONFIG}"
 unless File.exist?(WEBPACK_CONFIG)
-  puts "Webpack configuration not found."
-  puts "Please add the missing config file or run 'bundle exec rails webpacker:install' to install webpacker with default config files."
+  puts "Webpack config #{WEBPACK_CONFIG} not found, please run 'bundle exec rails webpacker:install' to install webpacker with default configs or add the missing config file for your custom environment."
   exit!
 end
 


### PR DESCRIPTION
# Purpose
When webpacker compiles files it looks for a matching config file for each 'top_level' environment defined in webpacker.yml.  By default, there are a number of examples of this but there is no 'staging' environment example.  I needed this so I added staging to webpacker.yml and then bin/webpack would no longer compile because it was looking for `config/webpacker/staging.js `.  The current error message is generic and did not help me debug the error.  It took a bit to figure out what was going on and so this PR adds better messaging around that process.  Simple, but will hopefully save others some time going forward.