### PR TITLE
Fix config to resolve extensions as specified in webpacker.yml

### DIFF
--- a/package/__tests__/environment.js
+++ b/package/__tests__/environment.js
@@ -70,5 +70,22 @@ describe('Environment', () => {
       expect(config.plugins).toBeInstanceOf(Array)
       expect(config.plugins).not.toBeInstanceOf(ConfigList)
     })
+
+    test('should return resolve extensions as listed in app config', () => {
+      const config = environment.toWebpackConfig()
+
+      expect(config.resolve.extensions).toEqual([
+        '.jsx',
+        '.js',
+        '.sass',
+        '.scss',
+        '.css',
+        '.png',
+        '.svg',
+        '.gif',
+        '.jpeg',
+        '.jpg',
+      ])
+    })
   })
 })

--- a/package/config.js
+++ b/package/config.js
@@ -9,6 +9,9 @@ const filePath = resolve('config', 'webpacker.yml')
 const environment = process.env.NODE_ENV || 'development'
 const defaultConfig = safeLoad(readFileSync(defaultFilePath), 'utf8')[environment]
 const appConfig = safeLoad(readFileSync(filePath), 'utf8')[environment]
+
+if (appConfig.extensions !== undefined) delete defaultConfig.extensions
+
 const config = deepMerge(defaultConfig, appConfig)
 
 const isBoolean = str => /^true/.test(str) || /^false/.test(str)

--- a/test/test_app/config/webpacker.yml
+++ b/test/test_app/config/webpacker.yml
@@ -16,6 +16,7 @@ default: &default
   cache_manifest: false
 
   extensions:
+    - .jsx
     - .js
     - .sass
     - .scss


### PR DESCRIPTION
Fixes https://github.com/rails/webpacker/issues/1225

### Problem
When we are deep-merging `defaultConfig.resolve.extensions` with `appConfig.resolve.extensions`, it ignores ordering of extensions specified in `appConfig` and always includes all `defaultConfig.resolve.extensions` and if there is something new presented in `appConfig` it will add it at the end of the array.
It results in some unexpected behavior as in this issue https://github.com/rails/webpacker/issues/1225.

### Solution
Overwrite default `config.resolve.extensions` if it presented in user's `appConfig`.