### PR TITLE
Capitalization fixes for "Webpacker" and "webpack"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![Gem](https://img.shields.io/gem/v/webpacker.svg)](https://github.com/rails/webpacker)
 
 Webpacker makes it easy to use the JavaScript pre-processor and bundler
-[Webpack 3.x.x+](https://webpack.js.org/)
+[webpack 3.x.x+](https://webpack.js.org/)
 to manage application-like JavaScript in Rails. It coexists with the asset pipeline,
-as the primary purpose for Webpack is app-like JavaScript, not images, CSS, or
+as the primary purpose for webpack is app-like JavaScript, not images, CSS, or
 even JavaScript Sprinkles (that all continues to live in app/assets).
 
 However, it is possible to use Webpacker for CSS, images and fonts assets as well,
@@ -23,7 +23,7 @@ in which case you may not even need the asset pipeline. This is mostly relevant 
   - [Upgrading](#upgrading)
   - [Usage](#usage)
   - [Development](#development)
-  - [Webpack configuration](#webpack-configuration)
+  - [webpack configuration](#webpack-configuration)
 - [Integrations](#integrations)
   - [React](#react)
   - [Angular with TypeScript](#angular-with-typescript)
@@ -49,7 +49,7 @@ in which case you may not even need the asset pipeline. This is mostly relevant 
 
 ## Features
 
-* [Webpack 3.x.x](https://webpack.js.org/)
+* [webpack 3.x.x](https://webpack.js.org/)
 * ES6 with [babel](https://babeljs.io/)
 * Automatic code splitting using multiple entry points
 * Stylesheets - SASS and CSS
@@ -175,9 +175,9 @@ WEBPACKER_DEV_SERVER_HOST=0.0.0.0 ./bin/webpack-dev-server
 
 **Note:** Don't forget to prefix `ruby` when running these binstubs on windows
 
-### Webpack configuration
+### webpack configuration
 
-See [docs/Webpack](docs/webpack.md) for modifying webpack configuration and loaders.
+See [docs/webpack](docs/webpack.md) for modifying webpack configuration and loaders.
 
 
 ### Upgrading
@@ -271,10 +271,10 @@ By default, Webpacker ships with simple conventions for where the JavaScript
 app files and compiled webpack bundles will go in your Rails app,
 but all these options are configurable from `config/webpacker.yml` file.
 
-The configuration for what Webpack is supposed to compile by default rests
+The configuration for what webpack is supposed to compile by default rests
 on the convention that every file in `app/javascript/packs/*`**(default)**
 or whatever path you set for `source_entry_path` in the `webpacker.yml` configuration
-is turned into their own output files (or entry points, as Webpack calls it). Therefore you don't want to put anything inside `packs` directory that you do want to be
+is turned into their own output files (or entry points, as webpack calls it). Therefore you don't want to put anything inside `packs` directory that you do want to be
 an entry file. As a rule thumb, put all files your want to link in your views inside
 "packs" directory and keep everything else under `app/javascript`.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -33,4 +33,4 @@ git push heroku master
 ## CDN
 
 Webpacker out-of-the-box provides CDN support using your Rails app `config.action_controller.asset_host` setting. If you already have [CDN](http://guides.rubyonrails.org/asset_pipeline.html#cdns) added in your rails app
-you don't need to do anything extra for webpacker, it just works.
+you don't need to do anything extra for Webpacker, it just works.

--- a/docs/env.md
+++ b/docs/env.md
@@ -2,7 +2,7 @@
 
 
 Environment variables are supported out of the box in Webpacker. For example if
-you run the Webpack dev server like so:
+you run the webpack dev server like so:
 ```
 FOO=hello BAR=world ./bin/webpack-dev-server
 ```
@@ -18,11 +18,11 @@ You may want to store configuration in environment variables via `.env` files,
 similar to the [dotenv Ruby gem](https://github.com/bkeepers/dotenv).
 
 In development, if you use [Foreman](http://ddollar.github.io/foreman) or [Invoker](http://invoker.codemancers.com)
-to launch the Webpack server, both of these tools have basic support for a
+to launch the webpack server, both of these tools have basic support for a
 `.env` file (Invoker also supports `.env.local`), so no further configuration
 is needed.
 
-However, if you run the Webpack server without Foreman/Invoker, or if you
+However, if you run the webpack server without Foreman/Invoker, or if you
 want more control over what `.env` files to load, you can use the
 [dotenv npm package](https://github.com/motdotla/dotenv). Here is what you could
 do to support a "Ruby-like" dotenv:

--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -1,9 +1,9 @@
 # Folder Structure
 
 
-## Packs a.k.a Webpack entries
+## Packs a.k.a webpack entries
 
-"Packs" is a special directory made only for Webpack entry files so don't put anything
+"Packs" is a special directory made only for webpack entry files so don't put anything
 here that you don't want to link in your views.
 
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,7 +15,7 @@ you install any new modules.
 ## Can't find hello_react.js in manifest.json
 
 * If you get this error `Can't find hello_react.js in manifest.json`
-when loading a view in the browser it's because Webpack is still compiling packs.
+when loading a view in the browser it's because webpack is still compiling packs.
 Webpacker uses a `manifest.json` file to keep track of packs in all environments,
 however since this file is generated after packs are compiled by webpack. So,
 if you load a view in browser whilst webpack is compiling you will get this error.
@@ -48,9 +48,9 @@ bundle config --delete bin
 ```
 
 
-## Running Webpack on Windows
+## Running webpack on Windows
 
-If you are running Webpack on Windows, your command shell may not be able to interpret the preferred interpreter
+If you are running webpack on Windows, your command shell may not be able to interpret the preferred interpreter
 for the scripts generated in `bin/webpack` and `bin/webpack-dev-server`. Instead you'll want to run the scripts
 manually with Ruby:
 
@@ -60,6 +60,6 @@ C:\path>ruby bin\webpack-dev-server
 ```
 
 
-## Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
+## Invalid configuration object. webpack has been initialised using a configuration object that does not match the API schema.
 
 If you receive this error when running `$ ./bin/webpack-dev-server` ensure your configuration is correct; most likely the path to your "packs" folder is incorrect if you modified from the original "source_path" defined in `config/webpacker.yml`.

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -3,7 +3,7 @@
 
 ## Typescript with React
 
-1. Setup react using webpacker [react installer](#react). Then add required depedencies
+1. Setup react using Webpacker [react installer](#react). Then add required depedencies
 for using typescript with React:
 
 ```bash

--- a/docs/webpack-dev-server.md
+++ b/docs/webpack-dev-server.md
@@ -1,4 +1,4 @@
-# Webpack Dev Server
+# webpack Dev Server
 
 
 ## HTTPS
@@ -36,10 +36,10 @@ otherwise you will get not found error for stylesheets.
 
 If you use Nginx in development to proxy requests to your Rails server from
 another domain, like `myapp.dev`, the Webpacker middleware will be able to
-forward requests for "packs" to the Webpack dev server.
+forward requests for "packs" to the webpack dev server.
 
 If you're using `inline` mode behing Nginx, you may also need to provide the
-hostname to Webpack dev server so it can initiate the websocket connection for
+hostname to webpack dev server so it can initiate the websocket connection for
 live reloading ([Webpack
 docs](https://webpack.js.org/configuration/dev-server/#devserver-public)).
 

--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -1,4 +1,4 @@
-# Webpack
+# webpack
 
 
 ## Configuration
@@ -86,9 +86,9 @@ babelLoader.options.cacheDirectory = false
 module.exports = environment
 ```
 
-### Overriding Loader Options in Webpack 3+ (for CSS Modules etc.)
+### Overriding Loader Options in webpack 3+ (for CSS Modules etc.)
 
-In Webpack 3+, if you'd like to specify additional or different options for a loader, edit `config/webpack/environment.js` and provide an options object to override. This is similar to the technique shown above, but the following example shows specifically how to apply CSS Modules, which is what you may be looking for:
+In webpack 3+, if you'd like to specify additional or different options for a loader, edit `config/webpack/environment.js` and provide an options object to override. This is similar to the technique shown above, but the following example shows specifically how to apply CSS Modules, which is what you may be looking for:
 
 ```javascript
 const { environment } = require('@rails/webpacker')
@@ -189,4 +189,4 @@ Now, add these files to your `layouts/application.html.erb`:
 <%= stylesheet_pack_tag "vendor" %>
 ```
 
-More detailed guides available here: [Webpack guides](https://webpack.js.org/guides/)
+More detailed guides available here: [webpack guides](https://webpack.js.org/guides/)

--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -50,7 +50,7 @@ to be available. In above case, it will be applied to development environment.
 
 ## Loaders
 
-You can add additional loaders beyond the base set that webpacker provides by
+You can add additional loaders beyond the base set that Webpacker provides by
 adding it to your environment. We'll use `json-loader` as an example:
 
 ```
@@ -72,7 +72,7 @@ module.exports = environment
 Finally add `.json` to the list of extensions in `config/webpacker.yml`. Now if you `import()` any `.json` files inside your javascript
 they will be processed using `json-loader`. Voila!
 
-You can also modify the loaders that webpacker pre-configures for you. We'll update
+You can also modify the loaders that Webpacker pre-configures for you. We'll update
 the `babel` loader as an example:
 
 ```js

--- a/lib/install/elm.rb
+++ b/lib/install/elm.rb
@@ -13,7 +13,7 @@ run "yarn add elm elm-webpack-loader"
 run "yarn add --dev elm-hot-loader"
 run "yarn run elm package install -- --yes"
 
-say "Updating Webpack paths to include Elm file extension"
+say "Updating webpack paths to include Elm file extension"
 insert_into_file Webpacker.config.config_path, "    - .elm\n", after: /extensions:\n/
 
 say "Updating Elm source location"

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -1,4 +1,4 @@
-# Install webpacker
+# Install Webpacker
 copy_file "#{__dir__}/config/webpacker.yml", "config/webpacker.yml"
 
 say "Copying webpack core config and loaders"

--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -4,7 +4,7 @@ tasks = {
   "webpacker:check_node"              => "Verifies if Node.js is installed",
   "webpacker:check_yarn"              => "Verifies if yarn is installed",
   "webpacker:check_binstubs"          => "Verifies that bin/webpack & bin/webpack-dev-server are present",
-  "webpacker:verify_install"          => "Verifies if webpacker is installed",
+  "webpacker:verify_install"          => "Verifies if Webpacker is installed",
   "webpacker:yarn_install"            => "Support for older Rails versions. Install all JavaScript dependencies as specified via Yarn",
   "webpacker:install:react"           => "Installs and setup example React component",
   "webpacker:install:vue"             => "Installs and setup example Vue component",
@@ -12,8 +12,8 @@ tasks = {
   "webpacker:install:elm"             => "Installs and setup example Elm component"
 }.freeze
 
-desc "Lists all available tasks in webpacker"
+desc "Lists all available tasks in Webpacker"
 task :webpacker do
-  puts "Available webpacker tasks are:"
+  puts "Available Webpacker tasks are:"
   tasks.each { |task, message| puts task.ljust(30) + message }
 end

--- a/lib/tasks/webpacker/check_binstubs.rake
+++ b/lib/tasks/webpacker/check_binstubs.rake
@@ -2,7 +2,7 @@ namespace :webpacker do
   desc "Verifies that bin/webpack & bin/webpack-dev-server are present."
   task :check_binstubs do
     unless File.exist?("bin/webpack") && File.exist?("bin/webpack-dev-server")
-      $stderr.puts "Webpack binstubs not found.\n"\
+      $stderr.puts "webpack binstubs not found.\n"\
            "Have you run rails webpacker:install ?\n"\
            "Make sure the bin directory or binstubs are not included in .gitignore\n"\
            "Exiting!"

--- a/lib/tasks/webpacker/install.rake
+++ b/lib/tasks/webpacker/install.rake
@@ -1,7 +1,7 @@
 WEBPACKER_APP_TEMPLATE_PATH = File.expand_path("../../install/template.rb", __dir__)
 
 namespace :webpacker do
-  desc "Install webpacker in this application"
+  desc "Install Webpacker in this application"
   task install: [:check_node, :check_yarn] do
     if Rails::VERSION::MAJOR >= 5
       exec "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{WEBPACKER_APP_TEMPLATE_PATH}"

--- a/lib/tasks/webpacker/verify_install.rake
+++ b/lib/tasks/webpacker/verify_install.rake
@@ -1,7 +1,7 @@
 require "webpacker/configuration"
 
 namespace :webpacker do
-  desc "Verifies if webpacker is installed"
+  desc "Verifies if Webpacker is installed"
   task verify_install: [:check_node, :check_yarn, :check_binstubs] do
     if Webpacker.config.config_path.exist?
       $stdout.puts "Webpacker is installed 🎉 🍰"

--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -20,7 +20,7 @@ module Webpacker
         @port              = dev_server["port"]
 
       rescue Errno::ENOENT, NoMethodError
-        $stdout.puts "Webpack dev_server configuration not found in #{@config_file}."
+        $stdout.puts "webpack dev_server configuration not found in #{@config_file}."
         $stdout.puts "Please run bundle exec rails webpacker:install to install webpacker"
         exit!
       end

--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -21,7 +21,7 @@ module Webpacker
 
       rescue Errno::ENOENT, NoMethodError
         $stdout.puts "webpack dev_server configuration not found in #{@config_file}."
-        $stdout.puts "Please run bundle exec rails webpacker:install to install webpacker"
+        $stdout.puts "Please run bundle exec rails webpacker:install to install Webpacker"
         exit!
       end
 

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -1,5 +1,5 @@
 module Webpacker::Helper
-  # Computes the full path for a given webpacker asset.
+  # Computes the full path for a given Webpacker asset.
   # Return relative path using manifest.json and passes it to asset_url helper
   # This will use asset_path internally, so most of their behaviors will be the same.
   #

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -9,7 +9,7 @@ module Webpacker::Helper
   def asset_pack_path(name, **options)
     asset_path(Webpacker.manifest.lookup!(name), **options)
   end
-  # Creates a script tag that references the named pack file, as compiled by Webpack per the entries list
+  # Creates a script tag that references the named pack file, as compiled by webpack per the entries list
   # in config/webpack/shared.js. By default, this list is auto-generated to match everything in
   # app/javascript/packs/*.js. In production mode, the digested reference is automatically looked up.
   #
@@ -21,7 +21,7 @@ module Webpacker::Helper
     javascript_include_tag(*sources_from_pack_manifest(names, type: :javascript), **options)
   end
 
-  # Creates a link tag that references the named pack file, as compiled by Webpack per the entries list
+  # Creates a link tag that references the named pack file, as compiled by webpack per the entries list
   # in config/webpack/shared.js. By default, this list is auto-generated to match everything in
   # app/javascript/packs/*.js. In production mode, the digested reference is automatically looked up.
   #

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -49,9 +49,9 @@ class Webpacker::Manifest
 Webpacker can't find #{bundle_name} in #{config.public_manifest_path}. Possible causes:
 1. You want to set webpacker.yml value of compile to true for your environment
    unless you are using the `webpack -w` or the webpack-dev-server.
-2. Webpack has not yet re-run to reflect updates.
+2. webpack has not yet re-run to reflect updates.
 3. You have misconfigured Webpacker's config/webpacker.yml file.
-4. Your Webpack configuration is not creating a manifest.
+4. Your webpack configuration is not creating a manifest.
 Your manifest contains:
 #{JSON.pretty_generate(@data)}
       MSG

--- a/lib/webpacker/runner.rb
+++ b/lib/webpacker/runner.rb
@@ -14,7 +14,7 @@ module Webpacker
       @webpack_config    = File.join(@app_path, "config/webpack/#{ENV["NODE_ENV"]}.js")
 
       unless File.exist?(@webpack_config)
-        $stderr.puts "webpack config #{@webpack_config} not found, please run 'bundle exec rails webpacker:install' to install webpacker with default configs or add the missing config file for your custom environment."
+        $stderr.puts "webpack config #{@webpack_config} not found, please run 'bundle exec rails webpacker:install' to install Webpacker with default configs or add the missing config file for your custom environment."
         exit!
       end
     end

--- a/lib/webpacker/runner.rb
+++ b/lib/webpacker/runner.rb
@@ -14,7 +14,7 @@ module Webpacker
       @webpack_config    = File.join(@app_path, "config/webpack/#{ENV["NODE_ENV"]}.js")
 
       unless File.exist?(@webpack_config)
-        $stderr.puts "Webpack config #{@webpack_config} not found, please run 'bundle exec rails webpacker:install' to install webpacker with default configs or add the missing config file for your custom environment."
+        $stderr.puts "webpack config #{@webpack_config} not found, please run 'bundle exec rails webpacker:install' to install webpacker with default configs or add the missing config file for your custom environment."
         exit!
       end
     end

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rails/webpacker",
   "version": "3.0.2",
-  "description": "Use Webpack to manage app-like JavaScript modules in Rails",
+  "description": "Use webpack to manage app-like JavaScript modules in Rails",
   "main": "package/index.js",
   "files": [
     "package"

--- a/webpacker.gemspec
+++ b/webpacker.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version  = Webpacker::VERSION
   s.authors  = [ "David Heinemeier Hansson", "Gaurav Tiwari" ]
   s.email    = [ "david@basecamp.com", "gaurav@gauravtiwari.co.uk" ]
-  s.summary  = "Use Webpack to manage app-like JavaScript modules in Rails"
+  s.summary  = "Use webpack to manage app-like JavaScript modules in Rails"
   s.homepage = "https://github.com/rails/webpacker"
   s.license  = "MIT"
   s.bindir   = "exe"


### PR DESCRIPTION
This changes all instances of "Webpacker" across the project (excluding those required in the code) to use title case for consistency, and similarly, to use lowercase for "webpack" as the [project branding guidelines](https://webpack.js.org/branding/#the-webpack-name) suggest.