### PR TITLE
move integrety check config to yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,16 +278,20 @@ yarn add @rails/webpacker@4.0.0-pre.2
 
 By default, in development, webpacker runs a yarn integrity check to ensure that all local JavaScript packages are up-to-date. This is similar to what bundler does currently in Rails, but for JavaScript packages. If your system is out of date, then Rails will not initialize. You will be asked to upgrade your local JavaScript packages by running `yarn install`.
 
-To turn off this option, you will need to override the default by adding a new config option to your Rails development environment configuration file (`config/environment/development.rb`):
+To turn off this option, you will need to change the default setting in `config/webpacker.yml`:
 
-```
-config.webpacker.check_yarn_integrity = false
+```yaml
+# config/webpacker.yml
+development:
+  ...
+  # Verifies that versions and hashed value of the package contents in the project's package.json
+  check_yarn_integrity: false
 ```
 
-You may also turn on this feature by adding the config option to any Rails environment configuration file:
+You may also turn on this feature by adding the config option for any Rails environment in `config/webpacker.yml`:
 
-```
-config.webpacker.check_yarn_integrity = true
+```yaml
+  check_yarn_integrity: true
 ```
 
 ## Integrations

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -5,6 +5,7 @@ default: &default
   source_entry_path: packs
   public_output_path: packs
   cache_path: tmp/cache/webpacker
+  check_yarn_integrity: false
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
@@ -30,6 +31,9 @@ default: &default
 development:
   <<: *default
   compile: true
+
+  # Verifies that versions and hashed value of the package contents in the project's package.json
+  check_yarn_integrity: true
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -22,21 +22,6 @@ end
 
 apply "#{__dir__}/binstubs.rb"
 
-say "Adding configurations"
-
-check_yarn_integrity_config = ->(value) { <<CONFIG.indent(2) }
-# Verifies that versions and hashed value of the package contents in the project's package.json
-config.webpacker.check_yarn_integrity = #{value}
-CONFIG
-
-if Rails::VERSION::MAJOR >= 5
-  environment check_yarn_integrity_config.call("true"), env: :development
-  environment check_yarn_integrity_config.call("false"), env: :production
-else
-  inject_into_file "config/environments/development.rb", "\n#{check_yarn_integrity_config.call("true")}", after: "Rails.application.configure do", verbose: false
-  inject_into_file "config/environments/production.rb", "\n#{check_yarn_integrity_config.call("false")}", after: "Rails.application.configure do", verbose: false
-end
-
 if File.exists?(".gitignore")
   append_to_file ".gitignore", <<-EOS
 /public/packs

--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -11,7 +11,6 @@ class Webpacker::Commands
   end
 
   def bootstrap
-    config.refresh
     manifest.refresh
   end
 

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -11,10 +11,6 @@ class Webpacker::Configuration
     @env = env
   end
 
-  def refresh
-    @data = load
-  end
-
   def dev_server
     fetch(:dev_server)
   end
@@ -61,6 +57,14 @@ class Webpacker::Configuration
 
   def extensions
     fetch(:extensions)
+  end
+
+  def check_yarn_integrity=(value)
+    data[:check_yarn_integrity] = value
+  end
+
+  def check_yarn_integrity?
+    fetch(:check_yarn_integrity)
   end
 
   private

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -25,7 +25,7 @@ class CompilerTest < Minitest::Test
     assert_equal Webpacker.compiler.send(:default_watched_paths), [
       "app/assets/**/*",
       "/etc/yarn/**/*",
-      "test/test_app/app/javascript/**/*",
+      "app/javascript/**/*",
       "yarn.lock",
       "package.json",
       "config/webpack/**/*"

--- a/test/test_app/config.ru
+++ b/test/test_app/config.ru
@@ -1,0 +1,5 @@
+# This file allows the `Rails.root` to be correctly determined.
+
+require_relative "config/environment"
+
+run Rails.application

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,9 +8,7 @@ require_relative "test_app/config/environment"
 
 Rails.env = "production"
 
-Webpacker.instance = Webpacker::Instance.new \
-  root_path: Pathname.new(File.expand_path("test_app", __dir__)),
-  config_path: Pathname.new(File.expand_path("./test_app/config/webpacker.yml", __dir__))
+Webpacker.instance = ::Webpacker::Instance.new
 
 class Webpacker::Test < Minitest::Test
   private


### PR DESCRIPTION
Currently the `webpacker:install` task updates the `development.rb` and `production.rb` environment files. 

This is problematic in rails/rails#33079 as it causes some of the tests to hang while waiting for the user to confirm if they want to overwrite the files.

This PR moves this configuration into the `webpacker.yml` by default.

Setting it in environment files is still supported for backwards compatibility. I am not sure if this should be deprecated, or expanded to allow for anything to be set via the `Rails.application.config`.

In order to be able to merge the configs set in the environment files and those loaded in the yml file, I have moved the reloading of the config out of the bootstrapping, and added the webpacker.yml to the watch so that spring restarts the environment when it changes.
 