### PR TITLE
Disable Exhaustive Search in resolve-url-loader.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "postcss-loader": "^2.0.6",
     "postcss-smart-import": "^0.7.5",
     "rails-erb-loader": "^5.2.1",
-    "resolve-url-loader": "^2.1.0",
+    "resolve-url-loader": "^2.2.0",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.18.2",
     "webpack": "^3.5.5",

--- a/package/loaders/style.js
+++ b/package/loaders/style.js
@@ -12,7 +12,7 @@ const extractOptions = {
   use: [
     { loader: 'css-loader', options: { minimize: isProduction } },
     { loader: 'postcss-loader', options: { sourceMap: true, config: { path: postcssConfigPath } } },
-    'resolve-url-loader',
+    { loader: 'resolve-url-loader', options: { attempts: 0 } },
     { loader: 'sass-loader', options: { sourceMap: true } }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4337,9 +4337,9 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve-url-loader@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/resolve-url-loader/-/resolve-url-loader-2.1.0.tgz#27c95cc16a4353923fdbdc2dbaf5eef22232c477"
+resolve-url-loader@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/resolve-url-loader/-/resolve-url-loader-2.2.0.tgz#9662feaa11debf7cf8e3feb91dae9544aa7dee88"
   dependencies:
     adjust-sourcemap-loader "^1.1.0"
     camelcase "^4.0.0"


### PR DESCRIPTION
This PR closes rails/webpacker#932 by upgrading `resolve-url-loader` to version `2.2.0` and passing it the option hash `{ attempts: 0 }`.

See rails/webpacker#932 and bholloway/resolve-url-loader#69 for details.