### PR TITLE
check if `webpacker.yml` exists before check_yarn_integrity?

### DIFF
--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -29,7 +29,7 @@ class Webpacker::Engine < ::Rails::Engine
   #     - edit config/environments/production.rb
   #     - add `config.webpacker.check_yarn_integrity = true`
   initializer "webpacker.yarn_check" do |app|
-    if File.exist?("yarn.lock") && Webpacker.config.check_yarn_integrity?
+    if File.exist?("yarn.lock") && Webpacker.config.config_path.exist? && Webpacker.config.check_yarn_integrity?
       output = `yarn check --integrity 2>&1`
 
       unless $?.success?


### PR DESCRIPTION
If you already have `yarn.lock` and you want to add webpacker later, that is, if you add `webpacker` to your Gemfile, `rails new webpack:install` fails. 

https://github.com/rails/webpacker/blob/48d9fd52c3e9637dbb21e551b48c84c0f2dbb2ed/lib/webpacker/railtie.rb#L32
`Webpacker.config.check_yarn_integrity?` happens to load` config / webpacker.yml`, the following error occurs.
https://github.com/rails/webpacker/blob/48d9fd52c3e9637dbb21e551b48c84c0f2dbb2ed/lib/webpacker/configuration.rb#L82
```
      raise "Webpacker configuration file not found #{config_path}. " \
            "Please run rails webpacker:install " \
            "Error: #{e.message}"
```

So, I change to check if `webpacker.yml` exists before `Webpacker.config.check_yarn_integrity?`