### PR TITLE
Add troubleshooting docs for "can't find executable webpack exception"

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -117,3 +117,12 @@ environment.plugins.append('ContextReplacement',
   )
 )
 ```
+
+# Rake assets:precompile or bin/webpack fails. Can't find executable webpack for gem webpacker (Gem::Exception)
+
+This can happen if you need to update your webpack and webpack-dev-server
+binstubs.  You can update your binstubs by running:
+
+```
+bundle exec rails webpacker:binstubs
+```


### PR DESCRIPTION
After I upgraded the Webpacker gem in a Rails 5.1 project from 3.0.2 to 3.3.1, I saw the following error locally when I would run `RAILS_ENV=test NODE_ENV=test bin/webpack`:

```
/Users/<me>/.gem/ruby/2.4.2/gems/bundler-1.16.1/lib/bundler/rubygems_integration.rb:458:in `block in replace_bin_path': can't find executable webpack for gem webpacker (Gem::Exception)
	from /Users/<me>/.gem/ruby/2.4.2/gems/bundler-1.16.1/lib/bundler/rubygems_integration.rb:489:in `block in replace_bin_path'
	from bin/webpack:17:in `<main>'
```

I was hoping to add some troubleshooting documentation to save someone some time in the future.

Credit where credit is due, I actually found the solution to my problem in [another issue in this repo](https://github.com/rails/webpacker/issues/1321#issuecomment-370526887).