### PR TITLE
Add `image_pack_tag` example to documentation

### DIFF
--- a/docs/assets.md
+++ b/docs/assets.md
@@ -103,4 +103,7 @@ app/javascript:
 
 <img src="<%= asset_pack_path 'images/calendar.png' %>" />
 <% # => <img src="/packs/images/calendar.png" /> %>
+
+<%= image_pack_tag 'images/calendar.png' %>
+<% # => <img src="/packs/images/calendar.png" /> %>
 ```


### PR DESCRIPTION
Right now it's not mentioned in the documentation at all.