### PR TITLE
Change DevServer#host_with_port to use host and port

### DIFF
--- a/lib/webpacker/dev_server.rb
+++ b/lib/webpacker/dev_server.rb
@@ -47,7 +47,7 @@ class Webpacker::DevServer
   end
 
   def host_with_port
-    fetch(:public)
+    "#{host}:#{port}"
   end
 
   private


### PR DESCRIPTION
I believe the intent of the [dev server `public` option](https://webpack.js.org/configuration/dev-server/#devserver-public) is primarily for the dev server `inline` mode script to know the public address of the dev server when it cannot guess. One such use case arises when the app server (in our case, Rails) sits behind an Nginx proxy that receives requests to `myapp.dev` and forwards them to `localhost:3000`. 

In our setup, to proxy "pack" requests to our webpack dev server, e.g., from `http://myapp.dev/packs/application-[chunkhash].js` to `http://localhost:3035`, we _could_ add Nginx configuration. Conveniently, `Webpacker::DevServerProxy` already attempts to do this and works—except when the public option is different than the host:port where the dev server is listening. 

I could be wrong about this, but I believe the Webpacker proxy should forward requests to host:port, not the public endpoint, and that the public option for `config/webpacker.yml` should be entirely optional (as it's only intended for use with inline mode scripts), whereas with the recent changes on master, it appears to be required for proxying. 

Curious to hear other thoughts on this.