### PR TITLE
Remove polyfill option

### DIFF
--- a/lib/install/config/.babelrc
+++ b/lib/install/config/.babelrc
@@ -22,7 +22,6 @@
       "@babel/plugin-transform-runtime",
       {
         "helpers": false,
-        "polyfill": false,
         "regenerator": true
       }
     ],

--- a/lib/install/examples/react/.babelrc
+++ b/lib/install/examples/react/.babelrc
@@ -28,7 +28,6 @@
       "@babel/plugin-transform-runtime",
       {
         "helpers": false,
-        "polyfill": false,
         "regenerator": true
       }
     ],


### PR DESCRIPTION
When I try to use webpacker v4, occurred an error like this: `The 'polyfill' option has been removed. The @babel/runtime module now skips polyfilling by default.`

This error introduced from `@babel/plugin-transform-runtime` version `7.0.0-beta.55`.

Currently, webpacker specifies greater than or equal to `7.0.0-beta.49`. I think users who are using the latest will fail to build.

So I removed this option on this PR. Perhaps, we can update babel to latest rc versions.