### PR TITLE
Removes env['SCRIPT_NAME'] when proxying requests to dev_server

### DIFF
--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -11,6 +11,7 @@ class Webpacker::DevServerProxy < Rack::Proxy
   def perform_request(env)
     if env["PATH_INFO"] =~ /#{public_output_uri_path}/ && Webpacker.dev_server.running?
       env["HTTP_HOST"] = env["HTTP_X_FORWARDED_HOST"] = env["HTTP_X_FORWARDED_SERVER"] = Webpacker.dev_server.host_with_port
+      env["SCRIPT_NAME"] = ""
 
       super(env)
     else


### PR DESCRIPTION
In the following situation:

- Running an app in development under a **sub-uri** (e.g. /myapp)
- webpack-dev-server **running**

Webpacker proxies the pack's request to the dev_server with wrong name:

```/myapp/packs/application-ef71d57d8f408a7eef48.js```

Causing a **502 Bad Gateway** or **Incomplete response received from application** response.