### PR TITLE
Invoke webpacker:yarn_install before assets:precompile in old rails

### DIFF
--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -9,11 +9,9 @@ ensure
 end
 
 def enhance_assets_precompile
-  Rake::Task["assets:precompile"].enhance do
-    unless Rake::Task.task_defined?("yarn:install")
-      # For Rails < 5.1
-      Rake::Task["webpacker:yarn_install"].invoke
-    end
+  # For Rails < 5.1
+  deps = Rake::Task.task_defined?("yarn:install") ? [] : ["webpacker:yarn_install"]
+  Rake::Task["assets:precompile"].enhance(deps) do
     Rake::Task["webpacker:compile"].invoke
   end
 end


### PR DESCRIPTION
Make it work similar to new rails, and it's now possible to use node_modules in sprockets.