### PR TITLE
Add support for node_modules to be included in babel

### DIFF
--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -190,3 +190,13 @@ Now, add these files to your `layouts/application.html.erb`:
 ```
 
 More detailed guides available here: [Webpack guides](https://webpack.js.org/guides/)
+
+## Including `node_modules` in babel
+
+If you have dependencies that are >ES6 you may want to include them to be processed by babel. A common case where you might need this is if you are finding the UglifyJS is raising errors during production complications. For example:
+
+```
+Unexpected character '`'
+```
+
+To include these dependencies in your pipeline change the value in `babel.exclude_node_modules` in `config/webpacker.yml` to `false`.

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -10,6 +10,9 @@ default: &default
   # ['app/assets', 'engine/foo/app/assets']
   resolved_paths: []
 
+  babel:
+    exclude_node_modules: true
+
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false
 

--- a/package/loaders/babel.js
+++ b/package/loaders/babel.js
@@ -1,9 +1,9 @@
 const { join } = require('path')
-const { cache_path } = require('../config')
+const { cache_path, babel } = require('../config')
 
 module.exports = {
   test: /\.(js|jsx)?(\.erb)?$/,
-  exclude: /node_modules/,
+  exclude: (babel.exclude_node_modules ? /node_modules/ : []),
   loader: 'babel-loader',
   options: {
     cacheDirectory: join(cache_path, 'babel-loader')


### PR DESCRIPTION
I've found dependencies that are ES6 fail during `UglifyJs` due to not first being handled by babel:

For example, my code has:

```js
import { Foundation } from 'foundation-sites/js/foundation.core';
import { Reveal } from 'foundation-sites/js/foundation.reveal';
import { Tabs } from 'foundation-sites/js/foundation.tabs'
```

When I run:

```
$ rm -Rf public/packs
$ NODE_ENV=production RAILS_ENV=production rails webpacker:compile --trace
```
I get the following error:

```
ERROR in application-37763722852138e61493.js from UglifyJs
Unexpected character '`' [./node_modules/foundation-sites/js/foundation.util.core.js:24,0][application-37763722852138e61493.js:11323,124]

ERROR in Modals-8541f74f3cf2b70f4a0f.js from UglifyJs
Unexpected token: name (matchMedia) [./node_modules/foundation-sites/js/foundation.util.mediaQuery.js:21,0][Modals-8541f74f3cf2b70f4a0f.js:102,4]

ERROR in TabbedExamples-b873f916d365855bfd5d.js from UglifyJs
Unexpected character '`' [./node_modules/foundation-sites/js/foundation.util.core.js:24,0][TabbedExamples-b873f916d365855bfd5d.js:100,124]
```

This change adds the ability to include `node_modules` to be compiled by `babel`. It defaults to the current behaviour, which I'm not entirely sure is correct anyway.

Related: #395
Possibly related: #746 

Copying in @dhh @gauravtiwari who have both touched `package/loaders/babel.js`.