### PR TITLE
uses last digest file per environment

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -69,7 +69,7 @@ class Webpacker::Compiler
     end
 
     def compilation_digest_path
-      config.cache_path.join(".last-compilation-digest")
+      config.cache_path.join(".last-compilation-digest-#{Webpacker.env}")
     end
 
     def webpack_env

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -17,4 +17,8 @@ class CompilerTest < Minitest::Test
     assert Webpacker.compiler.stale?
     assert !Webpacker.compiler.fresh?
   end
+
+  def test_compilation_digest_path
+    assert Webpacker.compiler.send(:compilation_digest_path).to_s.ends_with?(Webpacker.env)
+  end
 end


### PR DESCRIPTION
If you're relying on the lazy compilation, bundles can get out of sync while running tests with the rails server running because test and dev compile to two different places (`public/packs-test` vs `public/packs`).

If you change a bundled Javascript file and run a system test it'll have the latest change. But if you refresh your browser, it won't. Here's a sample app that shows that, with steps to reproduce in the readme: https://github.com/gkemmey/webpacker_test

This is a potential fix that uses a `.last-compilation-digest` per environment.
