### PR TITLE
Only extract CSS with dev server running and HMR enabled

### DIFF
--- a/package/loaders/style.js
+++ b/package/loaders/style.js
@@ -4,7 +4,8 @@ const { dev_server: devServer } = require('../config')
 
 const postcssConfigPath = path.resolve(process.cwd(), '.postcssrc.yml')
 const isProduction = process.env.NODE_ENV === 'production'
-const extractCSS = !(devServer && devServer.hmr)
+const inDevServer = process.argv.find(v => v.includes('webpack-dev-server'))
+const extractCSS = !(inDevServer && (devServer && devServer.hmr))
 
 const extractOptions = {
   fallback: 'style-loader',


### PR DESCRIPTION
Resolves https://github.com/rails/webpacker/issues/927.

We only want to try to extract CSS when the dev server is up and running and HMR is enabled. This matches the logic in the [`stylesheet_pack_tag` view helper](https://github.com/rails/webpacker/blob/master/lib/webpacker/helper.rb#L41), so we don't run into the issue of having a `link` tag on the page pointing to a stylesheet that is not being extracted.

Tested by running the normal rake tests, but most importantly using it in an app that I'm currently working on that is running into the same problems. Ran the same webpack config with both a dev server on and off, correctly extracted vs. inlined.