### PR TITLE
Allow custom env for Webpacker

### DIFF
--- a/package/config.js
+++ b/package/config.js
@@ -9,7 +9,7 @@ const defaultConfigPath = require.resolve('../lib/install/config/webpacker.yml')
 const configPath = resolve('config', 'webpacker.yml')
 
 const getConfig = () => {
-  const defaults = safeLoad(readFileSync(defaultConfigPath), 'utf8')[env]
+  const defaults = safeLoad(readFileSync(defaultConfigPath), 'utf8')[env] || {}
   const app = safeLoad(readFileSync(configPath), 'utf8')[env]
 
   if (isArray(app.extensions) && app.extensions.length) {

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -13,6 +13,20 @@ class EnvTest < Webpacker::Test
     end
   end
 
+  def test_custom_with_user_defined
+    with_node_env("cucumber") do
+      reloaded_config
+      assert_equal Webpacker.env, "cucumber"
+    end
+  end
+
+  def test_fallback
+    with_node_env("not-defined") do
+      reloaded_config
+      assert_equal Webpacker.env, "production"
+    end
+  end
+
   def test_default
     assert_equal Webpacker::Env::DEFAULT, "production"
   end

--- a/test/test_app/config/webpacker.yml
+++ b/test/test_app/config/webpacker.yml
@@ -61,3 +61,7 @@ production:
 
   # Cache manifest.json for performance
   cache_manifest: true
+
+cucumber:
+  <<: *default
+  compile: true


### PR DESCRIPTION
The Rails defined custom env is allowed by https://github.com/rails/webpacker/pull/1304.
However Webpacker custom env is not allowed for now.

```
/Users/tricknotes/dummy-app/node_modules/@rails/webpacker/package/config.js:16
    delete defaults.extensions
           ^

TypeError: Cannot convert undefined or null to object
```

This commit allows using user defined env for Webpacker.