### PR TITLE
Remove semicolon in vue example for consistency

### DIFF
--- a/lib/install/examples/vue/hello_vue.js
+++ b/lib/install/examples/vue/hello_vue.js
@@ -54,7 +54,7 @@ document.addEventListener('DOMContentLoaded', () => {
 //
 // Then uncomment the code block below:
 //
-// import TurbolinksAdapter from 'vue-turbolinks';
+// import TurbolinksAdapter from 'vue-turbolinks'
 // import Vue from 'vue/dist/vue.esm'
 // import App from '../app.vue'
 //


### PR DESCRIPTION
This is a small change that doesn't affect webpacker itself, it's just a detail in the code style.

