### PR TITLE
fixes issue #1615 by adding ERB processing to the yml loader

### DIFF
--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -1,3 +1,4 @@
+require "erb"
 require "yaml"
 require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/hash/indifferent_access"
@@ -81,7 +82,7 @@ class Webpacker::Configuration
     end
 
     def load
-      YAML.load(config_path.read)[env].deep_symbolize_keys
+      YAML.load(ERB.new(config_path.read).result)[env].deep_symbolize_keys
 
     rescue Errno::ENOENT => e
       raise "Webpacker configuration file not found #{config_path}. " \

--- a/lib/webpacker/webpack_runner.rb
+++ b/lib/webpacker/webpack_runner.rb
@@ -21,7 +21,7 @@ module Webpacker
     def compile_config
       config_file = File.join('config', 'webpacker.yml')
       config = YAML.load(ERB.new(File.read(config_file)).result)[env].deep_symbolize_keys
-      processed_config_file = File.join('config', 'webpacker.yml')
+      processed_config_file = File.join('config', '.webpacker.yml')
       File.open(processed_config_file, 'w') do |f|
         f.write(config.to_yaml)
       end

--- a/lib/webpacker/webpack_runner.rb
+++ b/lib/webpacker/webpack_runner.rb
@@ -17,14 +17,14 @@ module Webpacker
 
     private
 
-    # config/webpacker.yml may contain ERB that needs to be processed so that javascript can proceed
-    def compile_config
-      config_file = File.join('config', 'webpacker.yml')
-      config = YAML.load(ERB.new(File.read(config_file)).result)[env].deep_symbolize_keys
-      processed_config_file = File.join('config', '.webpacker.yml')
-      File.open(processed_config_file, 'w') do |f|
-        f.write(config.to_yaml)
+      # config/webpacker.yml may contain ERB that needs to be processed so that javascript can proceed
+      def compile_config
+        config_file = File.join("config", "webpacker.yml")
+        config = YAML.load(ERB.new(File.read(config_file)).result)[env].deep_symbolize_keys
+        processed_config_file = File.join("config", ".webpacker.yml")
+        File.open(processed_config_file, "w") do |f|
+          f.write(config.to_yaml)
+        end
       end
-    end
   end
 end

--- a/lib/webpacker/webpack_runner.rb
+++ b/lib/webpacker/webpack_runner.rb
@@ -1,14 +1,29 @@
+require "erb"
+require "yaml"
 require "shellwords"
 require "webpacker/runner"
 
 module Webpacker
   class WebpackRunner < Webpacker::Runner
     def run
+      compile_config
       env = Webpacker::Compiler.env
       cmd = [ "#{@node_modules_bin_path}/webpack", "--config", @webpack_config ] + @argv
 
       Dir.chdir(@app_path) do
         exec env, *cmd
+      end
+    end
+
+    private
+
+    # config/webpacker.yml may contain ERB that needs to be processed so that javascript can proceed
+    def compile_config
+      config_file = File.join('config', 'webpacker.yml')
+      config = YAML.load(ERB.new(File.read(config_file)).result)[env].deep_symbolize_keys
+      processed_config_file = File.join('config', 'webpacker.yml')
+      File.open(processed_config_file, 'w') do |f|
+        f.write(config.to_yaml)
       end
     end
   end

--- a/package/config.js
+++ b/package/config.js
@@ -1,12 +1,17 @@
 const { resolve } = require('path')
 const { safeLoad } = require('js-yaml')
-const { readFileSync } = require('fs')
+const { readFileSync, existsSync } = require('fs')
 const deepMerge = require('./utils/deep_merge')
 const { isArray } = require('./utils/helpers')
 const { railsEnv } = require('./env')
 
 const defaultConfigPath = require.resolve('../lib/install/config/webpacker.yml')
-const configPath = resolve('config', 'webpacker.yml')
+
+// We use ruby to compile the erb, then output the hidden yaml file, fall back in case its not there
+let configPath = resolve('config', '.webpacker.yml')
+if (!existsSync(configPath)) {
+  configPath = resolve('config', 'webpacker.yml')
+}
 
 const getDefaultConfig = () => {
   const defaultConfig = safeLoad(readFileSync(defaultConfigPath), 'utf8')

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -49,6 +49,7 @@ class ConfigurationTest < Webpacker::Test
   end
 
   def test_cache_manifest?
+    # this implicity tests production and the ERB processing of the config
     assert @config.cache_manifest?
 
     @config = Webpacker::Configuration.new(

--- a/test/test_app/config/webpacker.yml
+++ b/test/test_app/config/webpacker.yml
@@ -70,7 +70,7 @@ staging:
   compile: false
 
   # Cache manifest.json for performance
-  cache_manifest: true
+  cache_manifest: <%= ENV.fetch("WEBPACKER_CACHE_MANIFEST", 'true') %>
 
   # Compile staging packs to a separate directory
   public_output_path: packs-staging


### PR DESCRIPTION
This PR allows for ERB inside the `config/webpacker.yml` file.  Previous attempts failed to address the case of using `bin/webpack`, but this PR fixes that by processing the ERB in the yml file and outputing a hidden yml that the node process will look for by default.