### PR TITLE
Honor BUNDLE_PATH if set in tasks

### DIFF
--- a/lib/tasks/installers.rake
+++ b/lib/tasks/installers.rake
@@ -17,11 +17,6 @@ namespace :webpacker do
   namespace :install do
     installers.each do |name, task_name|
       desc "Install everything needed for #{name}"
-      if ENV["BUNDLE_BIN"]
-        bin_path = ENV["BUNDLE_BIN"]
-      else
-        bin_path = "./bin"
-      end
       task task_name => ["webpacker:verify_install"] do
         template = File.expand_path("../install/#{task_name}.rb", __dir__)
         base_path =

--- a/lib/tasks/installers.rake
+++ b/lib/tasks/installers.rake
@@ -17,13 +17,18 @@ namespace :webpacker do
   namespace :install do
     installers.each do |name, task_name|
       desc "Install everything needed for #{name}"
+      if ENV["BUNDLE_BIN"]
+        bin_path = ENV["BUNDLE_BIN"]
+      else
+        bin_path = "./bin"
+      end
       task task_name => ["webpacker:verify_install"] do
         template = File.expand_path("../install/#{task_name}.rb", __dir__)
         base_path =
           if Rails::VERSION::MAJOR >= 5
-            "#{RbConfig.ruby} ./bin/rails app:template"
+            "#{RbConfig.ruby} #{bin_path}/rails app:template"
           else
-            "#{RbConfig.ruby} ./bin/rake rails:template"
+            "#{RbConfig.ruby} #{bin_path}/rake rails:template"
           end
 
         dependencies[name] ||= []

--- a/lib/tasks/installers.rake
+++ b/lib/tasks/installers.rake
@@ -13,6 +13,12 @@ dependencies = {
   "Angular": [:typescript]
 }
 
+if ENV["BUNDLE_BIN"]
+  bin_path = ENV["BUNDLE_BIN"]
+else
+  bin_path = "./bin"
+end
+
 namespace :webpacker do
   namespace :install do
     installers.each do |name, task_name|

--- a/lib/tasks/installers.rake
+++ b/lib/tasks/installers.rake
@@ -13,11 +13,7 @@ dependencies = {
   "Angular": [:typescript]
 }
 
-if ENV["BUNDLE_BIN"]
-  bin_path = ENV["BUNDLE_BIN"]
-else
-  bin_path = "./bin"
-end
+bin_path = ENV["BUNDLE_BIN"] || "./bin"
 
 namespace :webpacker do
   namespace :install do

--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -19,6 +19,12 @@ tasks = {
   "webpacker:install:typescript"      => "Installs Typescript loader with an example"
 }.freeze
 
+if ENV["BUNDLE_BIN"]
+  bin_path = ENV["BUNDLE_BIN"]
+else
+  bin_path = "./bin"
+end
+
 desc "Lists all available tasks in Webpacker"
 task :webpacker do
   puts "Available Webpacker tasks are:"

--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -19,12 +19,6 @@ tasks = {
   "webpacker:install:typescript"      => "Installs Typescript loader with an example"
 }.freeze
 
-if ENV["BUNDLE_BIN"]
-  bin_path = ENV["BUNDLE_BIN"]
-else
-  bin_path = "./bin"
-end
-
 desc "Lists all available tasks in Webpacker"
 task :webpacker do
   puts "Available Webpacker tasks are:"

--- a/lib/tasks/webpacker/binstubs.rake
+++ b/lib/tasks/webpacker/binstubs.rake
@@ -1,10 +1,5 @@
 binstubs_template_path = File.expand_path("../../install/binstubs.rb", __dir__).freeze
-
-if ENV["BUNDLE_BIN"]
-  bin_path = ENV["BUNDLE_BIN"]
-else
-  bin_path = "./bin"
-end
+bin_path = ENV["BUNDLE_BIN"] || "./bin"
 
 namespace :webpacker do
   desc "Installs Webpacker binstubs in this application"

--- a/lib/tasks/webpacker/binstubs.rake
+++ b/lib/tasks/webpacker/binstubs.rake
@@ -1,5 +1,11 @@
 binstubs_template_path = File.expand_path("../../install/binstubs.rb", __dir__).freeze
 
+if ENV["BUNDLE_BIN"]
+  bin_path = ENV["BUNDLE_BIN"]
+else
+  bin_path = "./bin"
+end
+
 namespace :webpacker do
   desc "Installs Webpacker binstubs in this application"
   task binstubs: [:check_node, :check_yarn] do

--- a/lib/tasks/webpacker/binstubs.rake
+++ b/lib/tasks/webpacker/binstubs.rake
@@ -1,9 +1,4 @@
 binstubs_template_path = File.expand_path("../../install/binstubs.rb", __dir__).freeze
-if ENV["BUNDLE_BIN"]
-  bin_path = ENV["BUNDLE_BIN"]
-else
-  bin_path = "./bin"
-end
 
 namespace :webpacker do
   desc "Installs Webpacker binstubs in this application"

--- a/lib/tasks/webpacker/binstubs.rake
+++ b/lib/tasks/webpacker/binstubs.rake
@@ -1,12 +1,17 @@
 binstubs_template_path = File.expand_path("../../install/binstubs.rb", __dir__).freeze
+if ENV["BUNDLE_BIN"]
+  bin_path = ENV["BUNDLE_BIN"]
+else
+  bin_path = "./bin"
+end
 
 namespace :webpacker do
   desc "Installs Webpacker binstubs in this application"
   task binstubs: [:check_node, :check_yarn] do
     if Rails::VERSION::MAJOR >= 5
-      exec "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{binstubs_template_path}"
+      exec "#{RbConfig.ruby} #{bin_path}/rails app:template LOCATION=#{binstubs_template_path}"
     else
-      exec "#{RbConfig.ruby} ./bin/rake rails:template LOCATION=#{binstubs_template_path}"
+      exec "#{RbConfig.ruby} #{bin_path}/rake rails:template LOCATION=#{binstubs_template_path}"
     end
   end
 end

--- a/lib/tasks/webpacker/install.rake
+++ b/lib/tasks/webpacker/install.rake
@@ -1,9 +1,4 @@
 install_template_path = File.expand_path("../../install/template.rb", __dir__).freeze
-if ENV["BUNDLE_BIN"]
-  bin_path = ENV["BUNDLE_BIN"]
-else
-  bin_path = "./bin"
-end
 
 namespace :webpacker do
   desc "Install Webpacker in this application"

--- a/lib/tasks/webpacker/install.rake
+++ b/lib/tasks/webpacker/install.rake
@@ -1,12 +1,17 @@
 install_template_path = File.expand_path("../../install/template.rb", __dir__).freeze
+if ENV["BUNDLE_BIN"]
+  bin_path = ENV["BUNDLE_BIN"]
+else
+  bin_path = "./bin"
+end
 
 namespace :webpacker do
   desc "Install Webpacker in this application"
   task install: [:check_node, :check_yarn] do
     if Rails::VERSION::MAJOR >= 5
-      exec "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{install_template_path}"
+      exec "#{RbConfig.ruby} #{bin_path}/rails app:template LOCATION=#{install_template_path}"
     else
-      exec "#{RbConfig.ruby} ./bin/rake rails:template LOCATION=#{install_template_path}"
+      exec "#{RbConfig.ruby} #{bin_path}/rake rails:template LOCATION=#{install_template_path}"
     end
   end
 end

--- a/lib/tasks/webpacker/install.rake
+++ b/lib/tasks/webpacker/install.rake
@@ -1,4 +1,9 @@
 install_template_path = File.expand_path("../../install/template.rb", __dir__).freeze
+if ENV["BUNDLE_BIN"]
+  bin_path = ENV["BUNDLE_BIN"]
+else
+  bin_path = "./bin"
+end
 
 namespace :webpacker do
   desc "Install Webpacker in this application"

--- a/lib/tasks/webpacker/install.rake
+++ b/lib/tasks/webpacker/install.rake
@@ -1,9 +1,5 @@
 install_template_path = File.expand_path("../../install/template.rb", __dir__).freeze
-if ENV["BUNDLE_BIN"]
-  bin_path = ENV["BUNDLE_BIN"]
-else
-  bin_path = "./bin"
-end
+bin_path = ENV["BUNDLE_BIN"] || "./bin"
 
 namespace :webpacker do
   desc "Install Webpacker in this application"


### PR DESCRIPTION
If `$BUNDLE_PATH` is set the rake/rails binary will not be in the correct location and fail. The Ruby Docker images use this for instance.  I'm fairly new to Rails so there may be a better way to achieve this. 