### PR TITLE
Freeze lockfile when installing in production mode

### DIFF
--- a/lib/tasks/webpacker/yarn_install.rake
+++ b/lib/tasks/webpacker/yarn_install.rake
@@ -1,6 +1,6 @@
 namespace :webpacker do
   desc "Support for older Rails versions. Install all JavaScript dependencies as specified via Yarn"
   task :yarn_install do
-    system "yarn install --no-progress --production"
+    system "yarn install --no-progress --frozen-lockfile --production"
   end
 end


### PR DESCRIPTION
If yarn installing is generating a lockfile diff that's a problem