### PR TITLE
Fix required_ruby_version 1.9.3 => 2.2.0 in gemspec

### DIFF
--- a/webpacker.gemspec
+++ b/webpacker.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.bindir   = "exe"
   s.executables = `git ls-files -- exe/*`.split("\n").map { |f| File.basename(f) }
 
-  s.required_ruby_version = ">= 1.9.3"
+  s.required_ruby_version = ">= 2.2.0"
 
   s.add_dependency "activesupport", ">= 4.2"
   s.add_dependency "railties",      ">= 4.2"


### PR DESCRIPTION
Currently, required_ruby_version is `1.9.3`. But in `1.9.3` and `2.0.0`, webpacker cannot execute.

## Keyword arguments are not supported in 1.9.3

```ruby
class Webpacker::Instance
  cattr_accessor(:logger) { ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT)) }

  attr_reader :root_path, :config_path

  def initialize(root_path: Rails.root, config_path: Rails.root.join("config/webpacker.yml"))
    @root_path, @config_path = root_path, config_path
  end
...
```

## Required keyword argument are not supported in 2.0.0

```ruby
# lib/webpacker/helper.rb
...
  private
    def sources_from_pack_manifest(names, type:)
      names.map { |name| Webpacker.manifest.lookup!(pack_name_with_extension(name, type: type)) }
    end

    def pack_name_with_extension(name, type:)
      "#{name}#{compute_asset_extname(name, type: type)}"
    end
```

According [README](https://github.com/rails/webpacker#prerequisites), webpacker supports Ruby 2.2+. ~But I could run tests in Ruby 2.1~ (*). So I changed required_ruby_version from `1.9.3` to `2.2.0`.

⚠️  When it run tests in Ruby 2.1, we should add `require "action_view/test_case"` in `test/webpacker_test_helper.rb`.