### PR TITLE
Manifest lookups without exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,21 @@
 ## Unreleased
 
+### Added
+
 - Allow dev server connect timeout (in seconds) to be configurable, default: 0.01
 
 ```rb
 # Change to 1s
 Webpacker.dev_server.connect_timeout = 1
+```
+
+- A new `lookup` method to manifest to perform lookup without raise and return `nil`
+
+```rb
+Webpacker.manifest.lookup('foo.js')
+# => nil
+Webpacker.manifest.lookup!('foo.js')
+# => raises Webpacker::Manifest::MissingEntryError
 ```
 
 ## [3.0.1] - 2017-09-01

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -7,7 +7,7 @@ module Webpacker::Helper
   #
   #   <%= asset_pack_path 'calendar.css' %> # => "/packs/calendar-1016838bab065ae1e122.css"
   def asset_pack_path(name, **options)
-    asset_path(Webpacker.manifest.lookup(name), **options)
+    asset_path(Webpacker.manifest.lookup!(name), **options)
   end
   # Creates a script tag that references the named pack file, as compiled by Webpack per the entries list
   # in config/webpack/shared.js. By default, this list is auto-generated to match everything in
@@ -45,7 +45,7 @@ module Webpacker::Helper
 
   private
     def sources_from_pack_manifest(names, type:)
-      names.map { |name| Webpacker.manifest.lookup(pack_name_with_extension(name, type: type)) }
+      names.map { |name| Webpacker.manifest.lookup!(pack_name_with_extension(name, type: type)) }
     end
 
     def pack_name_with_extension(name, type:)

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -23,6 +23,10 @@ class Webpacker::Manifest
     find name
   end
 
+  def lookup!(name)
+    lookup(name) || handle_missing_entry(name)
+  end
+
   private
     def compiling?
       config.compile? && !dev_server.running?
@@ -33,7 +37,7 @@ class Webpacker::Manifest
     end
 
     def find(name)
-      data[name.to_s] || handle_missing_entry(name)
+      data[name.to_s].presence
     end
 
     def handle_missing_entry(name)

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -1,17 +1,25 @@
 require "webpacker_test_helper"
 
 class ManifestTest < Minitest::Test
-  def test_lookup_exception
+  def test_lookup_exception!
     manifest_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/public/packs", "manifest.json").to_s
     asset_file = "calendar.js"
 
     Webpacker.config.stub :compile?, false do
       error = assert_raises Webpacker::Manifest::MissingEntryError do
-        Webpacker.manifest.lookup(asset_file)
+        Webpacker.manifest.lookup!(asset_file)
       end
 
       assert_match "Webpacker can't find #{asset_file} in #{manifest_path}", error.message
     end
+  end
+
+  def test_lookup_success!
+    assert_equal Webpacker.manifest.lookup!("bootstrap.js"), "/packs/bootstrap-300631c4f0e0f9c865bc.js"
+  end
+
+  def test_lookup_nil
+    assert_nil Webpacker.manifest.lookup("foo.js")
   end
 
   def test_lookup_success


### PR DESCRIPTION
Much like Rails finders: `find_by` and `find_by!`

```rb
Webpacker.manifest.lookup('foo.js')
# => nil
Webpacker.manifest.lookup!('foo.js')
# => raises Webpacker::Manifest::MissingEntryError
```

Closes: #830