### PR TITLE
Read postcss configs on a root project directory.

### DIFF
--- a/package/utils/get_style_rule.js
+++ b/package/utils/get_style_rule.js
@@ -3,7 +3,6 @@ const path = require('path')
 const devServer = require('../dev_server')
 const { nodeEnv } = require('../env')
 
-const postcssConfigPath = path.resolve(process.cwd(), '.postcssrc.yml')
 const isProduction = nodeEnv === 'production'
 const inDevServer = process.argv.find(v => v.includes('webpack-dev-server'))
 const isHMR = inDevServer && (devServer && devServer.hmr)
@@ -31,8 +30,7 @@ const getStyleRule = (test, modules = false, preprocessors = []) => {
     {
       loader: 'postcss-loader',
       options: {
-        sourceMap: true,
-        config: { path: postcssConfigPath }
+        sourceMap: true
       }
     },
     ...preprocessors


### PR DESCRIPTION
It is impossible to put logic in `.postcssrc.yml`. In order to make `postcss-loader` to read the `postcss.config.js` file, a `path` option should be deleted.