### PR TITLE
Remove extra spaces in template.rb

### DIFF
--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -19,7 +19,7 @@ say "Adding configurations"
 
 check_yarn_integrity_config = ->(value) { <<CONFIG }
 # Verifies that versions and hashed value of the package contents in the project's package.json
-  config.webpacker.check_yarn_integrity = #{value}
+config.webpacker.check_yarn_integrity = #{value}
 CONFIG
 
 if Rails::VERSION::MAJOR >= 5


### PR DESCRIPTION
Currently it adds an extra indent level in a new webpacker Rails project's development.rb and production.rb, so the `config` statement doesn't line up with the others.