### PR TITLE
Remove Dangling Code introduced from .postcssrc.yml change

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "package/index.js",
   "files": [
     "package",
-    "lib/install/config/webpacker.yml",
-    "lib/install/config/.postcssrc.yml"
+    "lib/install/config/webpacker.yml"
   ],
   "engines": {
     "node": ">=6.0.0",

--- a/package/utils/__tests__/get_style_rule.js
+++ b/package/utils/__tests__/get_style_rule.js
@@ -33,19 +33,4 @@ describe('getStyleRule', () => {
 
     expect(cssRule.use).toMatchObject(expect.arrayContaining(expectation))
   })
-
-  test('adds default postcssrc if one is not found', () => {
-    const fs = require('fs')
-    fs.existsSync = jest.fn()
-    fs.existsSync.mockReturnValue(false)
-
-    const cssRule = getStyleRule(/\.(css)$/i, true)
-    const loader = cssRule.use.find((currentLoader) => {
-      return currentLoader.loader === 'postcss-loader'
-    })
-
-    if (loader.options.config) {
-      expect(loader.options.config.path).toContain('lib/install/config/.postcssrc.yml');
-    }
-  });
 })

--- a/package/utils/get_style_rule.js
+++ b/package/utils/get_style_rule.js
@@ -1,6 +1,4 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
-const path = require('path')
-const { existsSync } = require('fs')
 const devServer = require('../dev_server')
 const { nodeEnv } = require('../env')
 
@@ -8,14 +6,6 @@ const isProduction = nodeEnv === 'production'
 const inDevServer = process.argv.find(v => v.includes('webpack-dev-server'))
 const isHMR = inDevServer && (devServer && devServer.hmr)
 const extractCSS = !isHMR || isProduction
-
-let postcssConfigPath
-
-if (existsSync(`${process.cwd()}/.postcssrc.yml`)) {
-  postcssConfigPath = path.resolve(process.cwd(), '.postcssrc.yml')
-} else {
-  postcssConfigPath = require.resolve('../../lib/install/config/.postcssrc.yml')
-}
 
 const styleLoader = {
   loader: 'style-loader',


### PR DESCRIPTION
Relates to https://github.com/rails/webpacker/issues/1623

In https://github.com/rails/webpacker/issues/1623, it was asked that we make the postcssrc.yml file optional, and that it would look for a file inside the lib file by default. However, there was another commit made before this was merged that removed the need for the postcssrc.yml file. This resulted in dangling code, which is removed in this pull request.