### PR TITLE
Exclude ruby-2.3.7 w/ rails edge from travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,6 @@ script:
 matrix:
   allow_failures:
   - gemfile: gemfiles/Gemfile-rails-edge
+  exclude:
+    - rvm: 2.3.7
+      gemfile: gemfiles/Gemfile-rails-edge


### PR DESCRIPTION
rails edge doesn't support ruby-2.3, so it always a failure