### PR TITLE
Upgrade to Elm 0.19

### DIFF
--- a/lib/install/elm.rb
+++ b/lib/install/elm.rb
@@ -22,14 +22,15 @@ copy_file "#{__dir__}/examples/elm/Main.elm",
 
 say "Installing all Elm dependencies"
 run "yarn add elm elm-webpack-loader"
-run "yarn add --dev elm-hot-loader"
-run "yarn run elm package install -- --yes"
+run "yarn add --dev elm-hot-webpack-loader"
+run "yarn run elm init"
+run "yarn run elm make"
 
 say "Updating webpack paths to include .elm file extension"
 insert_into_file Webpacker.config.config_path, "- .elm\n".indent(4), after: /extensions:\n/
 
 say "Updating Elm source location"
-gsub_file "elm-package.json", /\"\.\"\n/,
+gsub_file "elm.json", /\"\src\"\n/,
   %("#{Webpacker.config.source_path.relative_path_from(Rails.root)}"\n)
 
 say "Updating .gitignore to include elm-stuff folder"

--- a/lib/install/loaders/elm.js
+++ b/lib/install/loaders/elm.js
@@ -2,12 +2,11 @@ const { resolve } = require('path')
 
 const isProduction = process.env.NODE_ENV === 'production'
 const elmSource = resolve(process.cwd())
-const elmMake = `${elmSource}/node_modules/.bin/elm-make`
+const elmBinary = `${elmSource}/node_modules/.bin/elm`
 
-const elmDefaultOptions = { cwd: elmSource, pathToMake: elmMake }
+const elmDefaultOptions = { cwd: elmSource, pathToElm: elmBinary }
 const developmentOptions = Object.assign({}, elmDefaultOptions, {
   verbose: true,
-  warn: true,
   debug: true
 })
 
@@ -19,5 +18,5 @@ const elmWebpackLoader = {
 module.exports = {
   test: /\.elm(\.erb)?$/,
   exclude: [/elm-stuff/, /node_modules/],
-  use: isProduction ? [elmWebpackLoader] : [{ loader: 'elm-hot-loader' }, elmWebpackLoader]
+  use: isProduction ? [elmWebpackLoader] : [{ loader: 'elm-hot-webpack-loader' }, elmWebpackLoader]
 }


### PR DESCRIPTION
Fixes #1668 

Notable changes that affect webpacker:

- `elm-package.json` renamed to `elm.json`
- the [old hot loader](https://github.com/fluxxu/elm-hot-loader) doesn't support Elm 0.19, so it has been replaced by [klazuka/elm-hot-webpack-loader](https://github.com/klazuka/elm-hot-webpack-loader)
- the Elm compiler no longer accepts the `--warn` flag
- elm-webpack-loader renamed the `pathToMake` option to `pathToElm`