### PR TITLE
Add ERB parsing to configuration

### DIFF
--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -59,7 +59,7 @@ class Webpacker::Configuration
     end
 
     def load
-      YAML.load(config_path.read)[env].deep_symbolize_keys
+      YAML.load(ERB.new(config_path.read).result)[env].deep_symbolize_keys
 
     rescue Errno::ENOENT => e
       raise "Webpacker configuration file not found #{config_path}. " \


### PR DESCRIPTION
I'm using Docker and need to pass in the Webpacker host from an ENV variable to the webpacker conf.
Right now, we don't do any ERB parsing making this pretty hard.

This is just adding simple ERB parsing when we load the webpack.yml file.