### PR TITLE
Fix elm-package.json source-directories

### DIFF
--- a/lib/install/elm.rb
+++ b/lib/install/elm.rb
@@ -1,13 +1,14 @@
 require "webpacker/configuration"
 
-puts "Copying elm example entry file to #{Webpacker.config.source_entry_path}"
-copy_file "#{__dir__}/examples/elm/Main.elm", "#{Webpacker.config.source_entry_path}/Main.elm"
-
-puts "Copying elm app file to #{Webpacker.config.source_entry_path}"
+puts "Copying Elm example entry file to #{Webpacker.config.source_entry_path}"
 copy_file "#{__dir__}/examples/elm/hello_elm.js",
-          "#{Webpacker.config.source_entry_path}/hello_elm.js"
+  "#{Webpacker.config.source_entry_path}/hello_elm.js"
 
-puts "Installing all elm dependencies"
+puts "Copying Elm app file to #{Webpacker.config.source_path}"
+copy_file "#{__dir__}/examples/elm/Main.elm",
+  "#{Webpacker.config.source_path}/Main.elm"
+
+puts "Installing all Elm dependencies"
 run "yarn add elm elm-webpack-loader"
 run "yarn add --dev elm-hot-loader"
 run "yarn run elm package install -- --yes"
@@ -15,10 +16,11 @@ run "yarn run elm package install -- --yes"
 puts "Updating Webpack paths to include Elm file extension"
 insert_into_file Webpacker.config.config_path, "    - .elm\n", after: /extensions:\n/
 
-puts "Updating elm source location"
-gsub_file "elm-package.json", /\"\.\"\n/, %("#{Webpacker.config.source_entry_path}"\n)
+puts "Updating Elm source location"
+gsub_file "elm-package.json", /\"\.\"\n/,
+  %("#{Webpacker.config.source_path.relative_path_from(Rails.root)}"\n)
 
 puts "Updating .gitignore to include elm-stuff folder"
 insert_into_file ".gitignore", "/elm-stuff\n", before: "/node_modules\n"
 
-puts "Webpacker now supports elm 🎉"
+puts "Webpacker now supports Elm 🎉"

--- a/lib/install/examples/elm/hello_elm.js
+++ b/lib/install/examples/elm/hello_elm.js
@@ -1,7 +1,8 @@
-// Run this example by adding <%= javascript_pack_tag "hello_elm" %> to the head of your layout
-// file, like app/views/layouts/application.html.erb. It will render "Hello Elm!" within the page.
+// Run this example by adding <%= javascript_pack_tag "hello_elm" %> to the
+// head of your layout file, like app/views/layouts/application.html.erb.
+// It will render "Hello Elm!" within the page.
 
-import Elm from './Main'
+import Elm from '../Main'
 
 document.addEventListener('DOMContentLoaded', () => {
   const target = document.createElement('div')


### PR DESCRIPTION
### Changes

- [x] makes the `source-directories` path relative, so it works in both development
and production (before: `"/Users/Admin/Playground/test_app/app/javascript/packs"`, after: `"app/javascript"`)
- [x] renamed elm to Elm where applicable
- [x] fixed installation messages incorrectly referring to entry file as Elm app file and
vice versa
- [x] moved `Main.elm` outside the packs folder. [Docs](https://github.com/rails/webpacker/blob/master/docs/folder-structure.md) state that packs file is only for entry files, so I believe having `Main.elm` within `packs` is incorrect and results in generating a pack we don't want.

Moving app files away form the `packs` folder also concerns Vue. Let me know if you agree with this change and I will update it as well (Angular already follows this, React example only has one file).

Resolves https://github.com/rails/webpacker/issues/805