### PR TITLE
allow dev runner to behave like the main runner

### DIFF
--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -50,6 +50,7 @@ module Webpacker
           "--config", @webpack_config
         ]
         cmd += ["--progress", "--color"] if @pretty
+        cmd += @argv
 
         Dir.chdir(@app_path) do
           exec env, *cmd


### PR DESCRIPTION
We allowed the use of ARGS in `Webpacker::WebpackRunner` to pass
down any necessary arguments to webpack itself:

```ruby
cmd = [ "#{@node_modules_path}/.bin/webpack", "--config", @webpack_config ] + @argv
```

However, this was not the case for `Webpacker::DevServerRunner`. Hence,
it was not possible to run the dev runner as such:

```bash
./bin/webpack-dev-server --inline=false
```

This is depite the fact that ARGS are passed to DevServerRunner.