### PR TITLE
Only record compilation digest if webpack runs successfully.

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -18,9 +18,8 @@ class Webpacker::Compiler
 
   def compile
     if stale?
-      record_compilation_digest
       run_webpack.tap do |success|
-        remove_compilation_digest if !success
+        record_compilation_digest if success
       end
     else
       true
@@ -52,11 +51,6 @@ class Webpacker::Compiler
     def record_compilation_digest
       config.cache_path.mkpath
       compilation_digest_path.write(watched_files_digest)
-    end
-
-    def remove_compilation_digest
-      compilation_digest_path.delete if compilation_digest_path.exist?
-    rescue Errno::ENOENT, Errno::ENOTDIR
     end
 
     def run_webpack


### PR DESCRIPTION
This fixes an issue where current request gets an stale pack,
because previous request wrote the compilation digest before
webpack ends up running.