### PR TITLE
Webpack Clean Task

### DIFF
--- a/lib/tasks/webpacker.rake
+++ b/lib/tasks/webpacker.rake
@@ -2,6 +2,7 @@ tasks = {
   "webpacker:info"                    => "Provides information on Webpacker's environment",
   "webpacker:install"                 => "Installs and setup webpack with Yarn",
   "webpacker:compile"                 => "Compiles webpack bundles based on environment",
+  "webpacker:clean"                   => "Remove old compiled webpacks",
   "webpacker:clobber"                 => "Removes the webpack compiled output directory",
   "webpacker:check_node"              => "Verifies if Node.js is installed",
   "webpacker:check_yarn"              => "Verifies if Yarn is installed",

--- a/lib/tasks/webpacker/clean.rake
+++ b/lib/tasks/webpacker/clean.rake
@@ -2,8 +2,8 @@ require "webpacker/configuration"
 
 namespace :webpacker do
   desc "Remove old compiled webpacks"
-  task clean: ["webpacker:verify_install", :environment] do
-    Webpacker.clean
+  task :clean, [:keep] => ["webpacker:verify_install", :environment] do |_, args|
+    Webpacker.clean(Integer(args.keep || 2))
   end
 end
 

--- a/lib/tasks/webpacker/clean.rake
+++ b/lib/tasks/webpacker/clean.rake
@@ -1,0 +1,15 @@
+require "webpacker/configuration"
+
+namespace :webpacker do
+  desc "Remove old compiled webpacks"
+  task clean: ["webpacker:verify_install", :environment] do
+    Webpacker.clean
+  end
+end
+
+# Run clean if the assets:clean is run
+if Rake::Task.task_defined?("assets:clean")
+  Rake::Task["assets:clean"].enhance do
+    Rake::Task["webpacker:clean"].invoke
+  end
+end

--- a/lib/webpacker.rb
+++ b/lib/webpacker.rb
@@ -24,7 +24,7 @@ module Webpacker
 
   delegate :logger, :logger=, :env, to: :instance
   delegate :config, :compiler, :manifest, :commands, :dev_server, to: :instance
-  delegate :bootstrap, :clobber, :compile, to: :commands
+  delegate :bootstrap, :clean, :clobber, :compile, to: :commands
 end
 
 require "webpacker/instance"

--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -10,8 +10,18 @@ class Webpacker::Commands
 
     files_on_filesystem = Dir.glob("#{config.public_output_path}/**/*").select { |f| File.file? f }
     files_in_manifest = manifest.refresh.values.map { |f| File.join config.root_path, "public", f }
+
+    count_to_keep = 2
+    versions_to_keep = files_in_manifest.flat_map do |file_in_manifest|
+      file_prefix, file_ext = file_in_manifest.scan(/(.*)[0-9a-f]{20}(.*)/).first
+      versions_of_file = Dir.glob("#{file_prefix}*#{file_ext}").grep(/#{file_prefix}[0-9a-f]{20}#{file_ext}/)
+      versions_of_file.map do |version_of_file|
+        [version_of_file, File.mtime(version_of_file).utc.to_i]
+      end.sort_by(&:last).reverse.first(count_to_keep).map(&:first)
+    end
+
     manifest_file = File.join config.public_output_path, "manifest.json"
-    files_to_be_removed = files_on_filesystem - files_in_manifest - [manifest_file]
+    files_to_be_removed = files_on_filesystem - files_in_manifest - versions_to_keep - [manifest_file]
 
     files_to_be_removed.each { |f| File.delete f }
   end

--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -5,6 +5,17 @@ class Webpacker::Commands
     @webpacker = webpacker
   end
 
+  def clean
+    return if !config.public_output_path.exist? || !config.public_manifest_path.exist?
+
+    files_on_filesystem = Dir.glob("#{config.public_output_path}/**/*").select { |f| File.file? f }
+    files_in_manifest = manifest.refresh.values.map { |f| File.join config.root_path, "public", f }
+    manifest_file = File.join config.public_output_path, "manifest.json"
+    files_to_be_removed = files_on_filesystem - files_in_manifest - [manifest_file]
+
+    files_to_be_removed.each { |f| File.delete f }
+  end
+
   def clobber
     config.public_output_path.rmtree if config.public_output_path.exist?
     config.cache_path.rmtree if config.cache_path.exist?

--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -6,20 +6,20 @@ class Webpacker::Commands
   end
 
   def clean(count_to_keep = 2)
-    return if !config.public_output_path.exist? || !config.public_manifest_path.exist?
+    if config.public_output_path.exist? && config.public_manifest_path.exist?
+      files_in_manifest = manifest.refresh.values.map { |f| File.join config.root_path, "public", f }
+      files_to_be_removed = files_in_manifest.flat_map do |file_in_manifest|
+        file_prefix, file_ext = file_in_manifest.scan(/(.*)[0-9a-f]{20}(.*)/).first
+        versions_of_file = Dir.glob("#{file_prefix}*#{file_ext}").grep(/#{file_prefix}[0-9a-f]{20}#{file_ext}/)
+        versions_of_file.map do |version_of_file|
+          next if version_of_file == file_in_manifest
 
-    files_in_manifest = manifest.refresh.values.map { |f| File.join config.root_path, "public", f }
-    files_to_be_removed = files_in_manifest.flat_map do |file_in_manifest|
-      file_prefix, file_ext = file_in_manifest.scan(/(.*)[0-9a-f]{20}(.*)/).first
-      versions_of_file = Dir.glob("#{file_prefix}*#{file_ext}").grep(/#{file_prefix}[0-9a-f]{20}#{file_ext}/)
-      versions_of_file.map do |version_of_file|
-        next if version_of_file == file_in_manifest
+          [version_of_file, File.mtime(version_of_file).utc.to_i]
+        end.compact.sort_by(&:last).reverse.drop(count_to_keep).map(&:first)
+      end
 
-        [version_of_file, File.mtime(version_of_file).utc.to_i]
-      end.compact.sort_by(&:last).reverse.drop(count_to_keep).map(&:first)
+      files_to_be_removed.each { |f| File.delete f }
     end
-
-    files_to_be_removed.each { |f| File.delete f }
   end
 
   def clobber

--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -17,7 +17,7 @@ class Webpacker::Commands
         next if version_of_file == file_in_manifest
 
         [version_of_file, File.mtime(version_of_file).utc.to_i]
-      end.compact.sort_by(&:last)[0..-(count_to_keep + 1)].map(&:first)
+      end.compact.sort_by(&:last).reverse.drop(count_to_keep).map(&:first)
     end
 
     files_to_be_removed.each { |f| File.delete f }

--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -5,10 +5,9 @@ class Webpacker::Commands
     @webpacker = webpacker
   end
 
-  def clean
+  def clean(count_to_keep = 2)
     return if !config.public_output_path.exist? || !config.public_manifest_path.exist?
 
-    count_to_keep = 2
     files_in_manifest = manifest.refresh.values.map { |f| File.join config.root_path, "public", f }
     files_to_be_removed = files_in_manifest.flat_map do |file_in_manifest|
       file_prefix, file_ext = file_in_manifest.scan(/(.*)[0-9a-f]{20}(.*)/).first

--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -8,20 +8,17 @@ class Webpacker::Commands
   def clean
     return if !config.public_output_path.exist? || !config.public_manifest_path.exist?
 
-    files_on_filesystem = Dir.glob("#{config.public_output_path}/**/*").select { |f| File.file? f }
-    files_in_manifest = manifest.refresh.values.map { |f| File.join config.root_path, "public", f }
-
     count_to_keep = 2
-    versions_to_keep = files_in_manifest.flat_map do |file_in_manifest|
+    files_in_manifest = manifest.refresh.values.map { |f| File.join config.root_path, "public", f }
+    files_to_be_removed = files_in_manifest.flat_map do |file_in_manifest|
       file_prefix, file_ext = file_in_manifest.scan(/(.*)[0-9a-f]{20}(.*)/).first
       versions_of_file = Dir.glob("#{file_prefix}*#{file_ext}").grep(/#{file_prefix}[0-9a-f]{20}#{file_ext}/)
       versions_of_file.map do |version_of_file|
-        [version_of_file, File.mtime(version_of_file).utc.to_i]
-      end.sort_by(&:last).reverse.first(count_to_keep).map(&:first)
-    end
+        next if version_of_file == file_in_manifest
 
-    manifest_file = File.join config.public_output_path, "manifest.json"
-    files_to_be_removed = files_on_filesystem - files_in_manifest - versions_to_keep - [manifest_file]
+        [version_of_file, File.mtime(version_of_file).utc.to_i]
+      end.compact.sort_by(&:last)[0..-(count_to_keep + 1)].map(&:first)
+    end
 
     files_to_be_removed.each { |f| File.delete f }
   end

--- a/test/rake_tasks_test.rb
+++ b/test/rake_tasks_test.rb
@@ -7,6 +7,7 @@ class RakeTasksTest < Minitest::Test
     assert_includes output, "webpacker:check_binstubs"
     assert_includes output, "webpacker:check_node"
     assert_includes output, "webpacker:check_yarn"
+    assert_includes output, "webpacker:clean"
     assert_includes output, "webpacker:clobber"
     assert_includes output, "webpacker:compile"
     assert_includes output, "webpacker:install"


### PR DESCRIPTION
Resolves https://github.com/rails/webpacker/issues/1410

 ## Goal
Add a task to clean old packs so that our packs directory doesn't get bloated with hundreds of old, unused assets.

 ## Approach
Create a new `webpacker:clean` task (which enhances the `assets:clean` task) to delete unused assets by detecting old assets (using the Webpack-generated manifest.json to find alternative versions and by using `File.mtime` to determine file age).

 ## Context
Users' browsers of a Webpacker-enabled app will request packs from the public packs directory. During a deploy the packs are replaced with a new version (at a new location) that the browser may not yet know about which results in 404s or other errors to the end user. Best practices recommend to keep a version or two of your assets around to avoid this scenario. Currently, if the packs directory is persisted across deploys, **all compiled packs are kept forever**. Sprockets has an `assets:clean` task which removes unused assets. This pull request intends to add the equivalent task to Webpacker.

 ## Notes
I'm not 100% confident with how I find the older versions but it's the best I can come up with. I'm open to suggestions.

 ## Related
* https://github.com/heroku/heroku-buildpack-ruby/pull/803