### PR TITLE
Fix checking 'webpack' binstub on Windows

### DIFF
--- a/lib/tasks/webpacker/check_binstubs.rake
+++ b/lib/tasks/webpacker/check_binstubs.rake
@@ -1,7 +1,7 @@
 namespace :webpacker do
   desc "Verifies that webpack & webpack-dev-server are present."
   task :check_binstubs do
-    unless Bundler.which("webpack")
+    unless Bundler.which(Gem.win_platform? ? "webpack.bat" : "webpack")
       $stderr.puts "webpack binstubs not found.\n"\
            "Have you run rails webpacker:install ?\n"\
            "Make sure the bin directory or binstubs are not included in .gitignore\n"\


### PR DESCRIPTION
webpacker:check_binstubs doesn't work on Windows because `Bundler.which("webpack")` returns false on this platform. I'm not sure if it should be fixed on webpacker side, but anyway this error doesn't allow Windows users to run any of webpacker related tasks.