### PR TITLE
Parse webpacker.yml with ERB to allow dynamic configurations

### DIFF
--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -1,3 +1,6 @@
+require "yaml"
+require "erb"
+
 class Webpacker::Configuration
   delegate :root_path, :config_path, :env, to: :@webpacker
 
@@ -67,7 +70,7 @@ class Webpacker::Configuration
     end
 
     def load
-      YAML.load(config_path.read)[env].deep_symbolize_keys
+      YAML.load(ERB.new(config_path.read).result)[env].deep_symbolize_keys
 
     rescue Errno::ENOENT => e
       raise "Webpacker configuration file not found #{config_path}. " \

--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -1,5 +1,6 @@
 require "shellwords"
 require "yaml"
+require "erb"
 require "socket"
 require "webpacker/runner"
 
@@ -14,7 +15,7 @@ module Webpacker
     private
       def load_config
         @config_file = File.join(@app_path, "config/webpacker.yml")
-        dev_server = YAML.load_file(@config_file)[ENV["RAILS_ENV"]]["dev_server"]
+        dev_server = YAML.load(ERB.new(File.read(@config_file)).result)[ENV["RAILS_ENV"]]["dev_server"]
 
         @hostname          = dev_server["host"]
         @port              = dev_server["port"]

--- a/test/test_app/config/webpacker.yml
+++ b/test/test_app/config/webpacker.yml
@@ -36,7 +36,8 @@ development:
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:
     https: false
-    host: localhost
+    # For testing ERB
+    host: <%= 'localhost' %>
     port: 3035
     public: localhost:3035
     hmr: false


### PR DESCRIPTION
This PR enhance Webpacker configuration management to allow having _dynamic_ values in `webpacker.yml`.

We have the following use case: some people in our team uses Docker for development (mostly backend devs), others use their host machines. We're running webpack-dev-server as a separate docker service, so we have to specify its hostname (within Docker network) in the `webpacker.yml`; but we cannot hard-code it since other devs use default "localhost".

With the provided patch our config looks like this:

```yml
development:
  <<: *default
  compile: true

  # Reference: https://webpack.js.org/configuration/dev-server/
  dev_server:
    https: false
    host: <%= ENV['WEBPACKER_HOST'] || 'localhost' %>
    port: 3035
```
