### PR TITLE
Handle http dev_server setting properly in the proxy

### DIFF
--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -11,7 +11,10 @@ class Webpacker::DevServerProxy < Rack::Proxy
   def perform_request(env)
     if env["PATH_INFO"].start_with?("/#{public_output_uri_path}") && Webpacker.dev_server.running?
       env["HTTP_HOST"] = env["HTTP_X_FORWARDED_HOST"] = env["HTTP_X_FORWARDED_SERVER"] = Webpacker.dev_server.host_with_port
-      env["HTTP_X_FORWARDED_PROTO"] = Webpacker.dev_server.protocol
+      env["HTTP_X_FORWARDED_PROTO"] = env["HTTP_X_FORWARDED_SCHEME"] = Webpacker.dev_server.protocol
+      unless Webpacker.dev_server.https?
+        env["HTTPS"] = env["HTTP_X_FORWARDED_SSL"] = "off"
+      end
       env["SCRIPT_NAME"] = ""
 
       super(env)


### PR DESCRIPTION
If dev_server is not set for https, the proxy should always forward requests to http, irrespective of the source request's scheme

The logic for which headers to change comes from looking at the Rack::Proxy source,
which determines if it should make an ssl request by using
http://www.rubydoc.info/gems/rack/Rack/Request/Helpers#scheme-instance_method

## Background

In our dev environment, we use an nginx proxy which terminates SSL and talks to the rails app over http. Our webpacker.yml contains the following config:

```
  dev_server:
    https: false
```

Which does effectively start `webpack-dev-server` in http mode, but the rails proxy baked into webpacker does not take this setting into account when forwarding requests onto `webpack-dev-server`. Instead, it blindly passes in env without mutating it, which `Rack::Proxy` then uses to determine that it should communicate to `webpack-dev-server` over https, matching the source request.

If there's some circumstance I'm ignoring/missing here, please let me know, I welcome feedback.