### PR TITLE
Add option to log webpack compile result

### DIFF
--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -6,6 +6,7 @@ default: &default
   public_output_path: packs
   cache_path: tmp/cache/webpacker
   check_yarn_integrity: false
+  webpack_compile_output: false
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -70,6 +70,7 @@ class Webpacker::Compiler
 
       if status.success?
         logger.info "Compiled all packs in #{config.public_output_path}"
+        logger.info stdout if config.webpack_compile_output?
       else
         logger.error "Compilation failed:\n#{sterr}\n#{stdout}"
       end

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -67,6 +67,10 @@ class Webpacker::Configuration
     fetch(:check_yarn_integrity)
   end
 
+  def webpack_compile_output?
+    fetch(:webpack_compile_output)
+  end
+
   private
     def fetch(key)
       data.fetch(key, defaults[key])

--- a/test/test_app/config/webpacker.yml
+++ b/test/test_app/config/webpacker.yml
@@ -5,6 +5,7 @@ default: &default
   source_entry_path: packs
   public_output_path: packs
   cache_path: tmp/cache/webpacker
+  webpack_compile_output: false
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']


### PR DESCRIPTION
Resolves #1702

I named the config option `webpack_compile_output` are we satisfied with that name or should it be more boolean-esque?