### PR TITLE
Make `DevServer.running?`more resilient to errors (fixes #876)

### DIFF
--- a/lib/webpacker/dev_server.rb
+++ b/lib/webpacker/dev_server.rb
@@ -12,7 +12,7 @@ class Webpacker::DevServer
   def running?
     Socket.tcp(host, port, connect_timeout: connect_timeout).close
     true
-  rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, NoMethodError
+  rescue
     false
   end
 


### PR DESCRIPTION
Catch all exceptions in `DevServer.running?` and return false.
This is required because some ruby implementations (particularly
`jruby 9.1.13.0` throws a `Errno::EBADF`) which ends up being uncaught
and blows up the stack with no indication as to why the error happened.