### PR TITLE
Include resolved paths in watched paths

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -64,8 +64,12 @@ class Webpacker::Compiler
       status.success?
     end
 
+    def resolved_paths_globbed
+      config.resolved_paths.map(&:to_s).map { |p| "#{p}/**/*" }
+    end
+
     def default_watched_paths
-      ["#{config.resolved_paths}/**/*", "#{config.source_path}/**/*", "yarn.lock", "package.json", "config/webpack/**/*"].freeze
+      [*resolved_paths_globbed, "#{config.source_path}/**/*", "yarn.lock", "package.json", "config/webpack/**/*"].freeze
     end
 
     def compilation_digest_path

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -65,7 +65,7 @@ class Webpacker::Compiler
     end
 
     def default_watched_paths
-      ["#{config.source_path}/**/*", "yarn.lock", "package.json", "config/webpack/**/*"].freeze
+      ["#{config.resolved_paths}/**/*", "#{config.source_path}/**/*", "yarn.lock", "package.json", "config/webpack/**/*"].freeze
     end
 
     def compilation_digest_path

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -22,7 +22,7 @@ class Webpacker::Configuration
   end
 
   def resolved_paths
-    fetch(:resolved_paths)
+    fetch(:resolved_paths).map { |p| root_path.join(p) }
   end
 
   def source_entry_path

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -22,7 +22,7 @@ class Webpacker::Configuration
   end
 
   def resolved_paths
-    root_path.join(fetch(:source_path))
+    fetch(:resolved_paths)
   end
 
   def source_entry_path

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -21,6 +21,10 @@ class Webpacker::Configuration
     root_path.join(fetch(:source_path))
   end
 
+  def resolved_paths
+    root_path.join(fetch(:source_path))
+  end
+
   def source_entry_path
     source_path.join(fetch(:source_entry_path))
   end


### PR DESCRIPTION
For people who are using resolved paths configurations, it might make sense to include these in the `default_watched_paths`. It won't affect anyone who left the resolved paths `[]` and it'll make test env re-compilation work for those who added resolved paths.

For folks who still have assets under `app/assets/javascripts/`, this will result in less hair pulling and fewer surprises. However, totally understand if you think this is better handled by an override like:
```ruby
Webpacker::Compiler.watched_paths << 'app/assets/javascripts/**/*'
```

Thanks!