### PR TITLE
Allow absolute imports from app/javascript for Typescript

### DIFF
--- a/lib/install/examples/typescript/tsconfig.json
+++ b/lib/install/examples/typescript/tsconfig.json
@@ -6,6 +6,10 @@
     "lib": ["es6", "dom"],
     "module": "es6",
     "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+        "*": ["node_modules/*", "app/javascript/*"]
+    },
     "sourceMap": true,
     "target": "es5"
   },


### PR DESCRIPTION
Given a directory structure like so:

```
app/
  ...
  javascript/
    packs/
      hello_typescript.ts
    my-analytics.ts
node_modules/
...
tsconfig.json
```

With the current `tsconfig.json` setup `hello_typescript.ts` will have to access `my-analytics.ts` like so:

**app/javascript/packs/hello_typescript.ts**
```typescript
import analytics from "../my-analytics"
```

Personally, I think relative imports are the devil.  If you use relative imports when referencing modules outside of the file's parent directory, then moving `packs/hello_typescript.ts` to `packs/hello_typescript/index.ts` will force you to update all your imports. Yuck.

This PR makes the default behaviour allow for:

**app/javascript/packs/hello_typescript.ts**
```typescript
import analytics from "my-analytics"
```

This is actually in line with how `webpacker` is currently setup. There is no change to behaviour, it just lets the Typescript compiler know how it should resolve modules.
