### PR TITLE
Add asset_pack_url helper

### DIFF
--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -1,6 +1,6 @@
 module Webpacker::Helper
-  # Computes the full path for a given Webpacker asset.
-  # Return relative path using manifest.json and passes it to asset_url helper
+  # Computes the relative path for a given Webpacker asset.
+  # Return relative path using manifest.json and passes it to asset_path helper
   # This will use asset_path internally, so most of their behaviors will be the same.
   #
   # Example:
@@ -9,6 +9,18 @@ module Webpacker::Helper
   def asset_pack_path(name, **options)
     asset_path(Webpacker.manifest.lookup!(name), **options)
   end
+
+  # Computes the absolute path for a given Webpacker asset.
+  # Return absolute path using manifest.json and passes it to asset_url helper
+  # This will use asset_url internally, so most of their behaviors will be the same.
+  #
+  # Example:
+  #
+  #   <%= asset_pack_url 'calendar.css' %> # => "http://example.com/packs/calendar-1016838bab065ae1e122.css"
+  def asset_pack_url(name, **options)
+    asset_url(Webpacker.manifest.lookup!(name), **options)
+  end
+
   # Creates a script tag that references the named pack file, as compiled by webpack per the entries list
   # in config/webpack/shared.js. By default, this list is auto-generated to match everything in
   # app/javascript/packs/*.js. In production mode, the digested reference is automatically looked up.

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -8,12 +8,20 @@ class HelperTest < ActionView::TestCase
   def setup
     @request = Class.new do
       def send_early_hints(links) end
+      def base_url
+        "https://example.com"
+      end
     end.new
   end
 
   def test_asset_pack_path
     assert_equal "/packs/bootstrap-300631c4f0e0f9c865bc.js", asset_pack_path("bootstrap.js")
     assert_equal "/packs/bootstrap-c38deda30895059837cf.css", asset_pack_path("bootstrap.css")
+  end
+
+  def test_asset_pack_url
+    assert_equal "https://example.com/packs/bootstrap-300631c4f0e0f9c865bc.js", asset_pack_url("bootstrap.js")
+    assert_equal "https://example.com/packs/bootstrap-c38deda30895059837cf.css", asset_pack_url("bootstrap.css")
   end
 
   def test_javascript_pack_tag


### PR DESCRIPTION
As referenced in #1071, this adds a helper method for `asset_pack_url` which returns an absolute URL to an asset, much like `asset_url` would.