### PR TITLE
Add missing instruction to create typescript loader

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -40,6 +40,14 @@ and rename your generated `hello_react.js` using react installer
 to `hello_react.tsx` and make it valid typescript and now you can use
 typescript, JSX with React.
 
+4. Create `config/webpack/loaders/typescript.js` with this content:
+
+```
+module.exports = {
+    test: /.(ts|tsx)$/,
+    loader: 'ts-loader'
+}
+```
 
 
 ## HTML templates with Typescript and Angular


### PR DESCRIPTION
We are missing an extra steps in document: https://github.com/rails/webpacker/issues/371#issuecomment-301215682