### PR TITLE
Fix proxy scheme

### DIFF
--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -11,6 +11,9 @@ class Webpacker::DevServerProxy < Rack::Proxy
   def perform_request(env)
     if env["PATH_INFO"] =~ /#{public_output_uri_path}/ && Webpacker.dev_server.running?
       env["HTTP_HOST"] = env["HTTP_X_FORWARDED_HOST"] = env["HTTP_X_FORWARDED_SERVER"] = Webpacker.dev_server.host_with_port
+      env.delete("HTTPS")
+      env.delete("HTTP_X_FORWARDED_SSL")
+      env["HTTP_X_FORWARDED_PROTO"] = env["HTTP_X_FORWARDED_SCHEME"] = Webpacker.dev_server.protocol
 
       super(env)
     else


### PR DESCRIPTION
Currently, if we run the rails app (with webpacker) and proxy it under an HTTPS server. The webpacker will forward asset requests to webpack-dev-server as HTTPS (`env['HTTP_X_FORWARDED_PROTO']`). The correct protocol should be the protocol should be `Webpack.dev_server.protocol`.
