### PR TITLE
docs: avoid confusion with  dynamic import()

### DIFF
--- a/docs/es6.md
+++ b/docs/es6.md
@@ -26,7 +26,7 @@ import "@babel/polyfill"
 ```
 
 
-## Module import() vs require()
+## Module import vs require()
 
 While you are free to use `require()` and `module.exports`, we encourage you
 to use `import` and `export` instead since it reads and looks much better.


### PR DESCRIPTION
This document refers to ES6 `import/export default, {named}` syntax.  Webpack currently supports ESNext dynamic `import('./path/to/module')` syntax for lazy-loading modules.  To avoid confusion between the two, I've removed the parentheses on the `import`.