### PR TITLE
Passing Config file through ERB first in order to better reference configs

### DIFF
--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -55,7 +55,7 @@ class Webpacker::Configuration
     end
 
     def load
-      YAML.load(config_path.read)[env].deep_symbolize_keys
+      YAML.load(ERB.new(File.read(config_path)).result)[env].deep_symbolize_keys
 
     rescue Errno::ENOENT => e
       raise "Webpacker configuration file not found #{config_path}. " \

--- a/lib/webpacker/instance.rb
+++ b/lib/webpacker/instance.rb
@@ -36,7 +36,7 @@ class Webpacker::Instance
   private
     def available_environments
       if config_path.exist?
-        YAML.load(config_path.read).keys
+        YAML.load(ERB.new(File.read(config_path)).result).keys
       else
         [].freeze
       end


### PR DESCRIPTION
This would allow us to use secrets.yml as follows:
`<%= { Rails.env.to_s => Rails.application.secrets[:webpacker].deep_stringify_keys }.to_yaml %>` thus resulting in a single config file and therefore better maintainability
