### PR TITLE
Allow look ups to succeed even if the build was done on Windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gem "rails"
 gem "rake", ">= 11.1"
 gem "rubocop", ">= 0.49", require: false
 gem "rack-proxy", require: false
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 group :test do
   gem "minitest", "~> 5.0"

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "rake", ">= 11.1"
 gem "rubocop", ">= 0.49", require: false
 gem "rack-proxy", require: false
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 group :test do
   gem "minitest", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,8 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2017.3)
+      tzinfo (>= 1.0.0)
     unicode-display_width (1.3.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
@@ -138,6 +140,7 @@ DEPENDENCIES
   rails
   rake (>= 11.1)
   rubocop (>= 0.49)
+  tzinfo-data
   webpacker!
 
 BUNDLED WITH

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -28,24 +28,24 @@ class Webpacker::Manifest
   end
 
   private
-  def compiling?
-    config.compile? && !dev_server.running?
-  end
+    def compiling?
+      config.compile? && !dev_server.running?
+    end
 
-  def compile
-    Webpacker.logger.tagged("Webpacker") { compiler.compile }
-  end
+    def compile
+      Webpacker.logger.tagged("Webpacker") { compiler.compile }
+    end
 
-  def find(name)
-    data[name.to_s].presence
-  end
+    def find(name)
+      data[name.to_s].presence
+    end
 
-  def handle_missing_entry(name)
-    raise Webpacker::Manifest::MissingEntryError, missing_file_from_manifest_error(name)
-  end
+    def handle_missing_entry(name)
+      raise Webpacker::Manifest::MissingEntryError, missing_file_from_manifest_error(name)
+    end
 
-  def missing_file_from_manifest_error(bundle_name)
-    <<-MSG
+    def missing_file_from_manifest_error(bundle_name)
+      <<-MSG
 Webpacker can't find #{bundle_name} in #{config.public_manifest_path}. Possible causes:
 1. You want to set webpacker.yml value of compile to true for your environment
    unless you are using the `webpack -w` or the webpack-dev-server.
@@ -54,32 +54,32 @@ Webpacker can't find #{bundle_name} in #{config.public_manifest_path}. Possible 
 4. Your webpack configuration is not creating a manifest.
 Your manifest contains:
 #{JSON.pretty_generate(@data)}
-    MSG
-  end
-
-  def data
-    if config.cache_manifest?
-      @data ||= load
-    else
-      refresh
+      MSG
     end
-  end
 
-  def load
-    if config.public_manifest_path.exist?
-      data = JSON.parse config.public_manifest_path.read
-      #if the build was done on a windows box manifest.json will have backslashes as keys
-      #we will ensure lookups continue to succeed
-      data.keys.each do |key|
-        dup_key = String.new key #key is frozen
-        unless dup_key.gsub!('\\', '/').eql?(key)
-          dup_key.freeze
-          data[dup_key] = data[key]
-        end
+    def data
+      if config.cache_manifest?
+        @data ||= load
+      else
+        refresh
       end
-      data
-    else
-      {}
     end
-  end
+
+    def load
+      if config.public_manifest_path.exist?
+        data = JSON.parse config.public_manifest_path.read
+        #if the build was done on a windows box manifest.json will have backslashes as keys
+        #we will ensure lookups continue to succeed
+        data.keys.each do |key|
+          dup_key = String.new key #key is frozen
+          unless dup_key.gsub!("\\", "/").eql?(key)
+            dup_key.freeze
+            data[dup_key] = data[key]
+          end
+        end
+        data
+      else
+        {}
+      end
+    end
 end

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -28,24 +28,24 @@ class Webpacker::Manifest
   end
 
   private
-    def compiling?
-      config.compile? && !dev_server.running?
-    end
+  def compiling?
+    config.compile? && !dev_server.running?
+  end
 
-    def compile
-      Webpacker.logger.tagged("Webpacker") { compiler.compile }
-    end
+  def compile
+    Webpacker.logger.tagged("Webpacker") { compiler.compile }
+  end
 
-    def find(name)
-      data[name.to_s].presence
-    end
+  def find(name)
+    data[name.to_s].presence
+  end
 
-    def handle_missing_entry(name)
-      raise Webpacker::Manifest::MissingEntryError, missing_file_from_manifest_error(name)
-    end
+  def handle_missing_entry(name)
+    raise Webpacker::Manifest::MissingEntryError, missing_file_from_manifest_error(name)
+  end
 
-    def missing_file_from_manifest_error(bundle_name)
-      <<-MSG
+  def missing_file_from_manifest_error(bundle_name)
+    <<-MSG
 Webpacker can't find #{bundle_name} in #{config.public_manifest_path}. Possible causes:
 1. You want to set webpacker.yml value of compile to true for your environment
    unless you are using the `webpack -w` or the webpack-dev-server.
@@ -54,22 +54,32 @@ Webpacker can't find #{bundle_name} in #{config.public_manifest_path}. Possible 
 4. Your webpack configuration is not creating a manifest.
 Your manifest contains:
 #{JSON.pretty_generate(@data)}
-      MSG
-    end
+    MSG
+  end
 
-    def data
-      if config.cache_manifest?
-        @data ||= load
-      else
-        refresh
-      end
+  def data
+    if config.cache_manifest?
+      @data ||= load
+    else
+      refresh
     end
+  end
 
-    def load
-      if config.public_manifest_path.exist?
-        JSON.parse config.public_manifest_path.read
-      else
-        {}
+  def load
+    if config.public_manifest_path.exist?
+      data = JSON.parse config.public_manifest_path.read
+      #if the build was done on a windows box manifest.json will have backslashes as keys
+      #we will ensure lookups continue to succeed
+      data.keys.each do |key|
+        dup_key = String.new key #key is frozen
+        unless dup_key.gsub!('\\', '/').eql?(key)
+          dup_key.freeze
+          data[dup_key] = data[key]
+        end
       end
+      data
+    else
+      {}
     end
+  end
 end


### PR DESCRIPTION
This is a fix for:

https://github.com/rails/webpacker/issues/1174

Originally, when I wrote up the defect I assumed the gem was writing the manifest.json file.  By holding a lock to manifest.json the stack trace reveals:

```
Error: EBUSY: resource busy or locked, open 'C:\work\VSO\vso\public\packs\manifest.json'
    at Object.fs.openSync (fs.js:646:18)
    at Object.fs.writeFileSync (fs.js:1291:33)
    at Object.outputFileSync (C:\work\VSO\vso\node_modules\fs-extra\lib\output\index.js:26:29)
    at ManifestPlugin.<anonymous> (C:\work\VSO\vso\node_modules\webpack-manifest-plugin\lib\plugin.js:158:11)
    at Compiler.applyPluginsAsyncSeries (C:\work\VSO\vso\node_modules\tapable\lib\Tapable.js:206:13)
    at Compiler.emitAssets (C:\work\VSO\vso\node_modules\webpack\lib\Compiler.js:354:8)
    at onCompiled (C:\work\VSO\vso\node_modules\webpack\lib\Compiler.js:58:19)
    at applyPluginsAsync.err (C:\work\VSO\vso\node_modules\webpack\lib\Compiler.js:510:14)
    at next (C:\work\VSO\vso\node_modules\tapable\lib\Tapable.js:202:11)
    at Compiler.<anonymous> (C:\work\VSO\vso\node_modules\webpack\lib\CachePlugin.js:78:5)
```

That the manifest file is written in node code by fs-extra.  A cursory examination leads me to believe that the code is technically correct (when running on Windows) since it is converting a file object to a string.

An alternative approach might be to get the node dependent library to support a flag to force UNIX style slashes.

The hash duplicates keys so, if running on a windows box, both look ups succeed:
'''
    <%=stylesheet_pack_tag 'stylesheets/layout' %>
'''
and
'''
    <%=stylesheet_pack_tag "stylesheets\\layout" %>
'''
Although I doubt any windows people would take the second approach (but both were tested in a deployed war file running in production mode).

I don't have a unix box at the moment to do that level of sanity testing.


