### PR TITLE
Have the *_pack_tag support entrypoints

### DIFF
--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -256,6 +256,47 @@ const { environment } = require('@rails/webpacker')
 environment.resolvedModules.append('vendor', 'vendor')
 ```
 
+### Add SplitChunks (Webpack V4)
+Originally, chunks (and modules imported inside them) were connected by a parent-child relationship in the internal webpack graph. The CommonsChunkPlugin was used to avoid duplicated dependencies across them, but further optimizations were not possible
+
+Since webpack v4, the CommonsChunkPlugin was removed in favor of optimization.splitChunks.
+
+For the full configuration options of SplitChunks, see the [Webpack documentation](https://webpack.js.org/plugins/split-chunks-plugin/).
+
+```js
+// config/webpack/environment.js
+const WebpackAssetsManifest = require('webpack-assets-manifest');
+
+const splitChunks = {
+  optimization: {
+    splitChunks: {
+      chunks: 'all'
+    },
+  },
+};
+
+environment.config.merge(splitChunks);
+
+// Should override the existing manifest plugin
+environment.plugins.insert(
+  'Manifest',
+  new WebpackAssetsManifest({
+    entrypoints: true, // default in rails is false
+    writeToDisk: true, // rails defaults copied from webpacker
+    publicPath: true // rails defaults copied from webpacker
+  })
+)
+```
+
+The `javascript_pack_tag` and `stylesheet_pack_tag` doesn't know (by default) whether they should use the entrypoints or that it should use the normal way of adding a pack. To make sure the `*_pack_tag` works with `SplitChunks`, you should use the following syntax;
+
+```erb
+javascript_pack_tag "your-entrypoint-javascript-file.js", split_chunks: true
+stylesheet_pack_tag "your-entrypoint-stylesheet-file.css", split_chunks: true
+```
+
+For the old configuration with the CommonsChunkPlugin see below
+
 ### Add common chunks
 
 The CommonsChunkPlugin is an opt-in feature that creates a separate file (known as a chunk), consisting of common modules shared between multiple entry points. By separating common modules from bundles, the resulting chunked file can be loaded once initially, and stored in the cache for later use. This results in page speed optimizations as the browser can quickly serve the shared code from the cache, rather than being forced to load a larger bundle whenever a new page is visited.

--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -288,11 +288,11 @@ environment.plugins.insert(
 )
 ```
 
-The `javascript_pack_tag` and `stylesheet_pack_tag` doesn't know (by default) whether they should use the entrypoints or that it should use the normal way of adding a pack. To make sure the `*_pack_tag` works with `SplitChunks`, you should use the following syntax;
+To use the `javascript_pack_tag` or the `stylesheet_pack_tag` with `SplitChunks` or `RuntimeChunks` you can refer to the packs as usual.
 
 ```erb
-javascript_pack_tag "your-entrypoint-javascript-file.js", split_chunks: true
-stylesheet_pack_tag "your-entrypoint-stylesheet-file.css", split_chunks: true
+javascript_pack_tag "your-entrypoint-javascript-file"
+stylesheet_pack_tag "your-entrypoint-stylesheet-file"
 ```
 
 For the old configuration with the CommonsChunkPlugin see below. **Note** that this functionality is deprecated in Webpack V4.

--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -295,9 +295,9 @@ javascript_pack_tag "your-entrypoint-javascript-file.js", split_chunks: true
 stylesheet_pack_tag "your-entrypoint-stylesheet-file.css", split_chunks: true
 ```
 
-For the old configuration with the CommonsChunkPlugin see below
+For the old configuration with the CommonsChunkPlugin see below. **Note** that this functionality is deprecated in Webpack V4.
 
-### Add common chunks
+### Add common chunks (deprecated in Webpack V4)
 
 The CommonsChunkPlugin is an opt-in feature that creates a separate file (known as a chunk), consisting of common modules shared between multiple entry points. By separating common modules from bundles, the resulting chunked file can be loaded once initially, and stored in the cache for later use. This results in page speed optimizations as the browser can quickly serve the shared code from the cache, rather than being forced to load a larger bundle whenever a new page is visited.
 

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -52,8 +52,8 @@ module Webpacker::Helper
   #   <%= javascript_pack_tag 'calendar', 'data-turbolinks-track': 'reload' %> # =>
   #   <script src="/packs/calendar-1016838bab065ae1e314.js" data-turbolinks-track="reload"></script>
   def javascript_pack_tag(*names, **options)
-    javascript_source_name = sources_from_pack_manifest(names, options[:split_chunks], type: :javascript)
-    javascript_include_tag(*javascript_source_name, **options.except(:split_chunks))
+    javascript_source_names = sources_from_pack_manifest(names, type: :javascript)
+    javascript_include_tag(*javascript_source_names, **options)
   end
 
   # Creates a link tag that references the named pack file, as compiled by webpack per the entries list
@@ -74,8 +74,8 @@ module Webpacker::Helper
   #   <link rel="stylesheet" media="screen" href="/packs/calendar-1016838bab065ae1e122.css" data-turbolinks-track="reload" />
   def stylesheet_pack_tag(*names, **options)
     unless Webpacker.dev_server.running? && Webpacker.dev_server.hot_module_replacing?
-      stylesheet_source_name = sources_from_pack_manifest(names, options[:split_chunks], type: :stylesheet)
-      stylesheet_link_tag(*stylesheet_source_name, **options.except(:split_chunks))
+      stylesheet_source_names = sources_from_pack_manifest(names, type: :stylesheet)
+      stylesheet_link_tag(*stylesheet_source_names, **options)
     end
   end
 
@@ -84,19 +84,7 @@ module Webpacker::Helper
       File.extname(name) == ".css"
     end
 
-    def sources_from_pack_manifest(names, using_split_chunks = false, type:)
-      names.map do |name|
-        full_pack_name = pack_name_with_extension(name, type: type)
-
-        if using_split_chunks
-          Webpacker.manifest.lookup_entrypoint!(name, type: type)
-        else
-          Webpacker.manifest.lookup!(full_pack_name)
-        end
-      end.flatten
-    end
-
-    def pack_name_with_extension(name, type:)
-      "#{name}#{compute_asset_extname(name.to_s, type: type)}"
+    def sources_from_pack_manifest(names, type:)
+      names.map { |name| Webpacker.manifest.lookup!(name, type: type) }.flatten
     end
 end

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -52,8 +52,7 @@ module Webpacker::Helper
   #   <%= javascript_pack_tag 'calendar', 'data-turbolinks-track': 'reload' %> # =>
   #   <script src="/packs/calendar-1016838bab065ae1e314.js" data-turbolinks-track="reload"></script>
   def javascript_pack_tag(*names, **options)
-    javascript_source_names = sources_from_pack_manifest(names, type: :javascript)
-    javascript_include_tag(*javascript_source_names, **options)
+    javascript_include_tag(*sources_from_pack_manifest(names, type: :javascript), **options)
   end
 
   # Creates a link tag that references the named pack file, as compiled by webpack per the entries list
@@ -74,8 +73,7 @@ module Webpacker::Helper
   #   <link rel="stylesheet" media="screen" href="/packs/calendar-1016838bab065ae1e122.css" data-turbolinks-track="reload" />
   def stylesheet_pack_tag(*names, **options)
     unless Webpacker.dev_server.running? && Webpacker.dev_server.hot_module_replacing?
-      stylesheet_source_names = sources_from_pack_manifest(names, type: :stylesheet)
-      stylesheet_link_tag(*stylesheet_source_names, **options)
+      stylesheet_link_tag(*sources_from_pack_manifest(names, type: :stylesheet), **options)
     end
   end
 

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -27,6 +27,10 @@ class Webpacker::Manifest
     lookup(name) || handle_missing_entry(name)
   end
 
+  def lookup_entrypoint!(name, type:)
+    lookup!("entrypoints")[name][manifest_type(type)]
+  end
+
   private
     def compiling?
       config.compile? && !dev_server.running?
@@ -70,6 +74,14 @@ Your manifest contains:
         JSON.parse config.public_manifest_path.read
       else
         {}
+      end
+    end
+
+    def manifest_type(type)
+      case type
+      when :javascript then "js"
+      when :stylesheet then "css"
+      else type.to_s
       end
     end
 end

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -18,17 +18,29 @@ class Webpacker::Manifest
     @data = load
   end
 
-  def lookup(name)
+  def lookup(name, pack_type = {})
     compile if compiling?
-    find name
+
+    # When using SplitChunks or RuntimeChunks the manifest hash will contain
+    # an extra object called "entrypoints". When the entrypoints key is not
+    # present in the manifest, or the name is not found in the entrypoints hash,
+    # it will raise a NoMethodError. If this happens, we should try to lookup
+    # a single instance of the pack based on the given name.
+    begin
+      manifest_pack_type = manifest_type(pack_type[:type])
+      manifest_pack_name = manifest_name(name, manifest_pack_type)
+
+      # Lookup the pack in the entrypoints of the manifest
+      find("entrypoints")[manifest_pack_name][manifest_pack_type]
+    rescue NoMethodError
+
+      # Lookup a single instance of the pack
+      find(full_pack_name(name, pack_type[:type]))
+    end
   end
 
-  def lookup!(name)
-    lookup(name) || handle_missing_entry(name)
-  end
-
-  def lookup_entrypoint!(name, type:)
-    lookup!("entrypoints")[name][manifest_type(type)]
+  def lookup!(name, pack_type = {})
+    lookup(name, pack_type) || handle_missing_entry(name)
   end
 
   private
@@ -40,12 +52,49 @@ class Webpacker::Manifest
       Webpacker.logger.tagged("Webpacker") { compiler.compile }
     end
 
+    def data
+      if config.cache_manifest?
+        @data ||= load
+      else
+        refresh
+      end
+    end
+
     def find(name)
       data[name.to_s].presence
     end
 
+    def full_pack_name(name, pack_type)
+      return name unless File.extname(name.to_s).empty?
+      "#{name}.#{manifest_type(pack_type)}"
+    end
+
     def handle_missing_entry(name)
       raise Webpacker::Manifest::MissingEntryError, missing_file_from_manifest_error(name)
+    end
+
+    def load
+      if config.public_manifest_path.exist?
+        JSON.parse config.public_manifest_path.read
+      else
+        {}
+      end
+    end
+
+    # The `manifest_name` method strips of the file extension of the name, because in the
+    # manifest hash the entrypoints are defined by their pack name without the extension.
+    # When the user provides a name with a file extension, we want to try to strip it off.
+    def manifest_name(name, pack_type)
+      return name if File.extname(name.to_s).empty?
+      File.basename(name, pack_type)
+    end
+
+    def manifest_type(pack_type)
+      case pack_type
+      when :javascript then "js"
+      when :stylesheet then "css"
+      else pack_type.to_s
+      end
     end
 
     def missing_file_from_manifest_error(bundle_name)
@@ -59,29 +108,5 @@ Webpacker can't find #{bundle_name} in #{config.public_manifest_path}. Possible 
 Your manifest contains:
 #{JSON.pretty_generate(@data)}
       MSG
-    end
-
-    def data
-      if config.cache_manifest?
-        @data ||= load
-      else
-        refresh
-      end
-    end
-
-    def load
-      if config.public_manifest_path.exist?
-        JSON.parse config.public_manifest_path.read
-      else
-        {}
-      end
-    end
-
-    def manifest_type(type)
-      case type
-      when :javascript then "js"
-      when :stylesheet then "css"
-      else type.to_s
-      end
     end
 end

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -61,7 +61,7 @@ class HelperTest < ActionView::TestCase
       %(<script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js"></script>\n) +
         %(<script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js"></script>\n) +
         %(<script src="/packs/application-k344a6d59eef8632c9d1.js"></script>),
-      javascript_pack_tag("application", split_chunks: true)
+      javascript_pack_tag("application")
   end
 
   def test_stylesheet_pack_tag

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -56,6 +56,14 @@ class HelperTest < ActionView::TestCase
       javascript_pack_tag("bootstrap.js", "application.js", defer: true)
   end
 
+  def test_javascript_pack_tag_split_chunks
+    assert_equal \
+      %(<script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js"></script>\n) +
+        %(<script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js"></script>\n) +
+        %(<script src="/packs/application-k344a6d59eef8632c9d1.js"></script>),
+      javascript_pack_tag("application", split_chunks: true)
+  end
+
   def test_stylesheet_pack_tag
     assert_equal \
       %(<link rel="stylesheet" media="screen" href="/packs/bootstrap-c38deda30895059837cf.css" />),

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -25,4 +25,14 @@ class ManifestTest < Minitest::Test
   def test_lookup_success
     assert_equal Webpacker.manifest.lookup("bootstrap.js"), "/packs/bootstrap-300631c4f0e0f9c865bc.js"
   end
+
+  def test_lookup_entrypoint
+    application_entrypoints = [
+      "/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js",
+      "/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js",
+      "/packs/application-k344a6d59eef8632c9d1.js"
+    ]
+
+    assert_equal Webpacker.manifest.lookup_entrypoint!("application", type: :javascript), application_entrypoints
+  end
 end

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -33,6 +33,6 @@ class ManifestTest < Minitest::Test
       "/packs/application-k344a6d59eef8632c9d1.js"
     ]
 
-    assert_equal Webpacker.manifest.lookup_entrypoint!("application", type: :javascript), application_entrypoints
+    assert_equal Webpacker.manifest.lookup!("application", type: :javascript), application_entrypoints
   end
 end

--- a/test/test_app/public/packs/manifest.json
+++ b/test/test_app/public/packs/manifest.json
@@ -3,5 +3,14 @@
   "application.css": "/packs/application-dd6b1cd38bfa093df600.css",
   "bootstrap.js": "/packs/bootstrap-300631c4f0e0f9c865bc.js",
   "application.js": "/packs/application-k344a6d59eef8632c9d1.js",
-  "application.png": "/packs/application-k344a6d59eef8632c9d1.png"
+  "application.png": "/packs/application-k344a6d59eef8632c9d1.png",
+  "entrypoints": {
+    "application": {
+      "js": [
+        "/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js",
+        "/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js",
+        "/packs/application-k344a6d59eef8632c9d1.js"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
This addresses #1622 by adding support and documentation for the `splitChunks` functionality of `Webpack 4.0`. I'm not entirely sure whether this is the best way to add support for it, so feedback is welcome and appreciated. 

The downside of this approach is that you need to add `split_chunk: true` to your `*_pack_tag` options list to make it work. If it's possible to do this in a more neat way; please tell me. It would be wonderful if the next version of `Webpacker` is entirely ready for this kind of functionality. 

Hope this helps @gauravtiwari releasing the final release of Webpacker, that is compatible with `Webpack 4.0`! 