### PR TITLE
Remove unnecessary linebreaks in TS and Vue installers

### DIFF
--- a/lib/install/typescript.rb
+++ b/lib/install/typescript.rb
@@ -31,10 +31,10 @@ say "Copying tsconfig.json to the Rails root directory for typescript"
 copy_file "#{__dir__}/examples/#{example_source}/tsconfig.json", "tsconfig.json"
 
 say "Updating webpack paths to include .ts file extension"
-insert_into_file Webpacker.config.config_path, optimize_indentation("- .ts\n", 4), after: /extensions:\n/
+insert_into_file Webpacker.config.config_path, optimize_indentation("- .ts", 4), after: /extensions:\n/
 
 say "Updating webpack paths to include .tsx file extension"
-insert_into_file Webpacker.config.config_path, optimize_indentation("- .tsx\n", 4), after: /extensions:\n/
+insert_into_file Webpacker.config.config_path, optimize_indentation("- .tsx", 4), after: /extensions:\n/
 
 say "Copying the example entry file to #{Webpacker.config.source_entry_path}"
 copy_file "#{__dir__}/examples/typescript/hello_typescript.ts",

--- a/lib/install/vue.rb
+++ b/lib/install/vue.rb
@@ -22,7 +22,7 @@ insert_into_file Rails.root.join("config/webpack/environment.js").to_s,
   before: "module.exports"
 
 say "Updating webpack paths to include .vue file extension"
-insert_into_file Webpacker.config.config_path, optimize_indentation("- .vue\n", 4), after: /extensions:\n/
+insert_into_file Webpacker.config.config_path, optimize_indentation("- .vue", 4), after: /extensions:\n/
 
 say "Copying the example entry file to #{Webpacker.config.source_entry_path}"
 copy_file "#{__dir__}/examples/vue/hello_vue.js",


### PR DESCRIPTION
In https://github.com/rails/webpacker/pull/1445 I forgot to remove some line breaks that are no longer needed as`optimize_indentation` will strip those and add them again.