### PR TITLE
Use only safe css optimizations

### DIFF
--- a/package/environments/production.js
+++ b/package/environments/production.js
@@ -16,7 +16,11 @@ module.exports = class extends Base {
       })
     )
 
-    this.plugins.append('OptimizeCSSAssets', new OptimizeCSSAssetsPlugin())
+    this.plugins.append('OptimizeCSSAssets', new OptimizeCSSAssetsPlugin({
+      cssPreprocessorOptions: {
+        safe: true
+      }
+    }))
 
     this.config.merge({
       devtool: 'nosources-source-map',


### PR DESCRIPTION
OptimizeCSSAssetsPlugin uses a number of optimizations,
see this [list](https://cssnano.co/guides/optimisations).
The optimization in particular that caused us harm was
the
[zindex](https://github.com/cssnano/cssnano/tree/master/packages/postcss-zindex)
optimization which compresses zindex numbers (100, 200 -> 1, 2) for all
css that is processed by webpack.  Not all css in a Rails app is
processed by webpack.  The asset pipeline can still process stylesheets
in addition to css that is included into the code itself.

Including this css optimization into the framework was a breaking change
for us.

Co-authored-by: Chris Erin <chris.erin@gmail.com>
Co-authored-by: Ryan Messner <rpmessner@gmail.com>