### PR TITLE
Specify class name in CSS modules in development

### DIFF
--- a/package/utils/get_style_rule.js
+++ b/package/utils/get_style_rule.js
@@ -22,6 +22,7 @@ const getStyleRule = (test, modules = false, preprocessors = []) => {
       options: {
         sourceMap: true,
         importLoaders: 2,
+        localIdentName: '[name]__[local]___[hash:base64:5]',
         modules
       }
     },


### PR DESCRIPTION
Addresses #1411.

I took the `localIdentName` from the docs, if there's a more sensible default please let me know.

If this isn't something the team thinks is necessary, I can close this.

Thanks!