### PR TITLE
Fix compilation for environments that are not test, development or production

### DIFF
--- a/package/config.js
+++ b/package/config.js
@@ -11,7 +11,7 @@ const environment = process.env.NODE_ENV || 'development'
 const defaultConfig = safeLoad(readFileSync(defaultFilePath), 'utf8')[environment]
 const appConfig = safeLoad(readFileSync(filePath), 'utf8')[environment]
 
-if (isArray(appConfig.extensions) && appConfig.extensions.length) {
+if (isArray(appConfig.extensions) && appConfig.extensions.length && defaultConfig) {
   delete defaultConfig.extensions
 } else {
   /* eslint no-console: 0 */


### PR DESCRIPTION
The changes introduced with #1253 (and therefore v3.2.2) will fail the compilation with:

`TypeError: Cannot convert undefined or null to object`

if the environment is something that is not in the default configs, for
example "staging". With this change, we don't try to delete from the
defaultConfig if there is no default config.

Test suite didn't work on my machine at all and I'm a bit short on time right now, but given that this fix is relatively straight forward, I thought it might be not too bad :)