### PR TITLE
Use complete variable name in CSP initializer

### DIFF
--- a/lib/install/angular.rb
+++ b/lib/install/angular.rb
@@ -14,9 +14,9 @@ if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR > 1
   say "This can be done in Rails 5.2+ for development environment in the CSP initializer", :yellow
   say "config/initializers/content_security_policy.rb with a snippet like this:", :yellow
   say "if Rails.env.development?", :yellow
-  say "  p.script_src :self, :https, :unsafe_eval", :yellow
+  say "  policy.script_src :self, :https, :unsafe_eval", :yellow
   say "else", :yellow
-  say "  p.script_src :self, :https", :yellow
+  say "  policy.script_src :self, :https", :yellow
   say "end", :yellow
 end
 

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -50,7 +50,7 @@ if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR > 1
   say "You need to allow webpack-dev-server host as allowed origin for connect-src.", :yellow
   say "This can be done in Rails 5.2+ for development environment in the CSP initializer", :yellow
   say "config/initializers/content_security_policy.rb with a snippet like this:", :yellow
-  say "p.connect_src :self, :https, \"http://localhost:3035\", \"ws://localhost:3035\" if Rails.env.development?", :yellow
+  say "policy.connect_src :self, :https, \"http://localhost:3035\", \"ws://localhost:3035\" if Rails.env.development?", :yellow
 end
 
 say "Webpacker successfully installed 🎉 🍰", :green

--- a/lib/install/vue.rb
+++ b/lib/install/vue.rb
@@ -40,9 +40,9 @@ if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR > 1
   say "This can be done in Rails 5.2+ for development environment in the CSP initializer", :yellow
   say "config/initializers/content_security_policy.rb with a snippet like this:", :yellow
   say "if Rails.env.development?", :yellow
-  say "  p.script_src :self, :https, :unsafe_eval", :yellow
+  say "  policy.script_src :self, :https, :unsafe_eval", :yellow
   say "else", :yellow
-  say "  p.script_src :self, :https", :yellow
+  say "  policy.script_src :self, :https", :yellow
   say "end", :yellow
 end
 


### PR DESCRIPTION
In this [commit](https://github.com/rails/rails/commit/4697b19b889e4416d46cdaebcecc8ea95d9eea30#diff-86f4b80f0cfb2ffba6469c8da0a61516) for Rails 5.2, the single initial variable name was replaced with a complete variable name.  This mirrors that change.