### PR TITLE
Remove compilation digest file if webpack command fails

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -19,7 +19,9 @@ class Webpacker::Compiler
   def compile
     if stale?
       record_compilation_digest
-      run_webpack
+      run_webpack.tap do |success|
+        remove_compilation_digest if !success
+      end
     else
       true
     end
@@ -48,6 +50,10 @@ class Webpacker::Compiler
     def record_compilation_digest
       config.cache_path.mkpath
       compilation_digest_path.write(watched_files_digest)
+    end
+
+    def remove_compilation_digest
+      compilation_digest_path.delete if compilation_digest_path.exist?
     end
 
     def run_webpack


### PR DESCRIPTION
Fixes #1398 

If the webpack compilation step fails, I believe the safest thing to do would be to remove the previously recorded compilation digest file so Webpacker doesn't get in the way of what could be a successful retry.