### PR TITLE
Replace #optimize_indentation calls with String#indent

### DIFF
--- a/lib/install/coffee.rb
+++ b/lib/install/coffee.rb
@@ -13,7 +13,7 @@ insert_into_file Rails.root.join("config/webpack/environment.js").to_s,
   before: "module.exports"
 
 say "Updating webpack paths to include .coffee file extension"
-insert_into_file Webpacker.config.config_path, optimize_indentation("- .coffee", 4), after: /extensions:\n/
+insert_into_file Webpacker.config.config_path, "- .coffee\n".indent(4), after: /extensions:\n/
 
 say "Copying the example entry file to #{Webpacker.config.source_entry_path}"
 copy_file "#{__dir__}/examples/coffee/hello_coffee.coffee",

--- a/lib/install/elm.rb
+++ b/lib/install/elm.rb
@@ -26,7 +26,7 @@ run "yarn add --dev elm-hot-loader"
 run "yarn run elm package install -- --yes"
 
 say "Updating webpack paths to include .elm file extension"
-insert_into_file Webpacker.config.config_path, optimize_indentation("- .elm", 4), after: /extensions:\n/
+insert_into_file Webpacker.config.config_path, "- .elm\n".indent(4), after: /extensions:\n/
 
 say "Updating Elm source location"
 gsub_file "elm-package.json", /\"\.\"\n/,

--- a/lib/install/erb.rb
+++ b/lib/install/erb.rb
@@ -13,7 +13,7 @@ insert_into_file Rails.root.join("config/webpack/environment.js").to_s,
   before: "module.exports"
 
 say "Updating webpack paths to include .erb file extension"
-insert_into_file Webpacker.config.config_path, optimize_indentation("- .erb", 4), after: /extensions:\n/
+insert_into_file Webpacker.config.config_path, "- .erb\n".indent(4), after: /extensions:\n/
 
 say "Copying the example entry file to #{Webpacker.config.source_entry_path}"
 copy_file "#{__dir__}/examples/erb/hello_erb.js.erb",

--- a/lib/install/react.rb
+++ b/lib/install/react.rb
@@ -23,7 +23,7 @@ say "Copying react example entry file to #{Webpacker.config.source_entry_path}"
 copy_file "#{__dir__}/examples/react/hello_react.jsx", "#{Webpacker.config.source_entry_path}/hello_react.jsx"
 
 say "Updating webpack paths to include .jsx file extension"
-insert_into_file Webpacker.config.config_path, optimize_indentation("- .jsx", 4), after: /extensions:\n/
+insert_into_file Webpacker.config.config_path, "- .jsx\n".indent(4), after: /extensions:\n/
 
 say "Installing all react dependencies"
 run "yarn add react react-dom babel-preset-react prop-types"

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -17,7 +17,7 @@ apply "#{__dir__}/binstubs.rb"
 
 say "Adding configurations"
 
-check_yarn_integrity_config = ->(value) { <<CONFIG }
+check_yarn_integrity_config = ->(value) { <<CONFIG.indent(2) }
 # Verifies that versions and hashed value of the package contents in the project's package.json
 config.webpacker.check_yarn_integrity = #{value}
 CONFIG
@@ -26,18 +26,18 @@ if Rails::VERSION::MAJOR >= 5
   environment check_yarn_integrity_config.call("true"), env: :development
   environment check_yarn_integrity_config.call("false"), env: :production
 else
-  inject_into_file "config/environments/development.rb", optimize_indentation(check_yarn_integrity_config.call("true"), 2), after: "Rails.application.configure do", verbose: false
-  inject_into_file "config/environments/production.rb", optimize_indentation(check_yarn_integrity_config.call("false"), 2), after: "Rails.application.configure do", verbose: false
+  inject_into_file "config/environments/development.rb", "\n#{check_yarn_integrity_config.call("true")}", after: "Rails.application.configure do", verbose: false
+  inject_into_file "config/environments/production.rb", "\n#{check_yarn_integrity_config.call("false")}", after: "Rails.application.configure do", verbose: false
 end
 
 if File.exists?(".gitignore")
-  append_to_file ".gitignore", optimize_indentation(<<-EOS)
-    /public/packs
-    /public/packs-test
-    /node_modules
-    yarn-debug.log*
-    .yarn-integrity
-  EOS
+  append_to_file ".gitignore", <<-EOS
+/public/packs
+/public/packs-test
+/node_modules
+yarn-debug.log*
+.yarn-integrity
+EOS
 end
 
 say "Installing all JavaScript dependencies"

--- a/lib/install/typescript.rb
+++ b/lib/install/typescript.rb
@@ -31,10 +31,10 @@ say "Copying tsconfig.json to the Rails root directory for typescript"
 copy_file "#{__dir__}/examples/#{example_source}/tsconfig.json", "tsconfig.json"
 
 say "Updating webpack paths to include .ts file extension"
-insert_into_file Webpacker.config.config_path, optimize_indentation("- .ts", 4), after: /extensions:\n/
+insert_into_file Webpacker.config.config_path, "- .ts\n".indent(4), after: /extensions:\n/
 
 say "Updating webpack paths to include .tsx file extension"
-insert_into_file Webpacker.config.config_path, optimize_indentation("- .tsx", 4), after: /extensions:\n/
+insert_into_file Webpacker.config.config_path, "- .tsx\n".indent(4), after: /extensions:\n/
 
 say "Copying the example entry file to #{Webpacker.config.source_entry_path}"
 copy_file "#{__dir__}/examples/typescript/hello_typescript.ts",

--- a/lib/install/vue.rb
+++ b/lib/install/vue.rb
@@ -22,7 +22,7 @@ insert_into_file Rails.root.join("config/webpack/environment.js").to_s,
   before: "module.exports"
 
 say "Updating webpack paths to include .vue file extension"
-insert_into_file Webpacker.config.config_path, optimize_indentation("- .vue", 4), after: /extensions:\n/
+insert_into_file Webpacker.config.config_path, "- .vue\n".indent(4), after: /extensions:\n/
 
 say "Copying the example entry file to #{Webpacker.config.source_entry_path}"
 copy_file "#{__dir__}/examples/vue/hello_vue.js",


### PR DESCRIPTION
In https://github.com/rails/webpacker/pull/1445 I introduced the method `#optimize_indentation`, but this was added in Rails 5.2 (https://github.com/rails/rails/pull/30166) and Webpacker should support Rails 4+.

In order to have the same benefit, I'm replacing the calls to the method `#optimize_indentation` with the method it uses from behind: `String#indent` (which was introduced in Rails 4.0.0 https://github.com/rails/rails/commit/2f58795e783150f2e1b1f6c64e305703f0061129).