### PR TITLE
Preserve the order of the source when deep-merging arrays.

### DIFF
--- a/package/utils/__tests__/deep_merge.js
+++ b/package/utils/__tests__/deep_merge.js
@@ -5,6 +5,6 @@ const deepMerge = require('../deep_merge')
 test('deep merge objects together', () => {
   const object1 = { foo: { bar: [1, 2, 3], z: 1 }, x: 0 }
   const object2 = { foo: { bar: ['x', 'y'] }, x: 1, y: 2 }
-  const expectation = { foo: { bar: [1, 2, 3, 'x', 'y'], z: 1 }, x: 1, y: 2 }
+  const expectation = { foo: { bar: ['x', 'y', 1, 2, 3], z: 1 }, x: 1, y: 2 }
   expect(deepMerge(object1, object2)).toEqual(expectation)
 })

--- a/package/utils/deep_merge.js
+++ b/package/utils/deep_merge.js
@@ -6,7 +6,7 @@ const deepMerge = (target, source) => {
   if (isEmpty(target)) return source
   if (isEmpty(source)) return target
   if (isEqual(target, source)) return source
-  if (isArray(target) && isArray(source)) return [...new Set([...target, ...source])]
+  if (isArray(target) && isArray(source)) return [...new Set([...source, ...target])]
   if (!(isObject(target) && isObject(source))) return source
 
   return [...Object.keys(target), ...Object.keys(source)].reduce(


### PR DESCRIPTION
I might have applied this change at too low a level, but I'll explain the problem we're having.

Say the default config in this package says, as it does right now:

```yml
  extensions:
    - .js
    - .sass
    - .scss
    - .css
    # etc.
```

Our app config has this:

```yml
  extensions:
    - .js
    - .jsx
    - .scss
    # etc.
```

We need `.jsx` to come before `.scss` in the priority order for resolving modules so that code like `import Foo from './foo'` imports `foo.jsx` rather than `foo.scss` which exists in the same directory. The way this package currently merges configs means that `.scss` appears before `.jsx` in `resolve.extensions`.

Merging lists between the default and app config makes sense, but we would like the order of our extensions to be preserved. I can see two main ways of doing this:

1. Reverse the order of the arguments to `deepMerge()` when merging configs. Unfortunately, for objects, this would result in values in the defaults overriding those from the app.

2. Make `deepMerge()` swap the argument order for arrays so that the source order is preserved. This does not result in values from the app being 'overridden' by the defaults, because that's not how arrays work. All it means is the result contains all the values from both inputs, but the order of values present in the app is preserved.

This approach makes sense for cases where the defaults are really expressing a set where the order is unimportant, but the app needs to specify an order. If the defaults do express an order then a different approach might be needed, or app developers also need to be aware that their order matters.