### PR TITLE
Remove default value duplication in rakefile.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,8 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
-Rake::TestTask.new(:test) do |t|
+Rake::TestTask.new do |t|
   t.libs << "test"
-  t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]
   t.verbose = true
 end


### PR DESCRIPTION
It was bugging me that `rake test` was outputting the ruby command with `/.rbenv/versions/2.4.2/bin/ruby -w -I"lib:test:lib"`.

Rake already adds 'lib' to the ruby load path by default so we do not need to append it during rake test task definition.