### PR TITLE
Allow symbol for pack name on *_pack_tag helpers

### DIFF
--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -87,6 +87,6 @@ module Webpacker::Helper
     end
 
     def pack_name_with_extension(name, type:)
-      "#{name}#{compute_asset_extname(name, type: type)}"
+      "#{name}#{compute_asset_extname(name.to_s, type: type)}"
     end
 end

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -43,6 +43,12 @@ class HelperTest < ActionView::TestCase
       javascript_pack_tag("bootstrap.js")
   end
 
+  def test_javascript_pack_tag_symbol
+    assert_equal \
+      %(<script src="/packs/bootstrap-300631c4f0e0f9c865bc.js"></script>),
+      javascript_pack_tag(:bootstrap)
+  end
+
   def test_javascript_pack_tag_splat
     assert_equal \
       %(<script src="/packs/bootstrap-300631c4f0e0f9c865bc.js" defer="defer"></script>\n) +
@@ -54,6 +60,12 @@ class HelperTest < ActionView::TestCase
     assert_equal \
       %(<link rel="stylesheet" media="screen" href="/packs/bootstrap-c38deda30895059837cf.css" />),
       stylesheet_pack_tag("bootstrap.css")
+  end
+
+  def test_stylesheet_pack_tag_symbol
+    assert_equal \
+      %(<link rel="stylesheet" media="screen" href="/packs/bootstrap-c38deda30895059837cf.css" />),
+      stylesheet_pack_tag(:bootstrap)
   end
 
   def test_stylesheet_pack_tag_splat


### PR DESCRIPTION
Allow javascript_pack_tag and stylesheet_pack_tag to receive the pack
name argument also as a symbol instead of only as a string. This adds
consistency with rails javascript_include_tag and others which can
receive asset names as strings or symbols.