### PR TITLE
Add PDF extension for file loader

### DIFF
--- a/package/rules/file.js
+++ b/package/rules/file.js
@@ -2,7 +2,7 @@ const { join } = require('path')
 const { source_path: sourcePath } = require('../config')
 
 module.exports = {
-  test: /\.(jpg|jpeg|png|gif|tiff|ico|svg|eot|otf|ttf|woff|woff2)$/i,
+  test: /\.(jpg|jpeg|png|gif|tiff|ico|svg|eot|otf|ttf|woff|woff2|pdf)$/i,
   use: [
     {
       loader: 'file-loader',


### PR DESCRIPTION
This adds PDF to the test for the file loader, allowing PDF assets to be served through Webpacker. 

In my app everything goes through Webpacker - the only thing I have left in the old asset pipeline is PDF files. I think it makes sense for Webpacker to support serving these files out of the box as well, without needing to configure it on a per-app basis.