### PR TITLE
Upgrade webpack manifest plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sass-loader": "^6.0.6",
     "style-loader": "^0.18.2",
     "webpack": "^3.5.5",
-    "webpack-manifest-plugin": "^1.3.1"
+    "webpack-manifest-plugin": "^1.3.2"
   },
   "devDependencies": {
     "eslint": "^3.16.1",

--- a/package/environment.js
+++ b/package/environment.js
@@ -26,7 +26,7 @@ function getPluginMap() {
   const result = new Map()
   result.set('Environment', new webpack.EnvironmentPlugin(JSON.parse(JSON.stringify(process.env))))
   result.set('ExtractText', new ExtractTextPlugin('[name]-[contenthash].css'))
-  result.set('Manifest', new ManifestPlugin({ publicPath: assetHost.publicPath, writeToFileEmit: true }))
+  result.set('Manifest', new ManifestPlugin({ writeToFileEmit: true }))
   return result
 }
 


### PR DESCRIPTION
The latest version of `webpack-manifest-plugin` (version `^1.3.2`) deprecates its `publicPath` option in favor of the webpack `output.publicPath`. This means the webpacker environment no longer needs to set `assetHost.publicPath` in multiple places. See https://github.com/danethurber/webpack-manifest-plugin/pull/80 for more info.