### PR TITLE
Fixes Webpacker::Compiler.env accessible to binstubs

### DIFF
--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -44,7 +44,7 @@ module Webpacker
       end
 
       def execute_cmd
-        env = { "NODE_PATH" => @node_modules_path.shellescape }
+        env = Webpacker::Compiler.env.merge("NODE_PATH" => @node_modules_path.shellescape)
         cmd = [
           "#{@node_modules_path}/.bin/webpack-dev-server",
           "--config", @webpack_config

--- a/lib/webpacker/webpack_runner.rb
+++ b/lib/webpacker/webpack_runner.rb
@@ -4,7 +4,7 @@ require "webpacker/runner"
 module Webpacker
   class WebpackRunner < Webpacker::Runner
     def run
-      env = { "NODE_PATH" => @node_modules_path.shellescape }
+      env = Webpacker::Compiler.env.merge("NODE_PATH" => @node_modules_path.shellescape)
       cmd = [ "#{@node_modules_path}/.bin/webpack", "--config", @webpack_config ] + @argv
 
       Dir.chdir(@app_path) do


### PR DESCRIPTION
#691 added the ability to set environment variables that can be read by the compiler, but these are only set when using the compiler directly (e.g. via `assets:precompile`). Environment variables set via the compiler are not accessible to `./bin/webpack` or `./bin/webpack-dev-server`, so manual compilation and development access does not work.

This patch fixes #1641. Webpacker::Compiler.env will be accessible in the binstubs when manually compiling or in development mode.

This is a production deployment blocker for us.