### PR TITLE
Reconcile RAILS_ENV and NODE_ENV

### DIFF
--- a/lib/install/bin/webpack
+++ b/lib/install/bin/webpack
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 
-ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
-ENV["NODE_ENV"]  ||= "development"
+ENV["RAILS_ENV"] ||= ENV["RACK_ENV"]
+ENV["RAILS_ENV"] ||= ENV["NODE_ENV"]
+ENV["RAILS_ENV"] || "development"
+ENV["NODE_ENV"] = ENV["RAILS_ENV"]
 
 require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",

--- a/lib/install/bin/webpack-dev-server
+++ b/lib/install/bin/webpack-dev-server
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 
-ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
-ENV["NODE_ENV"]  ||= "development"
+ENV["RAILS_ENV"] ||= ENV["RACK_ENV"]
+ENV["RAILS_ENV"] ||= ENV["NODE_ENV"]
+ENV["RAILS_ENV"] || "development"
+ENV["NODE_ENV"] = ENV["RAILS_ENV"]
 
 require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",


### PR DESCRIPTION
### Motivation:
Webpacker picks a section from config/webpacker.yml based on RAILS_ENV.  But it determines which environment files from config/webpack/*.js will be used based on NODE_ENV.

Bad (or at least quite confusing) things will happen when NODE_ENV and RAILS_ENV are different.

It is especially easy to have them set to different things by setting one (but not both) to 'production' or 'test' on the command line, e.g.
```bash
$ RAILS_ENV=production ./bin/webpack
```
If a user doesn't otherwise have NODE_ENV set, this will use the `production:` section in webpacker.yml, but run the config/development.js setup file.

### Fix:

This PR makes sure RAILS_ENV and NODE_ENV are set to the same thing.  

If both are set, with different values, then RAILS_ENV wins*.  If neither is set, RACK_ENV is used, and if that's not set either, we default to 'development'.

\* js programmers coming to Rails are likely to learn about RAILS_ENV soon, while Rails programmers adopting webpacker are unlikely to learn about node.js or NODE_ENV from the front-end libraries/frameworks they've chosen.