### PR TITLE
Run yarn check --verify-tree as part of the yarn integrity check

### DIFF
--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -30,13 +30,13 @@ class Webpacker::Engine < ::Rails::Engine
   #     - add `config.webpacker.check_yarn_integrity = true`
   initializer "webpacker.yarn_check" do |app|
     if File.exist?("yarn.lock") && Webpacker.config.config_path.exist? && Webpacker.config.check_yarn_integrity?
-      output = `yarn check --integrity 2>&1`
+      output = `yarn check --integrity && yarn check --verify-tree 2>&1`
 
       unless $?.success?
         $stderr.puts "\n\n"
         $stderr.puts "========================================"
         $stderr.puts "  Your Yarn packages are out of date!"
-        $stderr.puts "  Please run `yarn install` to update."
+        $stderr.puts "  Please run `yarn install --check-files` to update."
         $stderr.puts "========================================"
         $stderr.puts "\n\n"
         $stderr.puts "To disable this check, please change `check_yarn_integrity`"


### PR DESCRIPTION
I've found an issue in an application in which some packages where missing from `node_modules` but webpacker didn't give any warning message. 

### Steps to reproduce:

- remove some packages from `node_modules`
- restart the rails server

### Expected behaviour:

I see a message: `Your Yarn packages are out of date!`

### Actual behaviour: 

The app runs as usual and the compilation process fails.

### Fix

It turns out `yarn check --integrity` doesn't actually checks the whole integrity of `node_modules`. From the [yarn documentation](https://yarnpkg.com/lang/en/docs/cli/check/):

>`yarn check --integrity` checks that versions and hashed
> values of the package contents in the project’s package.json
> match those in yarn’s lock file.

We need both `yarn check --integrity` and [`yarn check --verify-tree`](https://yarnpkg.com/lang/en/docs/cli/check/#toc-yarn-check-verify-tree):

> `yarn check --verify-tree` Recursively verifies that the dependencies in package.json are present in node_modules and have the right version. This check does not consider yarn.lock.

Also it would be better to advise to run [`yarn install --check-files`](https://yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-check-files). Otherwise, missing files from `node_modules` will be ignored.