### PR TITLE
Patch for invalid response headers coming from express

### DIFF
--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -11,8 +11,10 @@ class Webpacker::DevServerProxy < Rack::Proxy
   def perform_request(env)
     if env["PATH_INFO"] =~ /#{public_output_uri_path}/ && Webpacker.dev_server.running?
       env["HTTP_HOST"] = env["HTTP_X_FORWARDED_HOST"] = env["HTTP_X_FORWARDED_SERVER"] = Webpacker.dev_server.host_with_port
-
-      super(env)
+      status, headers, body = super(env)
+      m = {}
+      headers.each_pair {|k,v| m[k] = v.is_a?(Array) ? v.first : v }
+      [status,m,body]
     else
       @app.call(env)
     end

--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -13,8 +13,8 @@ class Webpacker::DevServerProxy < Rack::Proxy
       env["HTTP_HOST"] = env["HTTP_X_FORWARDED_HOST"] = env["HTTP_X_FORWARDED_SERVER"] = Webpacker.dev_server.host_with_port
       status, headers, body = super(env)
       m = {}
-      headers.each_pair {|k,v| m[k] = v.is_a?(Array) ? v.first : v }
-      [status,m,body]
+      headers.each_pair { |k, v| m[k] = v.is_a?(Array) ? v.first : v }
+      [status, m, body]
     else
       @app.call(env)
     end


### PR DESCRIPTION
under node 8.5.0, rails 5.1 i noticed express is returning invalid http headers. this patch corrects it.
Example response:
{"x-powered-by"=>["Express"], "access-control-allow-origin"=>["*"], "accept-ranges"=>["bytes"], "content-type"=>["application/json; charset=UTF-8"], "content-length"=>["61"], "etag"=>["W/\"3d-5mD5tX4ZoI4R3XJKABPz5FxFGro\""], "vary"=>["Accept-Encoding"], "date"=>["Mon, 25 Sep 2017 21:12:36 GMT"]}

during HMR