### PR TITLE
Skip check integrity if yarn.lock not exist

### DIFF
--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -16,6 +16,18 @@ directory "#{__dir__}/javascript", Webpacker.config.source_path
 say "Installing binstubs"
 run "bundle binstubs webpacker"
 
+say "Adding configurations"
+environment <<CONFIG, env: :development
+# Verifies that versions and hashed value of the package contents in the project's package.json
+config.webpacker.check_yarn_integrity = true
+
+CONFIG
+environment <<CONFIG, env: :production
+# Verifies that versions and hashed value of the package contents in the project's package.json
+config.webpacker.check_yarn_integrity = false
+
+CONFIG
+
 if File.exists?(".gitignore")
   append_to_file ".gitignore", <<-EOS
 /public/packs

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -6,6 +6,7 @@ require "webpacker/dev_server_proxy"
 class Webpacker::Railtie < ::Rails::Railtie
   # Allows Webpacker config values to be set via Rails env config files
   config.webpacker = ActiveSupport::OrderedOptions.new
+  config.webpacker.check_yarn_integrity = false
 
   # ================================
   # Check Yarn Integrity Initializer
@@ -23,7 +24,7 @@ class Webpacker::Railtie < ::Rails::Railtie
   #     - edit config/environments/production.rb
   #     - add `config.webpacker.check_yarn_integrity = false`
   initializer "webpacker.yarn_check" do |app|
-    if app.config.webpacker[:check_yarn_integrity] || (!app.config.webpacker.key?(:check_yarn_integrity) && Rails.env.development?)
+    if File.exist?("yarn.lock") && app.config.webpacker.check_yarn_integrity
       ok = system("yarn check --integrity")
 
       if !ok


### PR DESCRIPTION
Currently, when it doesn't exist `yarn.lock`, we cannot execute `rails webpacker:install`.

### Case

1. When It doesn't have `yarn.lock` file in Rails application, and it runs `bin/rails webpacker:install`.
2. Then it returns error messages:

```bash
$ bin/rails webpacker:install
yarn check v1.2.1
error Couldn't find an integrity file
error Found 1 errors.
info Visit https://yarnpkg.com/en/docs/cli/check for documentation about this command.


========================================
  Your Yarn packages are out of date!
  Please run `yarn install` to update.
========================================


To disable this check, please add `config.webpacker.check_yarn_integrity = false`
to your Rails development config file (config/environments/development.rb).
```

3. And it runs `yarn install`:

```bash
$ yarn install
yarn install v1.2.1
info No lockfile found.
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...

info Lockfile not saved, no dependencies.
✨  Done in 1.61s.
```

4. It doesn't save `yarn.lock`, and we cannot pass `yarn check --integrity` 😢 
5. If it doesn't exist `yarn.lock`, it's better not to check integrity.