### PR TITLE
Install some npm libraries as devDependencies

### DIFF
--- a/lib/install/coffee.rb
+++ b/lib/install/coffee.rb
@@ -20,6 +20,6 @@ copy_file "#{__dir__}/examples/coffee/hello_coffee.coffee",
   "#{Webpacker.config.source_entry_path}/hello_coffee.coffee"
 
 say "Installing all Coffeescript dependencies"
-run "yarn add coffeescript@1.12.7 coffee-loader"
+run "yarn add --dev coffeescript@1.12.7 coffee-loader"
 
 say "Webpacker now supports Coffeeescript 🎉", :green

--- a/lib/install/elm.rb
+++ b/lib/install/elm.rb
@@ -21,8 +21,8 @@ copy_file "#{__dir__}/examples/elm/Main.elm",
   "#{Webpacker.config.source_path}/Main.elm"
 
 say "Installing all Elm dependencies"
-run "yarn add elm elm-webpack-loader"
-run "yarn add --dev elm-hot-loader"
+run "yarn add elm"
+run "yarn add --dev elm-hot-loader elm-webpack-loader"
 run "yarn run elm package install -- --yes"
 
 say "Updating webpack paths to include .elm file extension"

--- a/lib/install/erb.rb
+++ b/lib/install/erb.rb
@@ -20,6 +20,6 @@ copy_file "#{__dir__}/examples/erb/hello_erb.js.erb",
   "#{Webpacker.config.source_entry_path}/hello_erb.js.erb"
 
 say "Installing all Erb dependencies"
-run "yarn add rails-erb-loader"
+run "yarn add --dev rails-erb-loader"
 
 say "Webpacker now supports Erb in JS 🎉", :green

--- a/lib/install/typescript.rb
+++ b/lib/install/typescript.rb
@@ -41,6 +41,6 @@ copy_file "#{__dir__}/examples/typescript/hello_typescript.ts",
   "#{Webpacker.config.source_entry_path}/hello_typescript.ts"
 
 say "Installing all typescript dependencies"
-run "yarn add typescript ts-loader #{additional_packages}"
+run "yarn add --dev typescript ts-loader #{additional_packages}"
 
 say "Webpacker now supports typescript 🎉", :green

--- a/lib/install/vue.rb
+++ b/lib/install/vue.rb
@@ -24,6 +24,7 @@ copy_file "#{__dir__}/examples/vue/app.vue",
   "#{Webpacker.config.source_path}/app.vue"
 
 say "Installing all Vue dependencies"
-run "yarn add vue vue-loader vue-template-compiler"
+run "yarn add vue"
+run "yarn add --dev vue-loader vue-template-compiler"
 
 say "Webpacker now supports Vue.js 🎉", :green


### PR DESCRIPTION
Hello maintainers.

When I tried to use some installers, I found that some of npm libraries which should locate in `devDependencies` are in `dependencies` section in package.json.

So I just tweaked the installation scripts.