### PR TITLE
Add missing part about cache_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,9 +103,11 @@ live reload when manifest changes. If you have applied this workaround from [#72
 
 ### Breaking changes
 
-- Add `compile` option to `config/webpacker.yml` for configuring lazy compilation of packs when a file under tracked paths is changed [#503](https://github.com/rails/webpacker/pull/503). To enable expected behavior, update `config/webpacker.yml`:
+- Add `compile` and `cache_path` options to `config/webpacker.yml` for configuring lazy compilation of packs when a file under tracked paths is changed [#503](https://github.com/rails/webpacker/pull/503). To enable expected behavior, update `config/webpacker.yml`:
 
   ```yaml
+    default: &default
+      cache_path: tmp/cache/webpacker
     test:
       compile: true
 


### PR DESCRIPTION
Compile option needs cache_path as well. Otherwise you will have Nil to string conversion error.
https://github.com/rails/webpacker/commit/064148e9aed1fd0d2076edcd628fc5ec4f4f3b73

Take care