### PR TITLE
Added #include? to the manifest to check for packs.

### DIFF
--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -19,11 +19,21 @@ class Webpacker::Manifest
   end
 
   def lookup(name)
-    compile if compiling?
+    initialize!
     find name
   end
 
+  def include?(name)
+    initialize!
+    resolve(name).present?
+  end
+
   private
+
+    def initialize!
+      compile if compiling?
+    end
+
     def compiling?
       config.compile? && !dev_server.running?
     end
@@ -33,7 +43,11 @@ class Webpacker::Manifest
     end
 
     def find(name)
-      data[name.to_s] || handle_missing_entry(name)
+      resolve(name) || handle_missing_entry(name)
+    end
+
+    def resolve(name)
+      data[name.to_s] || nil
     end
 
     def handle_missing_entry(name)

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -17,4 +17,12 @@ class ManifestTest < Minitest::Test
   def test_lookup_success
     assert_equal Webpacker.manifest.lookup("bootstrap.js"), "/packs/bootstrap-300631c4f0e0f9c865bc.js"
   end
+
+  def test_include_success
+    assert_equal true, Webpacker.manifest.include?("bootstrap.js")
+  end
+
+  def test_include_failure
+    assert_equal false, Webpacker.manifest.include?("non-existent.js")
+  end
 end


### PR DESCRIPTION
Sprockets supported finding if an asset exists, without raising an exception. This was a bit hack-ish, requiring a train wreck: Rails.application.assets.find_asset(name).present?, but it was possible. I used this to allow controller-specific Javascript / CSS to be included as-needed, rather than always being a part of the main application-level asset.

With Webpacker this feels even more hack-ish, using Webpacker.manifest.refresh[name.to_s].present?. This feels like way too much knowledge about the inner workings of Manifest.

I'd like to add a method to check if the manifest includes an entry. My first stab was to add a #include?(name) method to the public interface. This change can be found here on my fork.