### PR TITLE
Allow custom RAILS_ENV

### DIFF
--- a/package/config.js
+++ b/package/config.js
@@ -11,7 +11,7 @@ const environment = process.env.NODE_ENV || 'development'
 const defaultConfig = safeLoad(readFileSync(defaultFilePath), 'utf8')[environment]
 const appConfig = safeLoad(readFileSync(filePath), 'utf8')[environment]
 
-if (isArray(appConfig.extensions) && appConfig.extensions.length) {
+if (isArray(appConfig.extensions) && appConfig.extensions.length && defaultConfig) {
   delete defaultConfig.extensions
 } else {
   /* eslint no-console: 0 */


### PR DESCRIPTION
When executing `RAILS_ENV=staging bin/rails assets:precompile`, following error is raised. This PR fix it.

```
[..snip..]
Webpacker is installed 🎉 🍰
Using /var/www/myapp/releases/20180216111626/config/webpacker.yml file for setting up webpack paths
Compiling…
Compilation failed:

/var/www/myapp/releases/20180216111626/node_modules/@rails/webpacker/package/config.js:15
  delete defaultConfig.extensions
  ^

TypeError: Cannot convert undefined or null to object
    at Object.<anonymous> (/var/www/myapp/releases/20180216111626/node_modules/@rails/webpacker/package/config.js:15:3)
    at Module._compile (module.js:641:30)
    at Object.Module._extensions..js (module.js:652:10)
    at Module.load (module.js:560:32)
    at tryModuleLoad (module.js:503:12)
    at Function.Module._load (module.js:495:3)
    at Module.require (module.js:585:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/var/www/myapp/releases/20180216111626/node_modules/@rails/webpacker/package/rules/babel.js:2:24)
    at Module._compile (module.js:641:30)
rake stderr: Nothing written
```