### PR TITLE
#784 Add ico file support

### DIFF
--- a/package/loaders/file.js
+++ b/package/loaders/file.js
@@ -3,7 +3,7 @@ const { source_path } = require('../config')
 const assetHost = require('../asset_host')
 
 module.exports = {
-  test: /\.(jpg|jpeg|png|gif|svg|eot|otf|ttf|woff|woff2)$/i,
+  test: /\.(jpg|jpeg|png|gif|tiff|ico|svg|eot|otf|ttf|woff|woff2)$/i,
   use: [{
     loader: 'file-loader',
     options: {


### PR DESCRIPTION
Add the ability to compile ico and tiff file extension with webpack.

See issue #784 for more details.