### PR TITLE
Remove unnecessary return value for `Array#forEach` function

### DIFF
--- a/package/dev_server.js
+++ b/package/dev_server.js
@@ -12,7 +12,7 @@ const devServer = () => {
   if (devServerConfig) {
     Object.keys(devServerConfig).forEach((key) => {
       const envValue = fetch(`WEBPACKER_DEV_SERVER_${key.toUpperCase().replace(/_/g, '')}`)
-      if (isEmpty(envValue)) return devServerConfig[key]
+      if (isEmpty(envValue)) return
       devServerConfig[key] = envValue
     })
   }


### PR DESCRIPTION
Without this commit, the following warning is shown:
```
$ yarn lint
yarn run v1.3.2
$ eslint {package,lib}/

/Users/tricknotes/src/github.com/rails/webpacker/package/dev_server.js
  13:48  error  Expected to return a value at the end of arrow function consistent-return
```