### PR TITLE
Use Railtie instead of Engine

### DIFF
--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -3,7 +3,7 @@ require "rails/railtie"
 require "webpacker/helper"
 require "webpacker/dev_server_proxy"
 
-class Webpacker::Engine < ::Rails::Engine
+class Webpacker::Railtie < ::Rails::Railtie
   initializer "webpacker.proxy" do |app|
     if Rails.env.development?
       app.middleware.insert_before 0,


### PR DESCRIPTION
## Summary

Webpacker is a rails plugin. So it doesn't need to define as engine, it needs to replace engine with railtie. Rails engine is usually used in the case that it needs to extend MVC or to provide features as mini application. On the other hand, Railtie is usually used in the case that it needs to provide initialize, generators and tasks.

Rails::Railtie
http://api.rubyonrails.org/classes/Rails/Railtie.html

Rails::Engine
http://api.rubyonrails.org/classes/Rails/Engine.html