### PR TITLE
Use ecma: 5 uglification in production

### DIFF
--- a/package/environments/production.js
+++ b/package/environments/production.js
@@ -26,7 +26,7 @@ module.exports = class extends Base {
             cache: true,
             sourceMap: true,
             uglifyOptions: {
-              ecma: 8,
+              ecma: 5,
               compress: {
                 warnings: false,
                 comparisons: false


### PR DESCRIPTION
### Motivation:

As much as I would love to bring about a brighter js future, for the time being almost every project out there is going to need to support MS IE11, and that means using `ecma: 5` in instead of `ecma: 8` for production uglification.

See also: https://github.com/rails/webpacker/issues/1235