### PR TITLE
Cross-origin warning in React error handler

### DIFF
--- a/lib/install/config/webpack/development.js
+++ b/lib/install/config/webpack/development.js
@@ -1,3 +1,6 @@
 const environment = require('./environment')
 
-module.exports = environment.toWebpackConfig()
+const config = environment.toWebpackConfig()
+config.devtool = 'cheap-module-source-map'
+
+module.exports = config


### PR DESCRIPTION
Hi! I recently came across this project and got the opportunity to apply it to an application I'm working on. I want to start by saying I am really impressed with how easy you guys made it to set this up. Great job!

I noticed when I was setting up for React that the error handler was getting masked by a cross-origin warning in development. For more information, check out React's documentation on [Webpack Cross-origin Errors](https://reactjs.org/docs/cross-origin-errors.html#webpack).

The warning occurs because the webpack bundle is wrapping the code in an `eval` statement which browsers treat as cross-origin. This PR changes the default webpack devtool to `cheap-module-source-map`.
