### PR TITLE
Fix README to allow `test` as `NODE_ENV`

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ staging:
   public_output_path: packs-staging
 ```
 
-or, Webpacker will use production environment as a fallback environment for loading configurations. Please note, `NODE_ENV` can either be set to `production` or `development`.
+or, Webpacker will use production environment as a fallback environment for loading configurations. Please note, `NODE_ENV` can either be set to `production`, `development` or `test`.
 This means you don't need to create additional environment files inside `config/webpacker/*` and instead use webpacker.yml to load different configurations using `RAILS_ENV`.
 
 For example, the below command will compile assets in production mode but will use staging configurations from `config/webpacker.yml` if available or use fallback production environment configuration:


### PR DESCRIPTION
`NODE_ENV=test` is allowed by https://github.com/rails/webpacker/pull/1563.