### PR TITLE
Hash files based on output rather than source

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.6.1",
-    "jest": "^22.2.1"
+    "jest": "^22.2.1",
+    "webpack-plugin-hash-output": "^1.3.0"
   },
   "jest": {
     "testRegex": "(/__tests__/.*|(\\.|/))\\.jsx?$",

--- a/package/__tests__/environment.js
+++ b/package/__tests__/environment.js
@@ -46,7 +46,7 @@ describe('Environment', () => {
 
     test('should return default plugins', () => {
       const config = environment.toWebpackConfig()
-      expect(config.plugins.length).toEqual(4)
+      expect(config.plugins.length).toEqual(5)
     })
 
     test('should return default resolveLoader', () => {

--- a/package/environment.js
+++ b/package/environment.js
@@ -11,6 +11,7 @@ const webpack = require('webpack')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const ManifestPlugin = require('webpack-manifest-plugin')
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin')
+const HashOutputPlugin = require('webpack-plugin-hash-output')
 
 const { ConfigList, ConfigObject } = require('./config_types')
 const rules = require('./rules')
@@ -28,6 +29,7 @@ const getPluginList = () => {
   result.append('CaseSensitivePaths', new CaseSensitivePathsPlugin())
   result.append('ExtractText', new ExtractTextPlugin('[name]-[contenthash].css'))
   result.append('Manifest', new ManifestPlugin({ publicPath: config.publicPath, writeToFileEmit: true }))
+  result.append('HashOutput', new HashOutputPlugin())
   return result
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5922,6 +5922,10 @@ webpack-manifest-plugin@^1.3.2:
     fs-extra "^0.30.0"
     lodash ">=3.5 <5"
 
+webpack-plugin-hash-output@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/webpack-plugin-hash-output/-/webpack-plugin-hash-output-1.3.0.tgz#998eb655bc2216fca95608735645f9c752532ce6"
+
 webpack-sources@^1.0.1, webpack-sources@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"


### PR DESCRIPTION
By default webpack hashes files based on their source contents, when doing any sort of uglification or transpiling this allows the output to change without the digest changing.

This is a known issue(https://github.com/webpack/webpack/issues/4659) and has an actively maintained plugin written specifically to alleviate that issue (https://www.npmjs.com/package/webpack-plugin-hash-output).

This patch set adds a dependency on `webpack-plugin-hash-output` and adds it to the default plugin list so that any projects which depend on webpacker's environment will have properly generated hashes that will work with caching.