### PR TITLE
Fix environment variable logic for dev_server options to allow falsey values

### DIFF
--- a/package/dev_server.js
+++ b/package/dev_server.js
@@ -11,7 +11,7 @@ const devServerConfig = config.dev_server
 if (devServerConfig) {
   Object.keys(devServerConfig).forEach((key) => {
     const envValue = fetch(`WEBPACKER_DEV_SERVER_${key.toUpperCase().replace(/_/g, '')}`)
-    if (envValue) devServerConfig[key] = envValue
+    if (envValue !== undefined) devServerConfig[key] = envValue
   })
 }
 


### PR DESCRIPTION
### Expected Behaviour ✅ 
A configuration in `config/webpacker.yml` such as: 

```yaml
  dev_server:
    hmr: true
```

and an environment variable with the value `WEBPACKER_DEV_SERVER_HOT=false`, should set `devServer.hot` to `false`.

### Current Behaviour 🐞 
Settings can not be set to `false`, `null`, `0`, or `''` using environment variables, only truthy values can override the configuration file settings.

### Description 📖 
This pull request changes the logic to only skip the override if the return value from `fetch` is `undefined`, as otherwise it means that a setting's environment variable is set, and the user intends to override the value.