### PR TITLE
add instructions for installing yarn package on master

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ gem 'webpacker', '~> 3.5'
 
 # OR if you prefer to use master
 gem 'webpacker', git: 'https://github.com/rails/webpacker.git'
+yarn add https://github.com/rails/webpacker.git
 
 # OR to try out 4.x pre-release
 gem 'webpacker', '>= 4.0.x'
-yarn add @rails/webpacker@4.0.0-pre.2 
+yarn add @rails/webpacker@4.0.0-pre.2
 ```
 
 Finally, run following to install Webpacker:


### PR DESCRIPTION
I tripped up on this issue: https://github.com/rails/webpacker/issues/1565

This PR adds instructions to install the yarn/npm package from master when you're installing the gem from master.