### PR TITLE
Add image_pack_tag helper

### DIFF
--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -33,6 +33,16 @@ module Webpacker::Helper
     end
   end
 
+  # Creates a image tag that references the named pack file.
+  #
+  # Example:
+  #
+  #  <%= image_pack_tag 'application.png', size: '16x10', alt: 'Edit Entry' %>
+  #  <img alt='Edit Entry' src='/packs/application-k344a6d59eef8632c9d1.png' width='16' height='10' />
+  def image_pack_tag(name, **options)
+    image_tag(asset_path(Webpacker.manifest.lookup!(name)), **options)
+  end
+
   # Creates a script tag that references the named pack file, as compiled by webpack per the entries list
   # in config/webpack/shared.js. By default, this list is auto-generated to match everything in
   # app/javascript/packs/*.js. In production mode, the digested reference is automatically looked up.

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -31,6 +31,12 @@ class HelperTest < ActionView::TestCase
     assert_equal "https://example.com/packs/bootstrap-c38deda30895059837cf.css", asset_pack_url("bootstrap.css")
   end
 
+  def test_image_pack_tag
+    assert_equal \
+      "<img alt=\"Edit Entry\" src=\"/packs/application-k344a6d59eef8632c9d1.png\" width=\"16\" height=\"10\" />",
+      image_pack_tag("application.png", size: "16x10", alt: "Edit Entry")
+  end
+
   def test_javascript_pack_tag
     assert_equal \
       %(<script src="/packs/bootstrap-300631c4f0e0f9c865bc.js"></script>),


### PR DESCRIPTION
Refiling of #1376 with specs and adjustment of HMR logic

I migrated my project to use packs for static images and found that image tag references because very cumbersome and wordy when I would have to constantly write:

`= link_to image_tag(asset_pack_path('my_iage.png')), root_path`