### PR TITLE
Updated path-complete-extname dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "glob": "^7.1.2",
     "js-yaml": "^3.10.0",
     "node-sass": "^4.7.2",
-    "path-complete-extname": "^0.1.0",
+    "path-complete-extname": "^1.0.0",
     "postcss-cssnext": "^3.1.0",
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4082,9 +4082,9 @@ path-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
 
-path-complete-extname@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/path-complete-extname/-/path-complete-extname-0.1.0.tgz#c454702669f31452f8193aa6168915fa31692f4a"
+path-complete-extname@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/path-complete-extname/-/path-complete-extname-1.0.0.tgz#f889985dc91000c815515c0bfed06c5acda0752b"
 
 path-exists@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
I just recently released [path-complete-extname@1.0.0](https://github.com/ruyadorno/path-complete-extname/releases/tag/v1.0.0) in order to mitigate a [vulnerability report](https://mobile.twitter.com/ruyadorno/status/971478590532431872) that traces back to the original **node@0.10** implementation in which the module was based on.

The solution was to rewrite the module basing it in the [current node implementation](https://github.com/nodejs/node/tree/v9.6.1/lib/path.js) and publish a new major version. I'm reaching out to all libraries described on [npm dependencies list](https://www.npmjs.com/browse/depended/path-complete-extname) to make sure they can all get the new patched version as soon as possible.

I decided for a major release in order to be able to properly follow [semver](https://semver.org/) from now on and to properly reflect the stable state of the library that has been around for 4 years 😊 

Let me know if there are any concerns and please feel free to [review all the code changes](https://github.com/ruyadorno/path-complete-extname/pull/1/files).

Best,

Ruy Adorno