### PR TITLE
Stricter configuration keys check before fallback

### DIFF
--- a/package/env.js
+++ b/package/env.js
@@ -11,7 +11,7 @@ const nodeEnv = process.env.NODE_ENV
 
 const config = safeLoad(readFileSync(configPath), 'utf8')
 const availableEnvironments = Object.keys(config).join('|')
-const regex = new RegExp(availableEnvironments, 'g')
+const regex = new RegExp("^(" + availableEnvironments + ")$", 'g')
 
 module.exports = {
   railsEnv: railsEnv && railsEnv.match(regex) ? railsEnv : DEFAULT,


### PR DESCRIPTION
If the `webpacker.yml` file doesn't include the `RAILS_ENV`, we want to fall back to the default `production` configuration. But the way that we're checking to see if a matching key is present is overly lax because it allows substring matches, so a `RAILS_ENV` of `my_production` will match the regex's `production` option, even if no `my_production` key is present. The old check made webpacker *act* is if a valid key was present, only to fail later (in `config.rb`) when it tries to load that key and gets nothing.

This commit updates the sanity checker so that it will only find keys that actually exist, not keys that contain substrings that match keys that exist.