### PR TITLE
convert to use ERB before loading YAML configuration

### DIFF
--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -1,3 +1,4 @@
+require "erb"
 require "yaml"
 require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/hash/indifferent_access"
@@ -73,7 +74,7 @@ class Webpacker::Configuration
     end
 
     def load
-      YAML.load(config_path.read)[env].deep_symbolize_keys
+      Rails.application.config_for(config_path, env: env).deep_symbolize_keys
 
     rescue Errno::ENOENT => e
       raise "Webpacker configuration file not found #{config_path}. " \

--- a/lib/webpacker/env.rb
+++ b/lib/webpacker/env.rb
@@ -1,3 +1,4 @@
+require "erb"
 class Webpacker::Env
   DEFAULT = "production".freeze
 
@@ -27,7 +28,7 @@ class Webpacker::Env
 
     def available_environments
       if config_path.exist?
-        YAML.load(config_path.read).keys
+        YAML.load(ERB.new(config_path.read).result).keys
       else
         [].freeze
       end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,3 +1,4 @@
+require "erb"
 require "test_helper"
 
 class ConfigurationTest < Webpacker::Test
@@ -43,8 +44,8 @@ class ConfigurationTest < Webpacker::Test
   end
 
   def test_extensions
-    config_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/config/webpacker.yml").to_s
-    webpacker_yml = YAML.load_file(config_path)
+    config_path = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), "test_app/config/webpacker.yml").to_s))
+    webpacker_yml = YAML.load(ERB.new(config_path.read).result)
     assert_equal @config.extensions, webpacker_yml["default"]["extensions"]
   end
 

--- a/test/test_app/config/webpacker.yml
+++ b/test/test_app/config/webpacker.yml
@@ -48,7 +48,7 @@ development:
 
 test:
   <<: *default
-  compile: true
+  compile: <%= 0 == 0 ? 'true' : 'false' %>
 
   # Compile test packs to a separate directory
   public_output_path: packs-test


### PR DESCRIPTION
For issue #1615 , adding the ability use ERB to modify the `webpacker.yml` before consumption by `YAML.load`.

This allows for configuration settings to be modified based on the environment, e.g.:

```
  test:
    <<: *default
    compile: <%= ENV['CI'] ? 'false' : 'true %>
```

to test with precompiled assets in CI.

