### PR TITLE
Drop `"uglify": true` from babel targets

### DIFF
--- a/lib/install/config/.babelrc
+++ b/lib/install/config/.babelrc
@@ -3,8 +3,7 @@
     ["env", {
       "modules": false,
       "targets": {
-        "browsers": "> 1%",
-        "uglify": true
+        "browsers": "> 1%"
       },
       "useBuiltIns": true
     }]


### PR DESCRIPTION
uglify-es (that supports es6) is used since 3.2.1, so we shouldn't downgrade js features to the ones supported by non-es uglify.


