### PR TITLE
Add line break after check_yarn_integrity template config

### DIFF
--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -18,9 +18,18 @@ run "bundle binstubs webpacker"
 
 say "Adding configurations"
 
+check_yarn_integrity_config = ->(value) { <<CONFIG }
 # Verifies that versions and hashed value of the package contents in the project's package.json
-inject_into_file "config/environments/development.rb", "  config.webpacker.check_yarn_integrity = true", after: "Rails.application.configure do\n", verbose: false
-inject_into_file "config/environments/production.rb", "  config.webpacker.check_yarn_integrity = false", after: "Rails.application.configure do\n", verbose: false
+  config.webpacker.check_yarn_integrity = #{value}
+CONFIG
+
+if Rails::VERSION::MAJOR >= 5
+  environment check_yarn_integrity_config.call("true"), env: :development
+  environment check_yarn_integrity_config.call("false"), env: :production
+else
+  inject_into_file "config/environments/development.rb", "\n  #{check_yarn_integrity_config.call("true")}", after: "Rails.application.configure do", verbose: false
+  inject_into_file "config/environments/production.rb", "\n  #{check_yarn_integrity_config.call("false")}", after: "Rails.application.configure do", verbose: false
+end
 
 if File.exists?(".gitignore")
   append_to_file ".gitignore", <<-EOS


### PR DESCRIPTION
This fix the issue mentioned in [this comment](https://github.com/rails/webpacker/pull/1182#commitcomment-27144337).

I also think that it is good to keep using Rails 5 API whenever we can. Being explicit about it prevents someone changing back to newer API before we drop support for Rails 4.2.