### PR TITLE
Handle case were webpacker root is different from the working directory

### DIFF
--- a/lib/install/bin/webpack
+++ b/lib/install/bin/webpack
@@ -12,4 +12,8 @@ require "bundler/setup"
 
 require "webpacker"
 require "webpacker/webpack_runner"
-Webpacker::WebpackRunner.run(ARGV)
+
+APP_ROOT = File.expand_path("..", __dir__)
+Dir.chdir(APP_ROOT) do
+  Webpacker::WebpackRunner.run(ARGV)
+end

--- a/lib/install/bin/webpack-dev-server
+++ b/lib/install/bin/webpack-dev-server
@@ -12,4 +12,8 @@ require "bundler/setup"
 
 require "webpacker"
 require "webpacker/dev_server_runner"
-Webpacker::DevServerRunner.run(ARGV)
+
+APP_ROOT = File.expand_path("..", __dir__)
+Dir.chdir(APP_ROOT) do
+  Webpacker::DevServerRunner.run(ARGV)
+end

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -66,7 +66,7 @@ class Webpacker::Compiler
     def run_webpack
       logger.info "Compiling…"
 
-      stdout, sterr , status = Open3.capture3(webpack_env, "#{RbConfig.ruby} ./bin/webpack")
+      stdout, sterr , status = Open3.capture3(webpack_env, "#{RbConfig.ruby} #{@webpacker.root_path}/bin/webpack")
 
       if status.success?
         logger.info "Compiled all packs in #{config.public_output_path}"


### PR DESCRIPTION
Webpacker currently assumes that it the working directory is the root of the application. However, this is not always the case.

In a generated rails plugin, the rails application is within `test/dummy` causing the working directory and the web packer root to be different. As a result, webpacker can't find the `./bin/webpack` script during compilation.

This PR uses the web packer `root_path` to find the binstub for web packer, and makes each of the binstubs move into applications directory before running.

This is required to get the test  at https://github.com/rails/rails/blob/09583ffad1c0d57003be3bf8f9dcc53660f77e46/railties/test/generators/scaffold_generator_test.rb#L522 passing for rails/rails#33079