### PR TITLE
Fix CHANGELOG format [ci skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
   - Handle http dev_server setting properly in the proxy [#1420]
   - Use correct protocol [#1425](https://github.com/rails/webpacker/pull/1425)
 
-### Added
+### Added
   - `image_pack_tag` helper [#1400](https://github.com/rails/webpacker/pull/1400)
   - devserver proxy for custom environments [#1415](https://github.com/rails/webpacker/pull/1415)
   - Rails webpacker:info task [#1416](https://github.com/rails/webpacker/pull/1416)


### PR DESCRIPTION
It seems that the added section of version 3.5.0 is not displayed properly. 
https://github.com/rails/webpacker/blob/3-4-stable/CHANGELOG.md#350---2018-04-29 

It seemed to be caused by using NO-BREAK SPACE (U+00A0), so I modified it to use SPACE (U+0020).
