### PR TITLE
Go back to array list for resolved modules config

### DIFF
--- a/package/environment.js
+++ b/package/environment.js
@@ -54,11 +54,9 @@ const getEntryObject = () => {
 }
 
 const getModulePaths = () => {
-  const result = new ConfigList()
-  result.append('source', resolve(config.source_path))
-  result.append('node_modules', 'node_modules')
+  let result = [resolve(config.source_path), 'node_modules']
   if (config.resolved_paths) {
-    config.resolved_paths.forEach(path => result.append(basename(path), path))
+    result = result.concat(config.resolved_paths)
   }
   return result
 }
@@ -112,7 +110,7 @@ module.exports = class Environment {
       plugins: this.plugins.values(),
 
       resolve: {
-        modules: this.resolvedModules.values()
+        modules: this.resolvedModules
       }
     })
   }


### PR DESCRIPTION
`basename()` is overriding valid configs when it shouldn't for example
having this on webpacker.yml:

```yml
  resolved_paths: [
    'app/javascript/shared',
    'public/javascripts',
    'vendor/assets/javascripts'
  ]
```

produces:

```js
   ConfigList [
     { key: 'source', value: '/home/huoxito/Coding/project/app/javascript' },
     { key: 'node_modules', value: 'node_modules' },
     { key: 'shared', value: 'app/javascript/shared' },
     { key: 'javascripts', value: 'vendor/assets/javascripts' }
   ]
```
Note it's missing the 'public/javascripts' path ^^

We can work around on the app code side but I think it can be considered a regression? Paths listed in webpacker.yml shouldn't disappear while building the config object. Another option to fix it could be removing `basename` and having key / value being the path itself. Let me know I can try to amend the patch.

I'm trying to upgrade a project to 3.1.1 at the moment. Thanks for the release o/