### PR TITLE
Fast uglification in test environment

### DIFF
--- a/package/environments/production.js
+++ b/package/environments/production.js
@@ -31,9 +31,7 @@ module.exports = class extends Base {
                 warnings: false,
                 comparisons: false
               },
-              mangle: {
-                safari10: true
-              },
+              safari10: true,
               output: {
                 comments: false,
                 ascii_only: true

--- a/package/environments/test.js
+++ b/package/environments/test.js
@@ -1,3 +1,32 @@
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 const Base = require('./base')
 
-module.exports = class extends Base {}
+module.exports = class extends Base {
+  constructor() {
+    super()
+    
+    this.config.merge({
+      devtool: 'nosources-source-map',
+      stats: 'normal',
+      bail: true,
+      optimization: {
+        minimizer: [
+          new UglifyJsPlugin({
+            parallel: true,
+            cache: true,
+            sourceMap: false,
+            uglifyOptions: {
+              ecma: 5,
+              compress: false,
+              output: {
+                comments: false,
+                ascii_only: true
+              },
+              safari10: true
+            }
+          })
+        ]
+      }
+    })
+  }
+}


### PR DESCRIPTION
### Important note:

This PR will have no effect without https://github.com/rails/webpacker/pull/1513 or some other fix to the problem of config/webpack/test.js not loading when NODE_ENV=test.

(Alternate solution in [another branch](https://github.com/rails/webpacker/compare/master...PuddleByteComputing:no_hardcoded_environments?expand=1))

### Motivation:
- Everyone wants faster tests.
- Everyone who has a large project and a CI server is desperate for faster test setup
- Uglification via UglifyJS can take a (very) long time, if you use its "compress" options.

### Fix:

There's an 80/20 tradeoff to be had by turning off the `compress` options of UglifyJS and using only the `mangle` options.  The Uglification step is much faster (~70% reduction for *the entire webpack build*) and the resulting file sizes are only ~15% larger.  So we:

- Turn off all `compress:` options in test, but keep mangling on (the default)
- Don't change production; we want full file-shrinkage and don't care (as much) about speed in deployments
- also, while we're at it, move the safari10 option to [where it belongs](https://github.com/mishoo/UglifyJS2/tree/harmony#minify-options) in the config

### Real-world Time/File-size measurements:

This is all from a build on a Project of Substantial Size, with half a dozen packs corresponding to as many React SPAs.

**With production uglification (current implementioni)**
                                                                                                            
total build time                                                                                            
                                                                                                            
real    1m46.541s                                                                                           
user    7m9.968s                                                                                            
sys     0m8.180s                                                                                            
                                                                                                            
size of resulting largest_pack.js: 4.8M                                                                               
                                                                                                            
**with fast uglification (in test, as implemented in this PR)** 
                                                                                                            
total build time                                                                                            
                                                                                                            
real    0m21.620s                                                                                           
user    0m33.844s                                                                                           
sys     0m1.688s                                                                                            
                                                                                                            
size of resulting largest_pack.js: 5.6M                                                                               
                                                                                                            
                                                                                                            
**with no uglification in development (as currently implemented):**
                                                                                                            
real    0m21.053s                                                                                           
user    0m35.115s                                                                                           
sys     0m1.733s                                                                                            
                                                                                                            
size of resulting largest_pack.js: 18M
