### PR TITLE
Correcting typo in webpacker:check_node

### DIFF
--- a/lib/tasks/webpacker/check_node.rake
+++ b/lib/tasks/webpacker/check_node.rake
@@ -4,7 +4,7 @@ namespace :webpacker do
     begin
       begin
         node_version = `node -v`
-      rescue Errno::EONENT
+      rescue Errno::ENOENT
         node_version = `nodejs -v`
         raise Errno::ENOENT if node_version.blank?
       end


### PR DESCRIPTION
Currently, if the node command line is `nodejs` and not `node` this rake task will never recognise that node is installed. Due to a typo on an exception name. This fixes that typo.