### PR TITLE
Add binstubs task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 **Please note that Webpacker 3.1.0 and 3.1.1 has some serious bugs so please consider using either 3.0.2 or 3.2.0**
 ## Unreleased
 
+### Added
+
+- Separate task for installing/updating binstubs
+
 ### Breaking changes
 
-- Fixes #1281 by installing binstubs only as local executables. To upgrade, run the install task and make sure the executables in the `bin` directory are overwritten.
+- Fixes #1281 by installing binstubs only as local executables. To upgrade:
+
+```
+bundle exec rails webpacker:binstubs
+```
 
 ## [3.2.2] - 2018-02-11
 

--- a/lib/install/binstubs.rb
+++ b/lib/install/binstubs.rb
@@ -1,0 +1,4 @@
+say "Copying binstubs"
+directory "#{__dir__}/bin", "bin"
+
+chmod "bin", 0755 & ~File.umask, verbose: false

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -13,10 +13,7 @@ copy_file "#{__dir__}/config/.babelrc", ".babelrc"
 say "Creating JavaScript app source directory"
 directory "#{__dir__}/javascript", Webpacker.config.source_path
 
-say "Copying binstubs"
-directory "#{__dir__}/bin", "bin"
-
-chmod "bin", 0755 & ~File.umask, verbose: false
+apply "#{__dir__}/binstubs.rb"
 
 say "Adding configurations"
 

--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -5,6 +5,7 @@ tasks = {
   "webpacker:check_node"              => "Verifies if Node.js is installed",
   "webpacker:check_yarn"              => "Verifies if Yarn is installed",
   "webpacker:check_binstubs"          => "Verifies that webpack & webpack-dev-server are present",
+  "webpacker:binstubs"                => "Installs Webpacker binstubs in this application",
   "webpacker:verify_install"          => "Verifies if Webpacker is installed",
   "webpacker:yarn_install"            => "Support for older Rails versions. Install all JavaScript dependencies as specified via Yarn",
   "webpacker:install:react"           => "Installs and setup example React component",

--- a/lib/tasks/webpacker/binstubs.rake
+++ b/lib/tasks/webpacker/binstubs.rake
@@ -1,0 +1,12 @@
+binstubs_template_path = File.expand_path("../../install/binstubs.rb", __dir__).freeze
+
+namespace :webpacker do
+  desc "Installs Webpacker binstubs in this application"
+  task binstubs: [:check_node, :check_yarn] do
+    if Rails::VERSION::MAJOR >= 5
+      exec "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{binstubs_template_path}"
+    else
+      exec "#{RbConfig.ruby} ./bin/rake rails:template LOCATION=#{binstubs_template_path}"
+    end
+  end
+end


### PR DESCRIPTION
Adds a new task `rails webpacker:binstubs` for copying the webpacker executables into Rails projects.

Allows devs to generate binstubs without having to run the whole install task, effectively replacing `bundle binstubs webpacker`. 

Depends on #1286 and may need to be modified slightly if that gets merged.