### PR TITLE
Support dev server `public` option

### DIFF
--- a/lib/install/bin/webpack-dev-server.tt
+++ b/lib/install/bin/webpack-dev-server.tt
@@ -28,7 +28,7 @@ begin
 
   HOSTNAME          = args('--host') || dev_server["host"]
   PORT              = args('--port') || dev_server["port"]
-  PUBLIC_HOSTNAME   = args('--public') || "#{HOSTNAME}:#{PORT}"
+  PUBLIC_HOSTNAME   = args('--public') || dev_server["public"] || "#{HOSTNAME}:#{PORT}"
   HTTPS             = ARGV.include?('--https') || dev_server["https"]
   DEV_SERVER_ADDR   = "http#{"s" if HTTPS}://#{HOSTNAME}:#{PORT}"
   LISTEN_HOST_ADDR  = args('--listen-host') || DEFAULT_LISTEN_HOST_ADDR

--- a/lib/install/bin/webpack-dev-server.tt
+++ b/lib/install/bin/webpack-dev-server.tt
@@ -28,6 +28,7 @@ begin
 
   HOSTNAME          = args('--host') || dev_server["host"]
   PORT              = args('--port') || dev_server["port"]
+  PUBLIC_HOSTNAME   = args('--public') || "#{HOSTNAME}:#{PORT}"
   HTTPS             = ARGV.include?('--https') || dev_server["https"]
   DEV_SERVER_ADDR   = "http#{"s" if HTTPS}://#{HOSTNAME}:#{PORT}"
   LISTEN_HOST_ADDR  = args('--listen-host') || DEFAULT_LISTEN_HOST_ADDR
@@ -48,7 +49,7 @@ rescue Errno::EADDRINUSE
 end
 
 # Delete supplied host, port and listen-host CLI arguments
-["--host", "--port", "--listen-host"].each do |arg|
+["--host", "--port", "--public", "--listen-host"].each do |arg|
   ARGV.delete(args(arg))
   ARGV.delete(arg)
 end
@@ -59,7 +60,7 @@ cmd = [
   "#{NODE_MODULES_PATH}/.bin/webpack-dev-server", "--progress", "--color",
   "--config", WEBPACK_CONFIG,
   "--host", LISTEN_HOST_ADDR,
-  "--public", "#{HOSTNAME}:#{PORT}",
+  "--public", PUBLIC_HOSTNAME,
   "--port", PORT.to_s
 ] + ARGV
 

--- a/package/environments/development.js
+++ b/package/environments/development.js
@@ -27,6 +27,7 @@ module.exports = class extends Environment {
       hot: dev_server.hmr,
       contentBase: assetHost.path,
       publicPath: assetHost.publicPath,
+      public: dev_server.public,
       clientLogLevel: 'none',
       compress: true,
       historyApiFallback: true,


### PR DESCRIPTION
This PR allows makes the [webpack-dev-server public option](https://webpack.js.org/configuration/dev-server/#devserver-public) configurable through `webpacker.yml`.

We currently use dnsmasq + nginx to reverse proxy requests from a custom local domain, i.e., `myapp.dev`, to our local Rails server for development. The recent addition of the `DevServerProxy` makes it easier for us to configure our setup for serving "packs" (thanks!). However, we'd still like the ability to proxy the dev server auto-refresh websocket connection, i.e., the `/sockjs-node` endpoint, through nginx as well.

To accomplish this (unless I'm missing an alternative), we would set the dev server `public` option to our local domain `myapp.dev`; however, the `public` is currently assumed to be `"#{HOSTNAME}:#{PORT}"` in the `bin/webpack-dev-server` wrapper. These changes ensure that a `public` option given in `webpacker.yml` or on the command line are passed through to the `webpack-dev-server` executable. 

I could add a section in `docs/webpack-dev-server.md` if that would be helpful for documentation.
