### PR TITLE
Replace unknown character with space in comment [ci skip]

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -3,7 +3,7 @@ require "digest/sha1"
 
 class Webpacker::Compiler
   # Additional paths that test compiler needs to watch
-  # Webpacker::Compiler.watched_paths << 'bower_components'
+  # Webpacker::Compiler.watched_paths << 'bower_components'
   mattr_accessor(:watched_paths) { [] }
 
   # Additional environment variables that the compiler is being run with

--- a/lib/webpacker/dev_server.rb
+++ b/lib/webpacker/dev_server.rb
@@ -1,6 +1,6 @@
 class Webpacker::DevServer
   # Configure dev server connection timeout (in seconds), default: 0.01
-  # Webpacker.dev_server.connect_timeout = 1
+  # Webpacker.dev_server.connect_timeout = 1
   mattr_accessor(:connect_timeout) { 0.01 }
 
   delegate :config, to: :@webpacker


### PR DESCRIPTION
### Summary

I found unknown chars are mixed in comment. I fixed it.