### PR TITLE
Enable matrix test in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ rvm:
   - 2.2.8
   - 2.3.5
   - 2.4.2
+  - ruby-head
+gemfile:
+  - gemfiles/Gemfile-rails.4.2.x
+  - gemfiles/Gemfile-rails.5.0.x
+  - gemfiles/Gemfile-rails.5.1.x
 cache:
   bundler: true
   directories:

--- a/gemfiles/Gemfile-rails.4.2.x
+++ b/gemfiles/Gemfile-rails.4.2.x
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gem "webpacker", path: ".."
+
+gem "rails", "~> 4.2"
+gem "rake", ">= 11.1"
+gem "rubocop", ">= 0.49", require: false
+gem "rack-proxy", require: false
+gem "minitest", "~> 5.0"
+gem "byebug"

--- a/gemfiles/Gemfile-rails.5.0.x
+++ b/gemfiles/Gemfile-rails.5.0.x
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gem "webpacker", path: ".."
+
+gem "rails", "~> 5.0"
+gem "rake", ">= 11.1"
+gem "rubocop", ">= 0.49", require: false
+gem "rack-proxy", require: false
+gem "minitest", "~> 5.0"
+gem "byebug"

--- a/gemfiles/Gemfile-rails.5.1.x
+++ b/gemfiles/Gemfile-rails.5.1.x
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gem "webpacker", path: ".."
+
+gem "rails", "~> 5.1"
+gem "rake", ">= 11.1"
+gem "rubocop", ">= 0.49", require: false
+gem "rack-proxy", require: false
+gem "minitest", "~> 5.0"
+gem "byebug"

--- a/test/test_app/config/application.rb
+++ b/test/test_app/config/application.rb
@@ -1,7 +1,10 @@
-require "rails/all"
+require "action_controller/railtie"
+require "action_view/railtie"
 require "webpacker"
 
 module TestApp
   class Application < ::Rails::Application
+    config.secret_key_base = "abcdef"
+    config.eager_load = true
   end
 end

--- a/test/test_app/config/environment.rb
+++ b/test/test_app/config/environment.rb
@@ -1,0 +1,4 @@
+require_relative "application"
+
+Rails.backtrace_cleaner.remove_silencers!
+Rails.application.initialize!

--- a/test/test_app/config/secrets.yml
+++ b/test/test_app/config/secrets.yml
@@ -1,5 +1,0 @@
-development:
-  secret_key_base: 'abcdef'
-
-test:
-  secret_key_base: 'abcdef'

--- a/test/webpacker_test_helper.rb
+++ b/test/webpacker_test_helper.rb
@@ -1,24 +1,17 @@
 # frozen_string_literal: true
+$LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require "minitest/autorun"
 require "rails"
 require "rails/test_help"
 require "byebug"
-
-require "webpacker"
+require "test_app/config/environment"
 
 ENV["NODE_ENV"] ||= "production"
 
 Webpacker.instance = Webpacker::Instance.new \
-  root_path: Pathname.new(File.expand_path("../test_app", __FILE__)),
-  config_path: Pathname.new(File.expand_path("../../lib/install/config/webpacker.yml", __FILE__))
-
-module TestApp
-  class Application < ::Rails::Application
-    config.root = File.join(File.dirname(__FILE__), "test_app")
-    config.eager_load = true
-  end
-end
+  root_path: Pathname.new(File.expand_path("test_app", __dir__)),
+  config_path: Pathname.new(File.expand_path("../lib/install/config/webpacker.yml", __dir__))
 
 class Webpacker::Test < Minitest::Test
   private
@@ -35,6 +28,3 @@ class Webpacker::Test < Minitest::Test
       ENV["NODE_ENV"] = original
     end
 end
-
-Rails.backtrace_cleaner.remove_silencers!
-TestApp::Application.initialize!


### PR DESCRIPTION
Enable matrix test in travis:

![](https://user-images.githubusercontent.com/15371677/31305177-44e7c704-ab6e-11e7-81e4-36ac479f55e1.png)

And I noticed that test is fail in Rails v4.2. So I've made it be able to run test in Rails 4.2. 

### Error log (Rails v4.2, ~Fixed in 868f2c1~ Currently, This problem is fixed by 0aea7f2)

```bash
% bundle exec rake
/Users/yhirano/.rbenv/versions/2.4.2/bin/ruby -w -I"lib:test:lib" -I"/Users/yhirano/dev/src/github.com/yhirano55/webpacker/vendor/bundle/gems/rake-12.1.0/lib" "/Users/yhirano/dev/src/github.com/yhirano55/webpacker/vendor/bundle/gems/rake-12.1.0/lib/rake/rake_test_loader.rb" "test/command_test.rb" "test/compiler_test.rb" "test/configuration_test.rb" "test/dev_server_test.rb" "test/helper_test.rb" "test/manifest_test.rb"
/Users/yhirano/dev/src/github.com/yhirano55/webpacker/vendor/bundle/gems/activesupport-4.2.10/lib/active_support/core_ext/enumerable.rb:20: warning: method redefined; discarding old sum
/Users/yhirano/dev/src/github.com/yhirano55/webpacker/test/helper_test.rb:3:in `<top (required)>': uninitialized constant ActionView (NameError)
        from /Users/yhirano/dev/src/github.com/yhirano55/webpacker/vendor/bundle/gems/rake-12.1.0/lib/rake/rake_test_loader.rb:17:in `block in <main>'
        from /Users/yhirano/dev/src/github.com/yhirano55/webpacker/vendor/bundle/gems/rake-12.1.0/lib/rake/rake_test_loader.rb:5:in `select'
        from /Users/yhirano/dev/src/github.com/yhirano55/webpacker/vendor/bundle/gems/rake-12.1.0/lib/rake/rake_test_loader.rb:5:in `<main>'
rake aborted!
Command failed with status (1): [ruby -w -I"lib:test:lib" -I"/Users/yhirano/dev/src/github.com/yhirano55/webpacker/vendor/bundle/gems/rake-12.1.0/lib" "/Users/yhirano/dev/src/github.com/yhirano55/webpacker/vendor/bundle/gems/rake-12.1.0/lib/rake/rake_test_loader.rb" "test/command_test.rb" "test/compiler_test.rb" "test/configuration_test.rb" "test/dev_server_test.rb" "test/helper_test.rb" "test/manifest_test.rb" ]
/Users/yhirano/dev/src/github.com/yhirano55/webpacker/vendor/bundle/gems/rake-12.1.0/exe/rake:27:in `<top (required)>'
/Users/yhirano/.rbenv/versions/2.4.2/bin/bundle:23:in `load'
/Users/yhirano/.rbenv/versions/2.4.2/bin/bundle:23:in `<main>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```