### PR TITLE
Handle race-conditions: .last-compilation-digest-test removed after existence check

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -40,6 +40,7 @@ class Webpacker::Compiler
   private
     def last_compilation_digest
       compilation_digest_path.read if compilation_digest_path.exist? && config.public_manifest_path.exist?
+    rescue Errno::ENOENT, Errno::ENOTDIR
     end
 
     def watched_files_digest
@@ -54,6 +55,7 @@ class Webpacker::Compiler
 
     def remove_compilation_digest
       compilation_digest_path.delete if compilation_digest_path.exist?
+    rescue Errno::ENOENT, Errno::ENOTDIR
     end
 
     def run_webpack


### PR DESCRIPTION
I encountered errors about `No such file or directory` about `.last-compilation-digest-test`.

Though it doesn't happen at local machine(sequential execution), it happens frequently at CI environment(4x parallel execution).  So I guess it is caused by race condition between existence check and its removal.

```ruby
# lib/webpacker/compiler.rb
def remove_compilation_digest
  if compilation_digest_path.exist?
    # another process removes compilation_digest_path(i.e. .last-compilation-digest-test) !!
    compilation_digest_path.delete 
  end
end
```

I added `rescue` clause to prevent this and the problem was solved in same environment.

## Env
 - Ruby: 2.5.1
 - Rails: 5.2.0
 - node: 10.0.0
 - Webpacker/`@rails/webpacker`: 3.5.3

## Stack trace
```
Failures:

  1) xxxxxxx
     Failure/Error: = javascript_pack_tag 'xxx'

     ActionView::Template::Error:
       No such file or directory @ rb_sysopen - /home/standfirm/sfinvoice/script/rrrspec/tmp/rrrspec-working/shared/tmp/cache/webpacker/.last-compilation-digest-test
     # /home/standfirm/.rvm/gems/ruby-2.5.1/gems/webpacker-3.5.3/lib/webpacker/compiler.rb:42:in `read'
     # /home/standfirm/.rvm/gems/ruby-2.5.1/gems/webpacker-3.5.3/lib/webpacker/compiler.rb:42:in `read'
     # /home/standfirm/.rvm/gems/ruby-2.5.1/gems/webpacker-3.5.3/lib/webpacker/compiler.rb:42:in `last_compilation_digest'
     # /home/standfirm/.rvm/gems/ruby-2.5.1/gems/webpacker-3.5.3/lib/webpacker/compiler.rb:32:in `fresh?'
     # /home/standfirm/.rvm/gems/ruby-2.5.1/gems/webpacker-3.5.3/lib/webpacker/compiler.rb:37:in `stale?'
     # /home/standfirm/.rvm/gems/ruby-2.5.1/gems/webpacker-3.5.3/lib/webpacker/compiler.rb:20:in `compile'
     # /home/standfirm/.rvm/gems/ruby-2.5.1/gems/webpacker-3.5.3/lib/webpacker/manifest.rb:36:in `block in compile'
     # /home/standfirm/.rvm/gems/ruby-2.5.1/gems/webpacker-3.5.3/lib/webpacker/manifest.rb:36:in `compile'
     # /home/standfirm/.rvm/gems/ruby-2.5.1/gems/webpacker-3.5.3/lib/webpacker/manifest.rb:22:in `lookup'
     # /home/standfirm/.rvm/gems/ruby-2.5.1/gems/webpacker-3.5.3/lib/webpacker/manifest.rb:27:in `lookup!'
     # /home/standfirm/.rvm/gems/ruby-2.5.1/gems/webpacker-3.5.3/lib/webpacker/helper.rb:86:in `block in sources_from_pack_manifest'
     # /home/standfirm/.rvm/gems/ruby-2.5.1/gems/webpacker-3.5.3/lib/webpacker/helper.rb:86:in `map'
     # /home/standfirm/.rvm/gems/ruby-2.5.1/gems/webpacker-3.5.3/lib/webpacker/helper.rb:86:in `sources_from_pack_manifest'
     # /home/standfirm/.rvm/gems/ruby-2.5.1/gems/webpacker-3.5.3/lib/webpacker/helper.rb:55:in `javascript_pack_tag'
     # ./app/views/foo/_form.html.haml:1:in `_app_views_foo__form_html_haml___95347850749341058_69966697625360'
(snip)
```