### PR TITLE
Fix proxy condition statement to prevent proxying wrong requests to dev server.

### DIFF
--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -9,7 +9,7 @@ class Webpacker::DevServerProxy < Rack::Proxy
   end
 
   def perform_request(env)
-    if env["PATH_INFO"] =~ /#{public_output_uri_path}/ && Webpacker.dev_server.running?
+    if env["PATH_INFO"].start_with?("/#{public_output_uri_path}") && Webpacker.dev_server.running?
       env["HTTP_HOST"] = env["HTTP_X_FORWARDED_HOST"] = env["HTTP_X_FORWARDED_SERVER"] = Webpacker.dev_server.host_with_port
 
       super(env)


### PR DESCRIPTION
I encountered a situation that webpacker will strangely proxy my request `/api/backpacks/123` to webapck dev server. After digging in the source code, I found `env["PATH_INFO"] =~ /#{public_output_uri_path}/` is the source of the problem.

Since `public_output_uri_path` is `"packs"` by default, the condition statement will be`env["PATH_INFO"] =~ /packs/` exactly, causing all requests whose path contains `packs` being proxyed to dev server.

If it is a bug, I am afraid if this change will break compatibility (seems like there is no test for `lib/webpacker/dev_server_proxy.rb`). If it is by design, I would like to know the right approach.