### PR TITLE
Default mode should be development for npm

### DIFF
--- a/package/__tests__/env.js
+++ b/package/__tests__/env.js
@@ -22,7 +22,7 @@ describe('Env', () => {
     delete process.env.NODE_ENV
     expect(require('../env')).toEqual({
       railsEnv: 'development',
-      nodeEnv: 'production'
+      nodeEnv: 'development'
     })
   })
 
@@ -30,8 +30,8 @@ describe('Env', () => {
     delete process.env.NODE_ENV
     delete process.env.RAILS_ENV
     expect(require('../env')).toEqual({
-      railsEnv: 'production',
-      nodeEnv: 'production'
+      railsEnv: 'development',
+      nodeEnv: 'development'
     })
   })
 
@@ -40,7 +40,7 @@ describe('Env', () => {
     process.env.NODE_ENV = 'staging'
     expect(require('../env')).toEqual({
       railsEnv: 'staging',
-      nodeEnv: 'production'
+      nodeEnv: 'development'
     })
   })
 })

--- a/package/__tests__/production.js
+++ b/package/__tests__/production.js
@@ -13,6 +13,7 @@ describe('Production environment', () => {
 
     test('should use production config and environment', () => {
       process.env.RAILS_ENV = 'production'
+      process.env.NODE_ENV = 'production'
       const { environment } = require('../index')
 
       const config = environment.toWebpackConfig()

--- a/package/__tests__/staging.js
+++ b/package/__tests__/staging.js
@@ -19,8 +19,7 @@ describe('Custom environment', () => {
       expect(config.output.path).toEqual(resolve('public', 'packs-staging'))
       expect(config.output.publicPath).toEqual('/packs-staging/')
       expect(config).toMatchObject({
-        devtool: 'nosources-source-map',
-        stats: 'normal'
+        "devtool": "cheap-module-source-map"
       })
     })
   })

--- a/package/env.js
+++ b/package/env.js
@@ -3,7 +3,8 @@ const { safeLoad } = require('js-yaml')
 const { readFileSync } = require('fs')
 
 const NODE_ENVIRONMENTS = ['development', 'production']
-const DEFAULT = 'production'
+const DEFAULT = 'development'
+
 const configPath = resolve('config', 'webpacker.yml')
 
 const railsEnv = process.env.RAILS_ENV

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -76,7 +76,7 @@ const getModulePaths = () => {
 
 const getBaseConfig = () =>
   new ConfigObject({
-    mode: 'production',
+    mode: 'development',
     output: {
       filename: '[name]-[chunkhash].js',
       chunkFilename: '[name]-[chunkhash].chunk.js',


### PR DESCRIPTION
In use from npm context, NODE_ENV is not set as default.
So default `mode` should be development on npm way, don't you think?
I appliciate if you consider.