### PR TITLE
Improve webpack url-loader example

### DIFF
--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -168,8 +168,12 @@ module.exports = {
 // config/webpack/environment.js
 
 const { environment } = require('@rails/webpacker')
+const url = require('./loaders/url')
 
 environment.loaders.prepend('url', url)
+
+// avoid using both file and url loaders
+environment.loaders.get('file').test = /\.(tiff|ico|svg|eot|otf|ttf|woff|woff2)$/i
 ```
 
 ### Overriding Loader Options in webpack 3+ (for CSS Modules etc.)


### PR DESCRIPTION
when using both url-loader and file loader, you get the file pathname base64'd instead of the image data