### PR TITLE
Revert "Use Railtie instead of Engine"

### DIFF
--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -3,7 +3,7 @@ require "rails/railtie"
 require "webpacker/helper"
 require "webpacker/dev_server_proxy"
 
-class Webpacker::Railtie < ::Rails::Railtie
+class Webpacker::Engine < ::Rails::Engine
   # Allows Webpacker config values to be set via Rails env config files
   config.webpacker = ActiveSupport::OrderedOptions.new
   config.webpacker.check_yarn_integrity = false
@@ -76,10 +76,5 @@ class Webpacker::Railtie < ::Rails::Railtie
       Webpacker.bootstrap
       Spring.after_fork { Webpacker.bootstrap } if defined?(Spring)
     end
-  end
-
-  rake_tasks do
-    tasks_path = File.expand_path("../tasks", __dir__)
-    Dir.glob("#{tasks_path}/**/*.rake").sort.each { |ext| load ext }
   end
 end


### PR DESCRIPTION
assets:precompile task is not being enhanced and therefore not executing
webpacker:compile when referencing webpacker master branch on Gemfile,
reverting back to Engine fix the problem immediately.

This reverts commit 6586ef7a969716abb44d80acf8d32659405c0e10 and 2c0c7dc12d2f9d6fc8b68ba2dcf857797d663955.