### PR TITLE
Fix uglify options and add css asset optimisation

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "js-yaml": "^3.12.0",
     "mini-css-extract-plugin": "^0.4.0",
     "node-sass": "^4.9.0",
+    "optimize-css-assets-webpack-plugin": "^4.0.2",
     "path-complete-extname": "^1.0.0",
     "postcss-import": "^11.1.0",
     "postcss-loader": "^2.1.5",

--- a/package/environments/production.js
+++ b/package/environments/production.js
@@ -1,5 +1,6 @@
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 const CompressionPlugin = require('compression-webpack-plugin')
+const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
 const Base = require('./base')
 
 module.exports = class extends Base {
@@ -15,6 +16,8 @@ module.exports = class extends Base {
       })
     )
 
+    this.plugins.append('OptimizeCSSAssets', new OptimizeCSSAssetsPlugin())
+
     this.config.merge({
       devtool: 'nosources-source-map',
       stats: 'normal',
@@ -26,8 +29,13 @@ module.exports = class extends Base {
             cache: true,
             sourceMap: true,
             uglifyOptions: {
-              ecma: 5,
+              parse: {
+                // Let uglify-js parse ecma 8 code but always output
+                // ES5 compliant code for older browsers
+                ecma: 8
+              },
               compress: {
+                ecma: 5,
                 warnings: false,
                 comparisons: false
               },
@@ -35,6 +43,7 @@ module.exports = class extends Base {
                 safari10: true
               },
               output: {
+                ecma: 5,
                 comments: false,
                 ascii_only: true
               }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3918,6 +3918,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
+last-call-webpack-plugin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz#9742df0e10e3cf46e5c0381c2de90d3a7a2d7555"
+  dependencies:
+    lodash "^4.17.5"
+    webpack-sources "^1.1.0"
+
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
@@ -4603,6 +4610,13 @@ optimist@^0.6.1:
   dependencies:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
+
+optimize-css-assets-webpack-plugin@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-4.0.2.tgz#813d511d20fe5d9a605458441ed97074d79c1122"
+  dependencies:
+    cssnano "^3.10.0"
+    last-call-webpack-plugin "^3.0.0"
 
 optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"


### PR DESCRIPTION
Ref: https://github.com/mishoo/UglifyJS2/tree/harmony#minify-options

Using different ECMA settings for various minification stages lets us avoid ES6 parsing problem + producing code that works in old browsers. 