### PR TITLE
Fix invalid task name in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ bundle exec rails webpacker:install:vue
 bundle exec rails webpacker:install:angular
 bundle exec rails webpacker:install:elm
 bundle exec rails webpacker:install:erb
-bundle exec rails webpacker:install::coffee
+bundle exec rails webpacker:install:coffee
 ```
 
 Or simply copy required loaders used in your app from
@@ -69,7 +69,7 @@ environment.loaders.append('erb', erb)
 
 ```bash
 bundle exec rails webpacker:install:erb
-bundle exec rails webpacker:install::coffee
+bundle exec rails webpacker:install:coffee
 ```
 
 - Resolved paths from webpacker.yml to compiler watched list


### PR DESCRIPTION
```
$ bundle exec rails webpacker:install::coffee
rails aborted!
Don't know how to build task 'webpacker:install::coffee' (see --tasks)
Did you mean?  webpacker:install:coffee
               webpacker:install:elm
               webpacker:install:erb
               webpacker:install:vue
               webpacker:install:react
               webpacker:install:angular
bin/rails:4:in `require'
bin/rails:4:in `<main>'
(See full trace by running task with --trace)
```