### PR TITLE
Match literal "." character instead of any char...

### DIFF
--- a/lib/install/examples/stimulus/application.js
+++ b/lib/install/examples/stimulus/application.js
@@ -2,5 +2,5 @@ import { Application } from "stimulus"
 import { definitionsFromContext } from "stimulus/webpack-helpers"
 
 const application = Application.start()
-const context = require.context("controllers", true, /.js$/)
+const context = require.context("controllers", true, /\.js$/)
 application.load(definitionsFromContext(context))


### PR DESCRIPTION
...in example application.js for Stimulus when specifying filename pattern in context. Fixes #1477.