### PR TITLE
bump version number in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Or add it to your `Gemfile`:
 
 ```ruby
 # Gemfile
-gem 'webpacker', '~> 3.0'
+gem 'webpacker', '~> 3.2'
 
 # OR if you prefer to use master
 gem 'webpacker', git: 'https://github.com/rails/webpacker.git'


### PR DESCRIPTION
Hello!

Thanks for the gem, I think I will use it a lot.

I see that the version listed on the README instruction is not up to date yet. On the old 3.0 version webpacker:install failed to create node_modules directory. Took me awhile to figure out I'm using the old version. Hopefully this simple change can save some little frustration on future newcomer