### PR TITLE
silence yarn output if checking is successfull

### DIFF
--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -25,9 +25,9 @@ class Webpacker::Engine < ::Rails::Engine
   #     - add `config.webpacker.check_yarn_integrity = false`
   initializer "webpacker.yarn_check" do |app|
     if File.exist?("yarn.lock") && app.config.webpacker.check_yarn_integrity
-      ok = system("yarn check --integrity")
+      output = `yarn check --integrity 2>&1`
 
-      if !ok
+      unless $?.success?
         warn "\n\n"
         warn "========================================"
         warn "  Your Yarn packages are out of date!"
@@ -36,6 +36,8 @@ class Webpacker::Engine < ::Rails::Engine
         warn "\n\n"
         warn "To disable this check, please add `config.webpacker.check_yarn_integrity = false`"
         warn "to your Rails development config file (config/environments/development.rb)."
+        warn "\n\n"
+        warn output
         warn "\n\n"
 
         exit(1)


### PR DESCRIPTION
on every `rake` or `rails` call I get this output:

```
yarn check v1.3.2
warning package.json: No license field
warning No license field
success Folder in sync.
✨  Done in 0.18s.
```

why not silence it if everything is in sync and only display it in case of errors?