### PR TITLE
Prefer `Module#cattr_accessor` over `Module#mattr_accessor`

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -4,11 +4,11 @@ require "digest/sha1"
 class Webpacker::Compiler
   # Additional paths that test compiler needs to watch
   # Webpacker::Compiler.watched_paths << 'bower_components'
-  mattr_accessor(:watched_paths) { [] }
+  cattr_accessor(:watched_paths) { [] }
 
   # Additional environment variables that the compiler is being run with
   # Webpacker::Compiler.env['FRONTEND_API_KEY'] = 'your_secret_key'
-  mattr_accessor(:env) { {} }
+  cattr_accessor(:env) { {} }
 
   delegate :config, :logger, to: :@webpacker
 

--- a/lib/webpacker/dev_server.rb
+++ b/lib/webpacker/dev_server.rb
@@ -1,7 +1,7 @@
 class Webpacker::DevServer
   # Configure dev server connection timeout (in seconds), default: 0.01
   # Webpacker.dev_server.connect_timeout = 1
-  mattr_accessor(:connect_timeout) { 0.01 }
+  cattr_accessor(:connect_timeout) { 0.01 }
 
   delegate :config, to: :@webpacker
 


### PR DESCRIPTION
`Webpacker::Compiler` and `Webpacker::DevServer` are not modules but classes.

So I feel it's a good to use `Module#cattr_accessor` instead of `Module#mattr_accessor`.
`Module#cattr_accessor` is an alias for `Module#mattr_accessor`:)