### PR TITLE
Use correct protocol

### DIFF
--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -11,6 +11,7 @@ class Webpacker::DevServerProxy < Rack::Proxy
   def perform_request(env)
     if env["PATH_INFO"].start_with?("/#{public_output_uri_path}") && Webpacker.dev_server.running?
       env["HTTP_HOST"] = env["HTTP_X_FORWARDED_HOST"] = env["HTTP_X_FORWARDED_SERVER"] = Webpacker.dev_server.host_with_port
+      env["HTTP_X_FORWARDED_PROTO"] = Webpacker.dev_server.protocol
       env["SCRIPT_NAME"] = ""
 
       super(env)


### PR DESCRIPTION
Currently we can run webpacker in either http or https mode.
But if we run webpacker in `http` mode but access it through a reverse proxy handling `https`, then it will break because the reverse proxy will have set `HTTP_X_FORWARDED_PROTO` to `https` and webpack-dev-server will try to understand the request as a secured one.

We must override `X_FORWARDED_PROTO` in the same way as we override the other headers.

In the meantime I'm using this initializer as a workaround  doing exactly the same work as this PR :

```ruby
# config/initializers/webpacker.rb
require "webpacker/dev_server_proxy.rb"

module Webpacker::DevServerProxy::ProtoOverride
  def perform_request(env)
      env["HTTP_X_FORWARDED_PROTO"] = Webpacker.dev_server.protocol
      super(env)
  end
end
Webpacker::DevServerProxy.include Webpacker::DevServerProxy::ProtoOverride

```