### PR TITLE
Let’s test against Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ gemfile:
   - gemfiles/Gemfile-rails.4.2.x
   - gemfiles/Gemfile-rails.5.0.x
   - gemfiles/Gemfile-rails.5.1.x
+  - gemfiles/Gemfile-rails.5.2.x
   - gemfiles/Gemfile-rails-edge
 cache:
   bundler: true

--- a/gemfiles/Gemfile-rails.4.2.x
+++ b/gemfiles/Gemfile-rails.4.2.x
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "webpacker", path: ".."
 
-gem "rails", "~> 4.2"
+gem "rails", "~> 4.2.0"
 gem "rake", ">= 11.1"
 gem "rubocop", ">= 0.49", require: false
 gem "rack-proxy", require: false

--- a/gemfiles/Gemfile-rails.5.0.x
+++ b/gemfiles/Gemfile-rails.5.0.x
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "webpacker", path: ".."
 
-gem "rails", "~> 5.0"
+gem "rails", "~> 5.0.0"
 gem "rake", ">= 11.1"
 gem "rubocop", ">= 0.49", require: false
 gem "rack-proxy", require: false

--- a/gemfiles/Gemfile-rails.5.1.x
+++ b/gemfiles/Gemfile-rails.5.1.x
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "webpacker", path: ".."
 
-gem "rails", "~> 5.1"
+gem "rails", "~> 5.1.0"
 gem "rake", ">= 11.1"
 gem "rubocop", ">= 0.49", require: false
 gem "rack-proxy", require: false

--- a/gemfiles/Gemfile-rails.5.2.x
+++ b/gemfiles/Gemfile-rails.5.2.x
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gem "webpacker", path: ".."
+
+gem "rails", "~> 5.2.0"
+gem "rake", ">= 11.1"
+gem "rubocop", ">= 0.49", require: false
+gem "rack-proxy", require: false
+gem "minitest", "~> 5.0"
+gem "byebug"


### PR DESCRIPTION
NOTE: https://github.com/rails/webpacker/commit/c5b63f843f25916a52d85da98691b3e37b04f811

> `~> 5.1` doesn't mean `5.1.x`. It means `5.x`. Now CIs aren't executed correctly.
> ref. https://bundler.io/v1.5/gemfile.html#gemfiles
