### PR TITLE
Fix the supported suffix

### DIFF
--- a/docs/css.md
+++ b/docs/css.md
@@ -32,7 +32,7 @@ const Hello = props => (
 
 ## Import scoped styles into your JS app
 
-Stylesheets end with '.modules.*' is treated as [CSS Modules](https://github.com/css-modules/css-modules).
+Stylesheets end with `.module.*` is treated as [CSS Modules](https://github.com/css-modules/css-modules).
 
 ```sass
 // app/javascript/hello_react/styles/hello-react.module.sass


### PR DESCRIPTION
Based upon #1248 it looks as though the supported suffix should be `module` singular, rather than plural. It looks correct in other parts of the documentation, just not here.