### PR TITLE
use NODE_ENV for development

### DIFF
--- a/package/rules/css.js
+++ b/package/rules/css.js
@@ -4,8 +4,9 @@ const { dev_server: devServer } = require('../config')
 
 const postcssConfigPath = path.resolve(process.cwd(), '.postcssrc.yml')
 const isProduction = process.env.NODE_ENV === 'production'
+const isDevelopment = process.env.NODE_ENV === 'development'
 const inDevServer = process.argv.find(v => v.includes('webpack-dev-server'))
-const isHMR = inDevServer && (devServer && devServer.hmr)
+const isHMR = (inDevServer || isDevelopment) && (devServer && devServer.hmr)
 const extractCSS = !(isHMR) || isProduction
 
 const styleLoader = {


### PR DESCRIPTION
The code currently requires the process name to match 'webpack-dev-server' in order to not use the ExtractTextPlugin loader.

This changes the code to check for  `NODE_ENV === 'development'` and sets the non `ExtractTextPlugin` versions of the loaders unless the env is production.

This allows the usage of other applications, like Storybook, to reuse the same configuration in development that work with HMR.

I'm guessing that there was a reason why `NODE_ENV` couldn't be used for this. If that's the case, I understand. But, there still should be a way to override the settings to allow the non extracted versions of the loaders to be used, outside of modifying the process name.