### PR TITLE
Require active_support’s string inquiry

### DIFF
--- a/lib/webpacker.rb
+++ b/lib/webpacker.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/module/attribute_accessors"
+require "active_support/core_ext/string/inquiry"
 require "active_support/logger"
 require "active_support/tagged_logging"
 


### PR DESCRIPTION
It’s used in Webpacker::Env and depending on which rails frameworks are chosen at boot, it may not always be required before webpacker runs.

This fixes the issue detailed in #1607 