### PR TITLE
Stop to use shorthand preset package name

### DIFF
--- a/lib/install/config/.babelrc
+++ b/lib/install/config/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
     [
-      "@babel/env",
+      "@babel/preset-env",
       {
         "modules": false,
         "forceAllTransforms": true,

--- a/lib/install/examples/react/.babelrc
+++ b/lib/install/examples/react/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
     [
-      "@babel/env",
+      "@babel/preset-env",
       {
         "modules": false,
         "forceAllTransforms": true,


### PR DESCRIPTION
this project isn't using shorthand package naming like `@babel/react`, `@babel/transform-runtime` except `@babel/env` at `.babelrc` file. I'm little confused about this.

I want to unify this official package naming rules. see more: https://babeljs.io/docs/en/next/v7-migration.html#package-renames

What do you think?