### PR TITLE
add cache-loader to rules

### DIFF
--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -115,6 +115,18 @@ For this to work, don't forget to use the `stylesheet_pack_tag`, for example:
 <%= stylesheet_pack_tag 'YOUR_PACK_NAME_HERE' %>
 ```
 
+### Add cache-loader
+[cache-loader](https://github.com/webpack-contrib/cache-loader) caches results of loaders on disk.
+Adding cache-loader to expensive loaders may increase your bundle compilation speed.
+
+```js
+// config/webpack/development.js
+environment.addCacheLoader() // enables on all loaders by default
+environment.addCacheLoader(['style', 'babel']) // enables on babel and style loader
+environment.addCacheLoader('style') // enables only on style
+```
+
+
 ## Plugins
 
 The process for adding or modifying webpack plugins is the same as the process

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.0",
+    "cache-loader": "^1.0.3",
     "coffee-loader": "^0.8.0",
     "coffeescript": "^1.12.7",
     "compression-webpack-plugin": "^1.0.0",

--- a/package/environment.js
+++ b/package/environment.js
@@ -11,6 +11,7 @@ const ManifestPlugin = require('webpack-manifest-plugin')
 
 const config = require('./config')
 const assetHost = require('./asset_host')
+const addCacheLoader = require('./lib/add_cache_loader')
 
 function getLoaderMap() {
   const result = new Map()
@@ -59,33 +60,21 @@ function getModulePaths() {
   return result
 }
 
-function addCacheLoader(rules) {
-  const cacheLoader = {
-    loader: 'cache-loader',
-    options: {
-      cacheDirectory: join(config.cache_path, 'cache-loader')
-    }
-  }
-  for (let rule of rules) {
-    if (rule.use) {
-      rule.use.unshift(cacheLoader)
-    } else if (rule.loader) {
-      let ruleLoader = null
-      if (rule.options) {
-        ruleLoader = { loader: rule.loader, options: rule.options }
-        delete rule.options
-      }
-      rule.use = [cacheLoader, ruleLoader || rule.loader]
-      delete rule.loader
-    }
-  }
-  return rules
-}
-
 module.exports = class Environment {
   constructor() {
     this.loaders = getLoaderMap()
     this.plugins = getPluginMap()
+  }
+
+  addCacheLoader(loader_names) {
+    if (!loader_names) {
+      loader_names = Array.from(getLoaderMap().keys())
+    } else if (loader_names.constructor === String) {
+      loader_names = [loader_names]
+    }
+    loader_names.forEach((loader_name) =>
+      addCacheLoader(this.loaders.get(loader_name))
+    )
   }
 
   toWebpackConfig() {
@@ -100,7 +89,7 @@ module.exports = class Environment {
       },
 
       module: {
-        rules: addCacheLoader(Array.from(this.loaders.values()))
+        rules: Array.from(this.loaders.values())
       },
 
       plugins: Array.from(this.plugins.values()),

--- a/package/environment.js
+++ b/package/environment.js
@@ -59,6 +59,29 @@ function getModulePaths() {
   return result
 }
 
+function addCacheLoader(rules) {
+  const cacheLoader = {
+    loader: 'cache-loader',
+    options: {
+      cacheDirectory: join(config.cache_path, 'cache-loader')
+    }
+  }
+  for (let rule of rules) {
+    if (rule.use) {
+      rule.use.unshift(cacheLoader)
+    } else if (rule.loader) {
+      let ruleLoader = null
+      if (rule.options) {
+        ruleLoader = { loader: rule.loader, options: rule.options }
+        delete rule.options
+      }
+      rule.use = [cacheLoader, ruleLoader || rule.loader]
+      delete rule.loader
+    }
+  }
+  return rules
+}
+
 module.exports = class Environment {
   constructor() {
     this.loaders = getLoaderMap()
@@ -77,7 +100,7 @@ module.exports = class Environment {
       },
 
       module: {
-        rules: Array.from(this.loaders.values())
+        rules: addCacheLoader(Array.from(this.loaders.values()))
       },
 
       plugins: Array.from(this.plugins.values()),

--- a/package/lib/add_cache_loader.js
+++ b/package/lib/add_cache_loader.js
@@ -1,0 +1,23 @@
+const config = require('../config')
+const { join } = require('path')
+
+const cacheLoader = {
+  loader: 'cache-loader',
+  options: {
+    cacheDirectory: join(config.cache_path, 'cache-loader')
+  }
+}
+
+module.exports = function(loader) {
+  if (loader.use) {
+    loader.use.unshift(cacheLoader)
+  } else if (loader.loader) {
+    let ruleLoader = null
+    if (loader.options) {
+      ruleLoader = { loader: loader.loader, options: loader.options }
+      delete loader.options
+    }
+    loader.use = [cacheLoader, ruleLoader || loader.loader]
+    delete loader.loader
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,7 +228,7 @@ async@2.4.1:
   dependencies:
     lodash "^4.14.0"
 
-async@^2.1.2, async@^2.1.5, async@^2.4.1:
+async@^2.1.2, async@^2.1.5, async@^2.3.0, async@^2.4.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
   dependencies:
@@ -942,6 +942,14 @@ builtin-modules@^1.0.0, builtin-modules@^1.1.1:
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
+
+cache-loader@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/cache-loader/-/cache-loader-1.0.3.tgz#7717963ec082db068b17a1412deaaa72d21c4e30"
+  dependencies:
+    async "^2.3.0"
+    loader-utils "^1.1.0"
+    mkdirp "^0.5.1"
 
 caller-path@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This PR adds `cache-loader` https://github.com/webpack-contrib/cache-loader to webpack config
This change improves bundle compiling speed.

For one of my projects (a lot of coffescripts with vue) it changes compile time from 11500ms to 8900ms
For another of my projects (tiny scripts + http://coreui.io styles and fonts) it changes compile time from 12500ms to 4800ms

In `cache-loader` description is said that
> there is an overhead for saving the reading and saving the cache file, so only use this loader to cache expensive loaders

any thoughts on which loaders should be cached?