### PR TITLE
Enables multiple entry points nested in rails root

### DIFF
--- a/package/environment.js
+++ b/package/environment.js
@@ -45,7 +45,7 @@ function getEntryObject() {
   const paths = sync(join(rootPath, glob))
   paths.forEach((path) => {
     const namespace = relative(join(rootPath), dirname(path))
-    const name = join(namespace, basename(path, extname(path)))
+    const name = basename(path, extname(path))
     result[name] = resolve(path)
   })
   return result


### PR DESCRIPTION
With this change, webpacker config file can contain (e.g.) source_path: "**/app/javascript". This creates packs for all entry points below the rails roots, and specifically for the engines in vendor/gems.

If this change is not present, then the keys of manifest.json are malformed due to the globbed source path.

I would be happy to submit a test for this, if you can suggest how to test it. It doesn't break the existing tests, but the affected code may not be covered by the test suite.