### PR TITLE
Support to extend default webpacker env for non-standard env

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,14 @@ by adding new paths to `watched_paths` array. This is much like Rails' `autoload
 Webpacker::Compiler.watched_paths << 'bower_components'
 ```
 
+## Non standard ENV
+
+If you want to use non-standard ENV (such as "staging"), you can specify the webpacker standard ENV to be extended.
+
+``` yml
+staging:
+  extend_default_env: production
+```
 
 ## Deployment
 

--- a/package/__tests__/index.js
+++ b/package/__tests__/index.js
@@ -28,4 +28,13 @@ describe('Webpacker', () => {
       stats: 'normal'
     })
   })
+
+  test('with a non-standard env extending webpacker\s default', () => {
+    process.env.NODE_ENV = 'cucumber'
+    process.env.RAILS_ENV = 'cucumber'
+    const { environment } = require('../index')
+    expect(environment.toWebpackConfig()).toMatchObject({
+      devtool: 'cheap-module-source-map'
+    })
+  })
 })

--- a/package/config.js
+++ b/package/config.js
@@ -9,7 +9,7 @@ const defaultConfigPath = require.resolve('../lib/install/config/webpacker.yml')
 const configPath = resolve('config', 'webpacker.yml')
 
 const getConfig = () => {
-  const defaults = safeLoad(readFileSync(defaultConfigPath), 'utf8')[env]
+  const defaults = safeLoad(readFileSync(defaultConfigPath), 'utf8')[env] || {}
   const app = safeLoad(readFileSync(configPath), 'utf8')[env]
 
   if (isArray(app.extensions) && app.extensions.length) {

--- a/package/index.js
+++ b/package/index.js
@@ -2,15 +2,22 @@
 /* eslint import/no-dynamic-require: 0 */
 
 const { resolve } = require('path')
-const { existsSync } = require('fs')
+const { existsSync, readFileSync } = require('fs')
+const { safeLoad } = require('js-yaml')
 const Environment = require('./environments/base')
 const loaders = require('./rules')
 const env = require('./env')
 const config = require('./config')
+
+const configPath = resolve('config', 'webpacker.yml')
 const devServer = require('./dev_server')
 
-const createEnvironment = () => {
-  const path = resolve(__dirname, 'environments', `${env}.js`)
+const appConfig = safeLoad(readFileSync(configPath), 'utf8')
+const app = appConfig && appConfig[env]
+const webpackerEnv = (app && app.extend_default_env) || env
+
+const createEnvironment = (baseEnv) => {
+  const path = resolve(__dirname, 'environments', `${baseEnv}.js`)
   const constructor = existsSync(path) ? require(path) : Environment
   return new constructor()
 }
@@ -18,7 +25,7 @@ const createEnvironment = () => {
 module.exports = {
   config,
   devServer,
-  environment: createEnvironment(),
+  environment: createEnvironment(webpackerEnv),
   Environment,
   loaders
 }

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -13,6 +13,20 @@ class EnvTest < Webpacker::Test
     end
   end
 
+  def test_custom_with_user_defined
+    with_node_env("cucumber") do
+      reloaded_config
+      assert_equal Webpacker.env, "cucumber"
+    end
+  end
+
+  def test_fallback
+    with_node_env("not-defined") do
+      reloaded_config
+      assert_equal Webpacker.env, "production"
+    end
+  end
+
   def test_default
     assert_equal Webpacker::Env::DEFAULT, "production"
   end

--- a/test/test_app/config/webpacker.yml
+++ b/test/test_app/config/webpacker.yml
@@ -61,3 +61,7 @@ production:
 
   # Cache manifest.json for performance
   cache_manifest: true
+
+cucumber:
+  <<: *default
+  compile: true

--- a/test/test_app/config/webpacker.yml
+++ b/test/test_app/config/webpacker.yml
@@ -65,3 +65,4 @@ production:
 cucumber:
   <<: *default
   compile: true
+  extend_default_env: development


### PR DESCRIPTION
Currently, the non-standard env is allowed to use but any webpacker default config is ignored.
Especially, the developer who use "staging" expects that the environment is almost the same as "production".
    
This commit allows to specify the default webpacker env to be extended by non-standard env.
    
If someone want to extend webpacker env without this commit, the following change is required.

``` diff
diff --git a/config/webpack/staging.js b/config/webpack/staging.js
index d7346478..77bb3afa 100644
--- a/config/webpack/staging.js
+++ b/config/webpack/staging.js
@@ -1,3 +1,4 @@
-const environment = require('./environment');
+const Environment = require('@rails/webpacker/package/environments/production');
+const environment = new Environment();
    
module.exports = environment.toWebpackConfig();
```

This PR depends on https://github.com/rails/webpacker/pull/1350 due to support for non-standard env :<