### PR TITLE
.postcssrc.yml needs to be updated for 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ environment.loaders.append('elm', elm)
 environment.loaders.append('erb', erb)
 ```
 
+In `.postcssrc.yml` you need to change the plugin name from `postcss-smart-import` to `postcss-import`:
+
+```yml
+plugins:
+  postcss-import: {}
+  postcss-cssnext: {}
+```
+
 ### Added (npm module)
 
 - Upgrade gems and webpack dependencies


### PR DESCRIPTION
When updating to webpacker 3.2.0 I suddenly got the error message:

```
Webpacker::Manifest::MissingEntryError:

     #   Webpacker can't find contracts.css in /path-to/public/packs-test/manifest.json. Possible causes:
```

This was because I have something like this in a JSX file:

```js
import 'react-select/dist/react-select.css'
```

which was part of a pack named `contracts` that I'm including like this:

```erb
<%= stylesheet_pack_tag 'contracts' %>
```

Turns out, you need to change the name of the plugin in `.postcssrc.yml` to reflect the changes that 3.2.0 made and everything works like a charm again :)

Hope this helps others who stumble over this. Thanks everyone for your work!