### PR TITLE
Add changelog URI to gemspec

### DIFF
--- a/webpacker.gemspec
+++ b/webpacker.gemspec
@@ -10,6 +10,11 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/rails/webpacker"
   s.license  = "MIT"
 
+  s.metadata = {
+    "source_code_uri" => "https://github.com/rails/webpacker/tree/v#{Webpacker::VERSION}",
+    "changelog_uri"   => "https://github.com/rails/webpacker/blob/v#{Webpacker::VERSION}/CHANGELOG.md"
+  }
+
   s.required_ruby_version = ">= 2.2.0"
 
   s.add_dependency "activesupport", ">= 4.2"


### PR DESCRIPTION
In line with the approach taken in [Rails](https://github.com/rails/rails/blob/master/activemodel/activemodel.gemspec#L23-L26).

Makes it easier for automated tools like Dependabot to get the right changelog (since the one on the 3.4-stable branch is now different to the one on master.