### PR TITLE
Deprecate as of 3.0.3 since it does exist in 3.0.2

### DIFF
--- a/package/config_types/config_list.js
+++ b/package/config_types/config_list.js
@@ -9,7 +9,7 @@ class ConfigList extends Array {
   }
 
   /**
-    * @deprecated Since 3.0.2 and will be removed in next major release
+    * @deprecated after the 3.0.2 release and will be removed in the next major release
   */
   set(key, value) {
     /* eslint no-console: 0 */


### PR DESCRIPTION
`ConfigList#set` was deprecated _after_ the 3.0.2 release, making the current deprecation message a bit misleading. Or perhaps it's confusing as "deprecated since" can be interpreted two ways?

Maybe a better solution would be to re-word the message?

> deprecated after the 3.0.2 release and will be removed in the next major release

Is that better?