### PR TITLE
Forward http scheme when dev server is not https

### DIFF
--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -11,6 +11,7 @@ class Webpacker::DevServerProxy < Rack::Proxy
   def perform_request(env)
     if env["PATH_INFO"].start_with?("/#{public_output_uri_path}") && Webpacker.dev_server.running?
       env["HTTP_HOST"] = env["HTTP_X_FORWARDED_HOST"] = env["HTTP_X_FORWARDED_SERVER"] = Webpacker.dev_server.host_with_port
+      env["HTTP_X_FORWARDED_PROTO"] = "http" unless Webpacker.dev_server.https?
 
       super(env)
     else


### PR DESCRIPTION
In instances where the rails server is accepting https requests, but the webpack dev server is not, this will fail with a Rack SSLError. This allow the proxy to forward the scheme that the dev server is expecting

I didn't see any tests for the proxy itself, but if I missed them, please let me know

[Here](https://github.com/rack/rack/blob/master/lib/rack/request.rb#L186-L198)'s the relevant rack code that's handling this header downstream

Just realized this is a dup of https://github.com/rails/webpacker/pull/897. Closing