### PR TITLE
add block context to CSP-related initializer snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,11 +346,13 @@ development environment. This can be done in the `config/initializers/content_se
 with the following code:
 
 ```ruby
+Rails.application.config.content_security_policy do |policy|
   if Rails.env.development?
     policy.script_src :self, :https, :unsafe_eval
   else
     policy.script_src :self, :https
   end
+end
 ```
 
 
@@ -374,11 +376,13 @@ This can be done in the `config/initializers/content_security_policy.rb` with th
 configuration:
 
 ```ruby
+Rails.application.config.content_security_policy do |policy|
   if Rails.env.development?
     policy.script_src :self, :https, :unsafe_eval
   else
     policy.script_src :self, :https
   end
+end
 ```
 You can read more about this in the [Vue docs](https://vuejs.org/v2/guide/installation.html#CSP-environments).
 


### PR DESCRIPTION
These now match the block at README.md:202

The documentation currently assumes the reader will place it within a `#content_security_policy` block. But, without context, a user may mistakenly plant the snippet in `config/initializers/content_security_policy.rb` bare, since in a new Rails app there is no existing block (it's commented out in that file).