### PR TITLE
Fix example test environment file in testing doc

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -43,7 +43,7 @@ environment.loaders.set('istanbul-instrumenter', {
   },
   exclude: ["node_modules", /\.test\.ts$/]
 }) /* optional */
-module.exports = environment
+module.exports = environment.toWebpackConfig()
 ```
 
 Finally, update `karma.conf.js` to read the same `test.js` file mentioned above. Rest of the things are mandatory (few marked as optional wherever appropriate).


### PR DESCRIPTION
Copying the example verbatim without ensuring "toWebpackConfig()" is present results in strange errors trying to run tests:

```
$ yarn test
yarn run v1.3.2
warning package.json: No license field
$ NODE_ENV=test karma start
TypeError: Cannot read property 'type' of undefined
    at Function.formatSchema (~/test/node_modules/webpack/lib/WebpackOptionsValidationError.js:72:13)
    at formatInnerSchema (~/test/node_modules/webpack/lib/WebpackOptionsValidationError.js:67:54)
    at Function.formatSchema (~/test/node_modules/webpack/lib/WebpackOptionsValidationError.js:95:15)
    at getSchemaPartText (~/test/node_modules/webpack/lib/WebpackOptionsValidationError.js:36:49)
    at Function.formatValidationError (~/test/node_modules/webpack/lib/WebpackOptionsValidationError.js:169:49)
    at WebpackOptionsValidationError.message.Invalid configuration object. .Webpack has been initialised using a configuration object that does not match the API schema.
.validationErrors.map.err (~/test/node_modules/webpack/lib/WebpackOptionsValidationError.js:57:77)
    at Array.map (<anonymous>)
    at new WebpackOptionsValidationError (~/test/node_modules/webpack/lib/WebpackOptionsValidationError.js:57:21)
    at webpack (~/test/node_modules/webpack/lib/webpack.js:19:9)
    at Plugin (~/test/node_modules/karma-webpack/lib/karma-webpack.js:67:16)
    at invoke (~/test/node_modules/di/lib/injector.js:75:15)
    at Array.instantiate (~/test/node_modules/di/lib/injector.js:59:20)
    at get (~/test/node_modules/di/lib/injector.js:48:43)
    at ~/test/node_modules/di/lib/injector.js:71:14
    at Array.map (<anonymous>)
    at Array.invoke (~/test/node_modules/di/lib/injector.js:70:31)
30 11 2017 10:06:34.262:ERROR [preprocess]: Can not load "webpack"!
  TypeError: Cannot read property 'type' of undefined
    at Function.formatSchema (~/test/node_modules/webpack/lib/WebpackOptionsValidationError.js:72:13)
    at formatInnerSchema (~/test/node_modules/webpack/lib/WebpackOptionsValidationError.js:67:54)
    at Function.formatSchema (~/test/node_modules/webpack/lib/WebpackOptionsValidationError.js:95:15)
    at getSchemaPartText (~/test/node_modules/webpack/lib/WebpackOptionsValidationError.js:36:49)
    at Function.formatValidationError (~/test/node_modules/webpack/lib/WebpackOptionsValidationError.js:169:49)
    at WebpackOptionsValidationError.message.Invalid configuration object. .Webpack has been initialised using a configuration object that does not match the API schema.
.validationErrors.map.err (~/test/node_modules/webpack/lib/WebpackOptionsValidationError.js:57:77)
    at Array.map (<anonymous>)
    at new WebpackOptionsValidationError (~/test/node_modules/webpack/lib/WebpackOptionsValidationError.js:57:21)
    at webpack (~/test/node_modules/webpack/lib/webpack.js:19:9)
    at Plugin (~/test/node_modules/karma-webpack/lib/karma-webpack.js:67:16)
    at invoke (~/test/node_modules/di/lib/injector.js:75:15)
    at Array.instantiate (~/test/node_modules/di/lib/injector.js:59:20)
    at get (~/test/node_modules/di/lib/injector.js:48:43)
    at ~/test/node_modules/di/lib/injector.js:71:14
    at Array.map (<anonymous>)
    at Array.invoke (~/test/node_modules/di/lib/injector.js:70:31)
module.js:544
    throw err;
```

