### PR TITLE
Install and require initializers

### DIFF
--- a/lib/install/javascript/initializers/hello.js
+++ b/lib/install/javascript/initializers/hello.js
@@ -1,0 +1,1 @@
+console.log('Hello World from a Webpacker initializer')

--- a/lib/install/javascript/initializers/index.js
+++ b/lib/install/javascript/initializers/index.js
@@ -1,0 +1,2 @@
+const importAll = (r) => r.keys().forEach(r)
+importAll(require.context('.', true, /\.js$/));

--- a/lib/install/javascript/packs/application.js
+++ b/lib/install/javascript/packs/application.js
@@ -7,4 +7,5 @@
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
 
+import '../initializers';
 console.log('Hello World from Webpacker')


### PR DESCRIPTION
Fixes #1207 

This is perhaps the most straightforward way I know of to require all files in a directory. There are Webpack plugins that may provide similar functionality, but would also require the developer to learn extra configuration to modify.

https://webpack.js.org/guides/dependency-management/#require-context