### PR TITLE
Re-load webpacker's tasks

### DIFF
--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -3,7 +3,7 @@ require "rails/railtie"
 require "webpacker/helper"
 require "webpacker/dev_server_proxy"
 
-class Webpacker::Railtie < ::Rails::Railtie
+class Webpacker::Engine < ::Rails::Engine
   initializer "webpacker.proxy" do |app|
     if Rails.env.development?
       app.middleware.insert_before 0,


### PR DESCRIPTION
I found that webpacker's rake tasks don't  loaded in the environment using master branch. It seems to be caused by 6586ef7a969716abb44d80acf8d32659405c0e10 (related to #903).

I think the easiest way to recover it is revert it. What do you think about it?

If it is better way to use `rake_tasks(&blk)` in `lib/webpacker/railtie.rb`, I'll do it. 
```diff
--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -38,4 +38,9 @@ class Webpacker::Engine < ::Rails::Engine
       Spring.after_fork { Webpacker.bootstrap } if defined?(Spring)
     end
   end
+
+  rake_tasks do
+    tasks_path = File.expand_path('../../tasks', __FILE__)
+    Dir.glob("#{tasks_path}/**/*.rake").sort.each { |ext| load ext }
+  end
 end
```




