### PR TITLE
Make compilation digest file visible

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -87,7 +87,7 @@ class Webpacker::Compiler
     end
 
     def compilation_digest_path
-      config.cache_path.join(".last-compilation-digest-#{Webpacker.env}")
+      config.cache_path.join("last-compilation-digest-#{Webpacker.env}")
     end
 
     def webpack_env

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -59,6 +59,6 @@ class CompilerTest < Minitest::Test
   end
 
   def test_compilation_digest_path
-    assert Webpacker.compiler.send(:compilation_digest_path).to_s.ends_with?(Webpacker.env)
+    assert_equal Webpacker.compiler.send(:compilation_digest_path).basename.to_s, "last-compilation-digest-#{Webpacker.env}"
   end
 end


### PR DESCRIPTION
Test pack caching was introduced in https://github.com/rails/webpacker/pull/539, and users are able to specify a desired [`cache_path`](https://github.com/rails/webpacker/blob/88ff79c2f46aedf94d95e0325c37b40e71f0f4a9/lib/install/config/webpacker.yml#L7) in the config. The cache path is used potentially by other caches, such as [bable-loader](https://github.com/rails/webpacker/pull/629).

From a user's perspective, it can be confusing not seeing the compilation digest file by following the `cache_path`, but seeing other cache files such as bable-loader caches. This makes it consistent.