### PR TITLE
On CI, sort files & check modified w/ digest intead of mtime

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -44,7 +44,12 @@ class Webpacker::Compiler
 
     def watched_files_digest
       files = Dir[*default_watched_paths, *watched_paths].reject { |f| File.directory?(f) }
-      Digest::SHA1.hexdigest(files.map { |f| "#{File.basename(f)}/#{File.mtime(f).utc.to_i}" }.join("/"))
+      file_ids = if ENV["CI"]
+        files.sort.map { |f| "#{File.basename(f)}/#{Digest::SHA1.file(f).hexdigest}" }
+      else
+        files.map { |f| "#{File.basename(f)}/#{File.mtime(f).utc.to_i}" }
+      end
+      Digest::SHA1.hexdigest(file_ids.join("/"))
     end
 
     def record_compilation_digest


### PR DESCRIPTION
In my quest to speed up our CI builds I noticed that, despite caching & restoring compiled packs & `tmp/cache/webpacker`, they were still being recompiled on every test run. It seems this is because the mtimes for all of the files will always be the time that the repo was cloned. As a result, I needed a different strategy for determining whether files were changed, so I'm computing SHA1 digests on a sorted list of files (I was also seeing inconsistency with file ordering between CI runs, so this ensures that the same list of files will be in the same order). To avoid killing performance outside of CI, I left the existing logic in place.

I'm open to suggestions about how to flag this, but I chose the CI env var because it seems that all major CI platforms set it.

It seems a further optimization could be made by caching the output of `watched_files_digest` because it seems to run a number of times on the same set of files during a CI build, which seems unnecessary. However, I know that a `Webpacker.instance` exists globally for a running Rails app, so I didn't want to implement that and have it failing to check for modified files when it should be. Any thoughts there? I can open a new issue to discuss separately.