### PR TITLE
Fix undefined method `watch' for Spring:Module

### DIFF
--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -83,7 +83,7 @@ class Webpacker::Engine < ::Rails::Engine
     if defined?(Rails::Server) || defined?(Rails::Console)
       Webpacker.bootstrap
       if defined?(Spring)
-        require 'spring/watcher'
+        require "spring/watcher"
         Spring.after_fork { Webpacker.bootstrap }
         Spring.watch(Webpacker.config.config_path)
       end

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -83,6 +83,7 @@ class Webpacker::Engine < ::Rails::Engine
     if defined?(Rails::Server) || defined?(Rails::Console)
       Webpacker.bootstrap
       if defined?(Spring)
+        require 'spring/watcher'
         Spring.after_fork { Webpacker.bootstrap }
         Spring.watch(Webpacker.config.config_path)
       end


### PR DESCRIPTION
This PR fixes `undefined method watch for Spring:Module` error.