### PR TITLE
Refactor configuration

### DIFF
--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -1,3 +1,7 @@
+require "yaml"
+require "active_support/core_ext/hash/keys"
+require "active_support/core_ext/hash/indifferent_access"
+
 class Webpacker::Configuration
   attr_reader :root_path, :config_path, :env
 

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -1,8 +1,10 @@
 class Webpacker::Configuration
-  delegate :root_path, :config_path, :env, to: :@webpacker
+  attr_reader :root_path, :config_path, :env
 
-  def initialize(webpacker)
-    @webpacker = webpacker
+  def initialize(root_path:, config_path:, env:)
+    @root_path = root_path
+    @config_path = config_path
+    @env = env
   end
 
   def refresh

--- a/lib/webpacker/dev_server.rb
+++ b/lib/webpacker/dev_server.rb
@@ -3,10 +3,10 @@ class Webpacker::DevServer
   # Webpacker.dev_server.connect_timeout = 1
   cattr_accessor(:connect_timeout) { 0.01 }
 
-  delegate :config, to: :@webpacker
+  attr_reader :config
 
-  def initialize(webpacker)
-    @webpacker = webpacker
+  def initialize(config)
+    @config = config
   end
 
   def running?
@@ -52,6 +52,10 @@ class Webpacker::DevServer
 
   def host_with_port
     "#{host}:#{port}"
+  end
+
+  def pretty?
+    fetch(:pretty)
   end
 
   private

--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -13,12 +13,19 @@ module Webpacker
 
     private
       def load_config
-        @config_file = File.join(@app_path, "config/webpacker.yml")
-        dev_server = YAML.load_file(@config_file)[ENV["RAILS_ENV"]]["dev_server"]
+        app_root = Pathname.new(@app_path)
 
-        @hostname          = dev_server["host"]
-        @port              = dev_server["port"]
-        @pretty            = dev_server.fetch("pretty", true)
+        config = Configuration.new(
+          root_path: app_root,
+          config_path: app_root.join("config/webpacker.yml"),
+          env: ENV["RAILS_ENV"]
+        )
+
+        dev_server = DevServer.new(config)
+
+        @hostname          = dev_server.host
+        @port              = dev_server.port
+        @pretty            = dev_server.pretty?
 
       rescue Errno::ENOENT, NoMethodError
         $stdout.puts "webpack dev_server configuration not found in #{@config_file}[#{ENV["RAILS_ENV"]}]."

--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -1,6 +1,7 @@
 require "shellwords"
-require "yaml"
 require "socket"
+require "webpacker/configuration"
+require "webpacker/dev_server"
 require "webpacker/runner"
 
 module Webpacker
@@ -28,7 +29,7 @@ module Webpacker
         @pretty            = dev_server.pretty?
 
       rescue Errno::ENOENT, NoMethodError
-        $stdout.puts "webpack dev_server configuration not found in #{@config_file}[#{ENV["RAILS_ENV"]}]."
+        $stdout.puts "webpack dev_server configuration not found in #{config.config_path}[#{ENV["RAILS_ENV"]}]."
         $stdout.puts "Please run bundle exec rails webpacker:install to install Webpacker"
         exit!
       end

--- a/lib/webpacker/instance.rb
+++ b/lib/webpacker/instance.rb
@@ -12,7 +12,11 @@ class Webpacker::Instance
   end
 
   def config
-    @config ||= Webpacker::Configuration.new self
+    @config ||= Webpacker::Configuration.new(
+      root_path: root_path,
+      config_path: config_path,
+      env: env
+    )
   end
 
   def compiler

--- a/lib/webpacker/instance.rb
+++ b/lib/webpacker/instance.rb
@@ -24,7 +24,7 @@ class Webpacker::Instance
   end
 
   def dev_server
-    @dev_server ||= Webpacker::DevServer.new self
+    @dev_server ||= Webpacker::DevServer.new config
   end
 
   def manifest

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,66 +1,90 @@
 require "test_helper"
 
 class ConfigurationTest < Webpacker::Test
+  def setup
+    @config = Webpacker::Configuration.new(
+      root_path: Pathname.new(File.expand_path("test_app", __dir__)),
+      config_path: Pathname.new(File.expand_path("./test_app/config/webpacker.yml", __dir__)),
+      env: "production"
+    )
+  end
+
   def test_source_path
     source_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/app/javascript").to_s
-    assert_equal source_path, Webpacker.config.source_path.to_s
+    assert_equal source_path, @config.source_path.to_s
   end
 
   def test_source_entry_path
     source_entry_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/app/javascript", "packs").to_s
-    assert_equal Webpacker.config.source_entry_path.to_s, source_entry_path
+    assert_equal @config.source_entry_path.to_s, source_entry_path
   end
 
   def test_public_output_path
     public_output_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/public/packs").to_s
-    assert_equal Webpacker.config.public_output_path.to_s, public_output_path
+    assert_equal @config.public_output_path.to_s, public_output_path
   end
 
   def test_public_manifest_path
     public_manifest_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/public/packs", "manifest.json").to_s
-    assert_equal Webpacker.config.public_manifest_path.to_s, public_manifest_path
+    assert_equal @config.public_manifest_path.to_s, public_manifest_path
   end
 
   def test_cache_path
     cache_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/tmp/cache/webpacker").to_s
-    assert_equal Webpacker.config.cache_path.to_s, cache_path
+    assert_equal @config.cache_path.to_s, cache_path
   end
 
   def test_resolved_paths
-    assert_equal Webpacker.config.resolved_paths, ["app/assets", "/etc/yarn"]
+    assert_equal @config.resolved_paths, ["app/assets", "/etc/yarn"]
   end
 
   def test_resolved_paths_globbed
-    assert_equal Webpacker.config.resolved_paths_globbed, ["app/assets/**/*", "/etc/yarn/**/*"]
+    assert_equal @config.resolved_paths_globbed, ["app/assets/**/*", "/etc/yarn/**/*"]
   end
 
   def test_extensions
     config_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/config/webpacker.yml").to_s
     webpacker_yml = YAML.load_file(config_path)
-    assert_equal Webpacker.config.extensions, webpacker_yml["default"]["extensions"]
+    assert_equal @config.extensions, webpacker_yml["default"]["extensions"]
   end
 
   def test_cache_manifest?
-    assert Webpacker.config.cache_manifest?
+    assert @config.cache_manifest?
 
-    with_rails_env("development") do
-      refute Webpacker.config.cache_manifest?
-    end
+    @config = Webpacker::Configuration.new(
+      root_path: @config.root_path,
+      config_path: @config.config_path,
+      env: "development"
+    )
 
-    with_rails_env("test") do
-      refute Webpacker.config.cache_manifest?
-    end
+    refute @config.cache_manifest?
+
+    @config = Webpacker::Configuration.new(
+      root_path: @config.root_path,
+      config_path: @config.config_path,
+      env: "test"
+    )
+
+    refute @config.cache_manifest?
   end
 
   def test_compile?
-    refute Webpacker.config.compile?
+    refute @config.compile?
 
-    with_rails_env("development") do
-      assert Webpacker.config.compile?
-    end
+    @config = Webpacker::Configuration.new(
+      root_path: @config.root_path,
+      config_path: @config.config_path,
+      env: "development"
+    )
 
-    with_rails_env("test") do
-      assert Webpacker.config.compile?
-    end
+    assert @config.compile?
+
+    @config = Webpacker::Configuration.new(
+      root_path: @config.root_path,
+      config_path: @config.config_path,
+      env: "test"
+    )
+
+    assert @config.compile?
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,8 +17,10 @@ class Webpacker::Test < Minitest::Test
     def reloaded_config
       Webpacker.instance.instance_variable_set(:@env, nil)
       Webpacker.instance.instance_variable_set(:@config, nil)
+      Webpacker.instance.instance_variable_set(:@dev_server, nil)
       Webpacker.env
       Webpacker.config
+      Webpacker.dev_server
     end
 
     def with_rails_env(env)

--- a/test/webpacker_test.rb
+++ b/test/webpacker_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class WebpackerTest < Webpacker::Test
+  def test_config_params
+    assert_equal Rails.env, Webpacker.config.env
+    assert_equal Webpacker.instance.root_path, Webpacker.config.root_path
+    assert_equal Webpacker.instance.config_path, Webpacker.config.config_path
+
+    with_rails_env("test") do
+      assert_equal "test", Webpacker.config.env
+    end
+  end
+end


### PR DESCRIPTION
This PR refactors configuration classes to make it possible to re-use then in runners.

This way we can support env variable in `DevServerRunner` too (the same way as we do in Webpacker itself).

See also the discussion https://github.com/rails/webpacker/pull/1515#issuecomment-390898745

/cc @gauravtiwari 