### PR TITLE
Remove webpack-dev-server upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ You can run following commands to upgrade Webpacker to the latest stable version
 ```bash
 bundle update webpacker
 yarn upgrade @rails/webpacker --latest
-yarn upgrade webpack-dev-server --latest
+yarn add webpack-dev-server@^2.11.1
 ```
 
 ### Yarn Integrity


### PR DESCRIPTION
In the Upgrade section the readme had `yarn upgrade webpack-dev-server --latest`. This will cause issues related to https://github.com/rails/webpacker/issues/1295 until webpacker supports webpack 4.0.