### PR TITLE
Fix typo in the hello_* examples

### DIFF
--- a/lib/install/examples/coffee/hello_coffee.coffee
+++ b/lib/install/examples/coffee/hello_coffee.coffee
@@ -1,4 +1,4 @@
-# Run this example by adding <%%= javascript_pack_tag 'hello_coffee' %> to the head of your layout file,
+# Run this example by adding <%= javascript_pack_tag 'hello_coffee' %> to the head of your layout file,
 # like app/views/layouts/application.html.erb.
 
 console.log 'Hello world from coffeescript'

--- a/lib/install/examples/erb/hello_erb.js.erb
+++ b/lib/install/examples/erb/hello_erb.js.erb
@@ -1,4 +1,4 @@
-// Run this example by adding <%%= javascript_pack_tag 'hello_erb' %> to the head of your layout file,
+// Run this example by adding <%= javascript_pack_tag 'hello_erb' %> to the head of your layout file,
 // like app/views/layouts/application.html.erb.
 
 <% name = 'Erb' %>

--- a/lib/install/examples/typescript/hello_typescript.ts
+++ b/lib/install/examples/typescript/hello_typescript.ts
@@ -1,4 +1,4 @@
-// Run this example by adding <%%= javascript_pack_tag 'hello_typescript' %> to the head of your layout file,
+// Run this example by adding <%= javascript_pack_tag 'hello_typescript' %> to the head of your layout file,
 // like app/views/layouts/application.html.erb.
 
 console.log('Hello world from typescript');


### PR DESCRIPTION
This seems to be a typo / copy&paste error. 