### PR TITLE
Yarn Integrity Check: New Rails initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ yarn upgrade @rails/webpacker --latest
 
 ### Yarn Integrity
 
-By default in development, webpacker runs a yarn integrity check to ensure that all local npm packages are up-to-date.  This is similar to what bundler does currently in Rails, but for Javascript packages.  If your system is out of date, then Rails will not initialize and you will be asked to upgrade your local npm packages by running `yarn install`.
+By default in development, webpacker runs a yarn integrity check to ensure that all local npm packages are up-to-date. This is similar to what bundler does currently in Rails, but for JavaScript packages. If your system is out of date, then Rails will not initialize and you will be asked to upgrade your local npm packages by running `yarn install`.
 
 To turn off this option, you will need to override the default by adding a new config options to your Rails development environment configuration file (`config/environment/development.rb`):
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ in which case you may not even need the asset pipeline. This is mostly relevant 
 - [Prerequisites](#prerequisites)
 - [Features](#features)
 - [Installation](#installation)
-  - [Upgrading](#upgrading)
   - [Usage](#usage)
   - [Development](#development)
   - [webpack configuration](#webpack-configuration)
+  - [Upgrading](#upgrading)
+  - [Yarn Integrity](#yarn-integrity)
 - [Integrations](#integrations)
   - [React](#react)
   - [Angular with TypeScript](#angular-with-typescript)
@@ -187,6 +188,22 @@ You can run following commands to upgrade Webpacker to the latest stable version
 ```bash
 bundle update webpacker
 yarn upgrade @rails/webpacker --latest
+```
+
+### Yarn Integrity
+
+By default in development, webpacker runs a yarn integrity check to ensure that all local npm packages are up-to-date.  This is similar to what bundler does currently in Rails, but for Javascript packages.  If your system is out of date, then Rails will not initialize and you will be asked to upgrade your local npm packages by running `yarn install`.
+
+To turn off this option, you will need to override the default by adding a new config options to your Rails development environment configuration file (`config/environment/development.rb`):
+
+```
+config.webpacker.check_yarn_integrity = false
+```
+
+You may also turn on this option by adding the config option to any Rails environment configuration file:
+
+```
+config.webpacker.check_yarn_integrity = true
 ```
 
 ## Integrations

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -4,7 +4,6 @@ require "webpacker/helper"
 require "webpacker/dev_server_proxy"
 
 class Webpacker::Railtie < ::Rails::Railtie
-
   # Allows webpacker config values to be set via rails env config files
   config.webpacker = ActiveSupport::OrderedOptions.new
 

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -4,7 +4,7 @@ require "webpacker/helper"
 require "webpacker/dev_server_proxy"
 
 class Webpacker::Railtie < ::Rails::Railtie
-  
+
   # Allows webpacker config values to be set via rails env config files
   config.webpacker = ActiveSupport::OrderedOptions.new
 
@@ -24,7 +24,7 @@ class Webpacker::Railtie < ::Rails::Railtie
   #     - edit config/environments/production.rb
   #     - add `config.webpacker.check_yarn_integrity = false`
   initializer "webpacker.yarn_check" do |app|
-    if app.config.webpacker[:check_yarn_integrity] || ( !app.config.webpacker.key?(:check_yarn_integrity) && Rails.env.development? )
+    if app.config.webpacker[:check_yarn_integrity] || (!app.config.webpacker.key?(:check_yarn_integrity) && Rails.env.development?)
       ok = system("yarn check --integrity")
 
       if !ok

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -4,7 +4,7 @@ require "webpacker/helper"
 require "webpacker/dev_server_proxy"
 
 class Webpacker::Railtie < ::Rails::Railtie
-  # Allows webpacker config values to be set via rails env config files
+  # Allows Webpacker config values to be set via Rails env config files
   config.webpacker = ActiveSupport::OrderedOptions.new
 
   # ================================
@@ -34,7 +34,7 @@ class Webpacker::Railtie < ::Rails::Railtie
         warn "========================================"
         warn "\n\n"
         warn "To disable this check, please add `config.webpacker.check_yarn_integrity = false`"
-        warn "to your Rails Development config file (config/environments/development.rb)."
+        warn "to your Rails development config file (config/environments/development.rb)."
         warn "\n\n"
 
         exit(1)


### PR DESCRIPTION
This adds a new initializer step into the Rails initialization process that runs a yarn integrity check by default for the development environment.  It is also configurable via the standard environment configuration files (`config/environments/development.rb`, etc).  

At User Testing we have found this check to be a really valuable addition to our local Rails setup.  It leverages the standard `yarn check --integrity` command which compares the exact local install state of npm packages with the expected state.  This check when it passes takes only an additional 20-30ms to complete.  Because Rails does not currently offer any way to ensure that npm packages are up-to-date, our team of over fifty engineers have run into multiple instances where having an incorrect set of local javascript packages can cause webpack to fail without reliable messaging.  In a majority of these cases, the problems are resolved by running `yarn install`.

This update also adds more info about this initializer and instructions for configuring it to `README.md`.