### PR TITLE
Add image_pack_tag helper

### DIFF
--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -33,6 +33,22 @@ module Webpacker::Helper
     end
   end
 
+  # Creates a image tag that references the named pack file.
+  # This will use asset_pack_path internally, so most of their behaviors will be the same.
+  #
+  # Example:
+  #
+  #   # In development mode with hot module replacement:
+  #   <%= image_pack_tag 'logo.png' %> # => nil
+  #
+  #   # In production mode:
+  #   <%= image_pack_tag 'logo.png' %> # => "http://example.com/packs/logo-1016838bab065ae1e122.png"
+  def image_pack_tag(name, **options)
+    unless Webpacker.dev_server.running? && Webpacker.dev_server.hot_module_replacing?
+      image_tag(asset_pack_path(name), **options)
+    end
+  end
+
   # Creates a script tag that references the named pack file, as compiled by webpack per the entries list
   # in config/webpack/shared.js. By default, this list is auto-generated to match everything in
   # app/javascript/packs/*.js. In production mode, the digested reference is automatically looked up.


### PR DESCRIPTION
I migrated my project to use packs for static images and found that image tag references because very cumbersome and wordy. I can understand if people think this belongs in per-project helpers rather than in the library, but figured I'd open a PR if that wasn't the case.

Will add tests/documentation if we decide to move forward