### PR TITLE
Switch config.devtool from cheap-eval-source-map to cheap-module-source-map

### DIFF
--- a/package/environments/development.js
+++ b/package/environments/development.js
@@ -14,7 +14,7 @@ module.exports = class extends Environment {
     }
 
     this.config.merge({
-      devtool: 'cheap-eval-source-map',
+      devtool: 'cheap-module-source-map',
       output: {
         pathinfo: true
       },


### PR DESCRIPTION
This configuration plays nice with new CSP defaults in Rails 5.2

Related: https://github.com/rails/rails/pull/31162#issuecomment-347154237 https://github.com/rails/rails/issues/31258