### PR TITLE
Gracefully handle missing node

### DIFF
--- a/lib/tasks/webpacker/check_node.rake
+++ b/lib/tasks/webpacker/check_node.rake
@@ -4,6 +4,7 @@ namespace :webpacker do
     begin
       begin
         node_version = `node -v`
+        raise Errno::ENOENT if node_version.blank?
       rescue Errno::ENOENT
         node_version = `nodejs -v`
         raise Errno::ENOENT if node_version.blank?

--- a/lib/tasks/webpacker/check_node.rake
+++ b/lib/tasks/webpacker/check_node.rake
@@ -2,13 +2,8 @@ namespace :webpacker do
   desc "Verifies if Node.js is installed"
   task :check_node do
     begin
-      begin
-        node_version = `node -v`
-        raise Errno::ENOENT if node_version.blank?
-      rescue Errno::ENOENT
-        node_version = `nodejs -v`
-        raise Errno::ENOENT if node_version.blank?
-      end
+      node_version = `node -v || nodejs -v`
+      raise Errno::ENOENT if node_version.blank?
 
       pkg_path = Pathname.new("#{__dir__}/../../../package.json").realpath
       node_requirement = JSON.parse(pkg_path.read)["engines"]["node"]


### PR DESCRIPTION
The `webpacker:check_node` task blows up when node is not installed.  The code that rescues `Errno::ENOENT` doesn't behave as expected when rails is loaded because [ActiveSupport monkeypatches Kernel#`]( https://github.com/rails/rails/blob/7d75599c875b081f63fc292e454b25e8e42eb60e/activesupport/lib/active_support/core_ext/kernel/agnostics.rb) to suppress raising Errno::ENOENT.  With this monkeypatch in place the code never reaches the fallback branch for legacy node versions introduced in https://github.com/rails/webpacker/pull/798.

We can fix this by manually raising the exception that the activesupport monkeypatch has suppressed.

Before:
```
$ bundle exec rake webpacker:check_node
[...]/gems/ruby-2.4.2/bin/rake: No such file or directory - node
rake aborted!
NoMethodError: undefined method `strip' for nil:NilClass
[...]/gems/webpacker-3.1.1/lib/tasks/webpacker/check_node.rake:16:in `block (2 levels) in <main>'
```

After:
```
$ bundle exec rake webpacker:check_node
[...]/gems/ruby-2.4.2/bin/rake: No such file or directory - node
[...]/gems/ruby-2.4.2/bin/rake: No such file or directory - nodejs
Node.js not installed. Please download and install Node.js https://nodejs.org/en/download/
```

Fixes https://github.com/rails/webpacker/issues/954