### PR TITLE
[ci skip] Improve the description of Upgrading

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ You can run following commands to upgrade Webpacker to the latest stable version
 
 ```bash
 bundle update webpacker
+rails webpacker:binstubs
 yarn upgrade @rails/webpacker --latest
 yarn add webpack-dev-server@^2.11.1
 


### PR DESCRIPTION
Without updating the binstub, `bin/webpack-dev-server` results in `Gem::Exception`.

```
/Users/tanimichi.tsukuru/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/rubygems_integration.rb:458:in `block in replace_bin_path': can't find executable webpack-dev-server for gem webpacker (Gem::Exception)
    from /Users/tanimichi.tsukuru/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/bundler-1.16.1/lib/bundler/rubygems_integration.rb:489:in `block in replace_bin_path'
    from bin/webpack-dev-server:21:in `<main>'
(snip)
```