### PR TITLE
Update typescript.md

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -35,7 +35,21 @@ yarn add ts-loader typescript @types/react @types/react-dom
 }
 ```
 
-3. Finally add `.tsx` to the list of extensions in `config/webpacker.yml`
+3. Edit `config/webpack/environment.js` and add ts-loader (webpacker@3.2.0 and above)
+
+```js
+const { environment } = require("@rails/webpacker");
+
+environment.loaders.set("typescript", {
+  test: /\.(tsx|ts)?$/,
+  use: "ts-loader"
+});
+
+module.exports = environment;
+```
+
+
+4. Finally add `.tsx` to the list of extensions in `config/webpacker.yml`
 and rename your generated `hello_react.js` using react installer
 to `hello_react.tsx` and make it valid typescript and now you can use
 typescript, JSX with React.


### PR DESCRIPTION
webpacker 3.2.0 has drastic changes in the `rules` directory.

https://github.com/rails/webpacker/tree/v3.1.1/package/rules
https://github.com/rails/webpacker/tree/v3.2.0/package/rules

If you don't add ts-loader in the environment.js, you will end up with this error.

```
ERROR in ./app/javascript/packs/hello_react.tsx
Module parse failed: Unexpected token (10:11)
You may need an appropriate loader to handle this file type.
| class Hello extends React.Component {
|   render() {
|     return <div>hello world</div>;
|   }
| }
 @ multi (webpack)-dev-server/client?http://localhost:3035 ./app/javascript/packs/hello_react.tsx
```