### PR TITLE
Enable test with edge Rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ gemfile:
   - gemfiles/Gemfile-rails.4.2.x
   - gemfiles/Gemfile-rails.5.0.x
   - gemfiles/Gemfile-rails.5.1.x
+  - gemfiles/Gemfile-rails-edge
 cache:
   bundler: true
   directories:
@@ -25,3 +26,6 @@ script:
   - yarn lint
   - bundle exec rubocop
   - bundle exec rake test
+matrix:
+  allow_failures:
+  - gemfile: gemfiles/Gemfile-rails-edge

--- a/gemfiles/Gemfile-rails-edge
+++ b/gemfiles/Gemfile-rails-edge
@@ -1,0 +1,13 @@
+source "https://rubygems.org"
+
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+gem "webpacker", path: ".."
+
+gem "rails", github: "rails/rails"
+gem "arel", github: "rails/arel"
+gem "rake", ">= 11.1"
+gem "rubocop", ">= 0.49", require: false
+gem "rack-proxy", require: false
+gem "minitest", "~> 5.0"
+gem "byebug"


### PR DESCRIPTION
Enabled tests with edge Rails to notice bugs or problems early.

But edge Rails has many changes, so I think it's better to allow failure on edge Rails.

---

It was able to configure without any problems :)

![](https://user-images.githubusercontent.com/15371677/31569758-5506cdca-b0b8-11e7-878b-13119dd53b1c.png)

---

And I noticed test failure on edge Rails (Maybe related [Rails#30744](https://github.com/rails/rails/pull/30744).)

But I'm going to open another pull request to fix this problem.

---

### Failure logs

```bash
$ bundle exec rake test
/home/travis/.rvm/rubies/ruby-2.2.8/bin/ruby -w -I"lib:test:lib" -I"/home/travis/.rvm/gems/ruby-2.2.8/gems/rake-12.1.0/lib" "/home/travis/.rvm/gems/ruby-2.2.8/gems/rake-12.1.0/lib/rake/rake_test_loader.rb" "test/command_test.rb" "test/compiler_test.rb" "test/configuration_test.rb" "test/dev_server_test.rb" "test/helper_test.rb" "test/manifest_test.rb" "test/rake_tasks_test.rb" 
Run options: --seed 7154
# Running:
......E
Error:
HelperTest#test_stylesheet_pack_tag_splat:
NoMethodError: undefined method `send_early_hints' for nil:NilClass
    /home/travis/.rvm/gems/ruby-2.2.8/bundler/gems/rails-680b853ddbdd/actionview/lib/action_view/helpers/asset_tag_helper.rb:143:in `stylesheet_link_tag'
    lib/webpacker/helper.rb:42:in `stylesheet_pack_tag'
    test/helper_test.rb:37:in `test_stylesheet_pack_tag_splat'
    minitest (5.10.3) lib/minitest/test.rb:107:in `block (3 levels) in run'
    minitest (5.10.3) lib/minitest/test.rb:204:in `capture_exceptions'
    minitest (5.10.3) lib/minitest/test.rb:104:in `block (2 levels) in run'
    minitest (5.10.3) lib/minitest/test.rb:255:in `time_it'
    minitest (5.10.3) lib/minitest/test.rb:103:in `block in run'
    minitest (5.10.3) lib/minitest.rb:350:in `on_signal'
    minitest (5.10.3) lib/minitest/test.rb:275:in `with_info_handler'
    minitest (5.10.3) lib/minitest/test.rb:102:in `run'
    minitest (5.10.3) lib/minitest.rb:839:in `run_one_method'
    minitest (5.10.3) lib/minitest.rb:324:in `run_one_method'
    minitest (5.10.3) lib/minitest.rb:311:in `block (2 levels) in run'
    minitest (5.10.3) lib/minitest.rb:310:in `each'
    minitest (5.10.3) lib/minitest.rb:310:in `block in run'
    minitest (5.10.3) lib/minitest.rb:350:in `on_signal'
    minitest (5.10.3) lib/minitest.rb:337:in `with_info_handler'
    minitest (5.10.3) lib/minitest.rb:309:in `run'
    minitest (5.10.3) lib/minitest.rb:159:in `block in __run'
    minitest (5.10.3) lib/minitest.rb:159:in `map'
    minitest (5.10.3) lib/minitest.rb:159:in `__run'
    minitest (5.10.3) lib/minitest.rb:136:in `run'
    minitest (5.10.3) lib/minitest.rb:63:in `block in autorun'
bin/rails test test/helper_test.rb:33
.E
Error:
HelperTest#test_stylesheet_pack_tag:
NoMethodError: undefined method `send_early_hints' for nil:NilClass
    /home/travis/.rvm/gems/ruby-2.2.8/bundler/gems/rails-680b853ddbdd/actionview/lib/action_view/helpers/asset_tag_helper.rb:143:in `stylesheet_link_tag'
    lib/webpacker/helper.rb:42:in `stylesheet_pack_tag'
    test/helper_test.rb:30:in `test_stylesheet_pack_tag'
    minitest (5.10.3) lib/minitest/test.rb:107:in `block (3 levels) in run'
    minitest (5.10.3) lib/minitest/test.rb:204:in `capture_exceptions'
    minitest (5.10.3) lib/minitest/test.rb:104:in `block (2 levels) in run'
    minitest (5.10.3) lib/minitest/test.rb:255:in `time_it'
    minitest (5.10.3) lib/minitest/test.rb:103:in `block in run'
    minitest (5.10.3) lib/minitest.rb:350:in `on_signal'
    minitest (5.10.3) lib/minitest/test.rb:275:in `with_info_handler'
    minitest (5.10.3) lib/minitest/test.rb:102:in `run'
    minitest (5.10.3) lib/minitest.rb:839:in `run_one_method'
    minitest (5.10.3) lib/minitest.rb:324:in `run_one_method'
    minitest (5.10.3) lib/minitest.rb:311:in `block (2 levels) in run'
    minitest (5.10.3) lib/minitest.rb:310:in `each'
    minitest (5.10.3) lib/minitest.rb:310:in `block in run'
    minitest (5.10.3) lib/minitest.rb:350:in `on_signal'
    minitest (5.10.3) lib/minitest.rb:337:in `with_info_handler'
    minitest (5.10.3) lib/minitest.rb:309:in `run'
    minitest (5.10.3) lib/minitest.rb:159:in `block in __run'
    minitest (5.10.3) lib/minitest.rb:159:in `map'
    minitest (5.10.3) lib/minitest.rb:159:in `__run'
    minitest (5.10.3) lib/minitest.rb:136:in `run'
    minitest (5.10.3) lib/minitest.rb:63:in `block in autorun'
bin/rails test test/helper_test.rb:27
E
Error:
HelperTest#test_javascript_pack_tag:
NoMethodError: undefined method `send_early_hints' for nil:NilClass
    /home/travis/.rvm/gems/ruby-2.2.8/bundler/gems/rails-680b853ddbdd/actionview/lib/action_view/helpers/asset_tag_helper.rb:94:in `javascript_include_tag'
    lib/webpacker/helper.rb:21:in `javascript_pack_tag'
    test/helper_test.rb:17:in `test_javascript_pack_tag'
    minitest (5.10.3) lib/minitest/test.rb:107:in `block (3 levels) in run'
    minitest (5.10.3) lib/minitest/test.rb:204:in `capture_exceptions'
    minitest (5.10.3) lib/minitest/test.rb:104:in `block (2 levels) in run'
    minitest (5.10.3) lib/minitest/test.rb:255:in `time_it'
    minitest (5.10.3) lib/minitest/test.rb:103:in `block in run'
    minitest (5.10.3) lib/minitest.rb:350:in `on_signal'
    minitest (5.10.3) lib/minitest/test.rb:275:in `with_info_handler'
    minitest (5.10.3) lib/minitest/test.rb:102:in `run'
    minitest (5.10.3) lib/minitest.rb:839:in `run_one_method'
    minitest (5.10.3) lib/minitest.rb:324:in `run_one_method'
    minitest (5.10.3) lib/minitest.rb:311:in `block (2 levels) in run'
    minitest (5.10.3) lib/minitest.rb:310:in `each'
    minitest (5.10.3) lib/minitest.rb:310:in `block in run'
    minitest (5.10.3) lib/minitest.rb:350:in `on_signal'
    minitest (5.10.3) lib/minitest.rb:337:in `with_info_handler'
    minitest (5.10.3) lib/minitest.rb:309:in `run'
    minitest (5.10.3) lib/minitest.rb:159:in `block in __run'
    minitest (5.10.3) lib/minitest.rb:159:in `map'
    minitest (5.10.3) lib/minitest.rb:159:in `__run'
    minitest (5.10.3) lib/minitest.rb:136:in `run'
    minitest (5.10.3) lib/minitest.rb:63:in `block in autorun'
bin/rails test test/helper_test.rb:14
E
Error:
HelperTest#test_javascript_pack_tag_splat:
NoMethodError: undefined method `send_early_hints' for nil:NilClass
    /home/travis/.rvm/gems/ruby-2.2.8/bundler/gems/rails-680b853ddbdd/actionview/lib/action_view/helpers/asset_tag_helper.rb:94:in `javascript_include_tag'
    lib/webpacker/helper.rb:21:in `javascript_pack_tag'
    test/helper_test.rb:24:in `test_javascript_pack_tag_splat'
    minitest (5.10.3) lib/minitest/test.rb:107:in `block (3 levels) in run'
    minitest (5.10.3) lib/minitest/test.rb:204:in `capture_exceptions'
    minitest (5.10.3) lib/minitest/test.rb:104:in `block (2 levels) in run'
    minitest (5.10.3) lib/minitest/test.rb:255:in `time_it'
    minitest (5.10.3) lib/minitest/test.rb:103:in `block in run'
    minitest (5.10.3) lib/minitest.rb:350:in `on_signal'
    minitest (5.10.3) lib/minitest/test.rb:275:in `with_info_handler'
    minitest (5.10.3) lib/minitest/test.rb:102:in `run'
    minitest (5.10.3) lib/minitest.rb:839:in `run_one_method'
    minitest (5.10.3) lib/minitest.rb:324:in `run_one_method'
    minitest (5.10.3) lib/minitest.rb:311:in `block (2 levels) in run'
    minitest (5.10.3) lib/minitest.rb:310:in `each'
    minitest (5.10.3) lib/minitest.rb:310:in `block in run'
    minitest (5.10.3) lib/minitest.rb:350:in `on_signal'
    minitest (5.10.3) lib/minitest.rb:337:in `with_info_handler'
    minitest (5.10.3) lib/minitest.rb:309:in `run'
    minitest (5.10.3) lib/minitest.rb:159:in `block in __run'
    minitest (5.10.3) lib/minitest.rb:159:in `map'
    minitest (5.10.3) lib/minitest.rb:159:in `__run'
    minitest (5.10.3) lib/minitest.rb:136:in `run'
    minitest (5.10.3) lib/minitest.rb:63:in `block in autorun'
bin/rails test test/helper_test.rb:20
...............
Finished in 0.634651s, 40.9674 runs/s, 88.2375 assertions/s.
26 runs, 56 assertions, 0 failures, 4 errors, 0 skips
rake aborted!
Command failed with status (1): [ruby -w -I"lib:test:lib" -I"/home/travis/.rvm/gems/ruby-2.2.8/gems/rake-12.1.0/lib" "/home/travis/.rvm/gems/ruby-2.2.8/gems/rake-12.1.0/lib/rake/rake_test_loader.rb" "test/command_test.rb" "test/compiler_test.rb" "test/configuration_test.rb" "test/dev_server_test.rb" "test/helper_test.rb" "test/manifest_test.rb" "test/rake_tasks_test.rb" ]
/home/travis/.rvm/gems/ruby-2.2.8/gems/rake-12.1.0/exe/rake:27:in `<top (required)>'
/home/travis/.rvm/gems/ruby-2.2.8/bin/ruby_executable_hooks:15:in `eval'
/home/travis/.rvm/gems/ruby-2.2.8/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```