### PR TITLE
Remove version specification of coffeescript

### DIFF
--- a/lib/install/coffee.rb
+++ b/lib/install/coffee.rb
@@ -20,6 +20,6 @@ copy_file "#{__dir__}/examples/coffee/hello_coffee.coffee",
   "#{Webpacker.config.source_entry_path}/hello_coffee.coffee"
 
 say "Installing all Coffeescript dependencies"
-run "yarn add coffeescript@1.12.7 coffee-loader"
+run "yarn add coffeescript coffee-loader"
 
 say "Webpacker now supports Coffeeescript 🎉", :green


### PR DESCRIPTION
Hello.

Is there any reason to stick CoffeeScript's version to 1.12.7? If nothing, it's better to remove the version specification. 

Also `coffee-loader` already supports CoffeeScript 2.
ref: https://github.com/webpack-contrib/coffee-loader/pull/30