### PR TITLE
Ignore check integrity on TestApp

### DIFF
--- a/test/test_app/config/application.rb
+++ b/test/test_app/config/application.rb
@@ -6,5 +6,6 @@ module TestApp
   class Application < ::Rails::Application
     config.secret_key_base = "abcdef"
     config.eager_load = true
+    config.webpacker.check_yarn_integrity = false
   end
 end


### PR DESCRIPTION
When it run `rake test`, it check yarn integrity on initializing TestApp.
So I think it is not necessarry to check yarn integrity on TestApp, and I turned off this :)