### PR TITLE
Exposing attribute for configured file extensions

### DIFF
--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -45,6 +45,10 @@ class Webpacker::Configuration
     root_path.join(fetch(:cache_path))
   end
 
+  def extensions
+    fetch(:extensions)
+  end
+
   private
     def fetch(key)
       data.fetch(key, defaults[key])

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -27,8 +27,8 @@ class ConfigurationTest < Webpacker::Test
   end
 
   def test_extensions
-    webpacker_yml = YAML.load_file('lib/install/config/webpacker.yml')
-    assert_equal Webpacker.config.extensions, webpacker_yml['default']['extensions']
+    webpacker_yml = YAML.load_file("lib/install/config/webpacker.yml")
+    assert_equal Webpacker.config.extensions, webpacker_yml["default"]["extensions"]
   end
 
   def test_cache_manifest?

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -26,6 +26,11 @@ class ConfigurationTest < Webpacker::Test
     assert_equal Webpacker.config.cache_path.to_s, cache_path
   end
 
+  def test_extensions
+    webpacker_yml = YAML.load_file('lib/install/config/webpacker.yml')
+    assert_equal Webpacker.config.extensions, webpacker_yml['default']['extensions']
+  end
+
   def test_cache_manifest?
     with_node_env("development") do
       refute reloaded_config.cache_manifest?


### PR DESCRIPTION
We can't get the extensions list from the config object in version 3.0, so this PR adds it as an attribute.

Backstory: In version 2.0 we were using the config object to get the configured file extensions and globbing for everything in the source directory with those extensions. This enabled us to fingerprint the files and determine at build-time whether we needed to rebuild assets or just use the ones already in CDN (also it made our builds faster.)