### PR TITLE
Add semicolon to default "Hello World"-message statement

### DIFF
--- a/lib/install/javascript/packs/application.js
+++ b/lib/install/javascript/packs/application.js
@@ -7,4 +7,4 @@
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
 
-console.log('Hello World from Webpacker')
+console.log('Hello World from Webpacker');


### PR DESCRIPTION
After upgrading `webpacker` for our Rails apps, our JS linter complained about the missing semicolon here. Do you agree on adding it?