### PR TITLE
Fixes Vue root instance initialization

### DIFF
--- a/lib/install/examples/vue/hello_vue.js
+++ b/lib/install/examples/vue/hello_vue.js
@@ -9,10 +9,11 @@ import Vue from 'vue'
 import App from '../app.vue'
 
 document.addEventListener('DOMContentLoaded', () => {
-  document.body.appendChild(document.createElement('hello'))
+  const el = document.body.appendChild(document.createElement('hello'))
   const app = new Vue({
+    el,
     render: h => h(App)
-  }).$mount('hello')
+  })
 
   console.log(app)
 })


### PR DESCRIPTION
Initializes Vue the more common way by passing in `el` instead of mounting explicitly. Calling `$mount()` is a little weird and API-y.