### PR TITLE
Removed unnecessary activesupport explicit dependency.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     webpacker (3.2.1)
-      activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
 

--- a/webpacker.gemspec
+++ b/webpacker.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.2.0"
 
-  s.add_dependency "activesupport", ">= 4.2"
   s.add_dependency "railties",      ">= 4.2"
   s.add_dependency "rack-proxy",    ">= 0.6.1"
 


### PR DESCRIPTION
railties >= 4.2 already has activesupport runtime dependency, https://github.com/rails/rails/blob/master/railties/railties.gemspec