### PR TITLE
Refactor singleton usage

### DIFF
--- a/lib/install/bin/webpack
+++ b/lib/install/bin/webpack
@@ -12,4 +12,7 @@ require "bundler/setup"
 
 require "webpacker"
 require "webpacker/webpack_runner"
-Webpacker::WebpackRunner.run(ARGV)
+
+Dir.chdir(File.expand_path("../../", __FILE__)) do
+  Webpacker::WebpackRunner.run(ARGV)
+end

--- a/lib/install/bin/webpack-dev-server
+++ b/lib/install/bin/webpack-dev-server
@@ -12,4 +12,7 @@ require "bundler/setup"
 
 require "webpacker"
 require "webpacker/dev_server_runner"
-Webpacker::DevServerRunner.run(ARGV)
+
+Dir.chdir(File.expand_path("../../", __FILE__)) do
+  Webpacker::DevServerRunner.run(ARGV)
+end

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -10,7 +10,7 @@ class Webpacker::Compiler
   # Webpacker::Compiler.env['FRONTEND_API_KEY'] = 'your_secret_key'
   cattr_accessor(:env) { {} }
 
-  delegate :config, :logger, to: :@webpacker
+  delegate :config, :logger, to: :webpacker
 
   def initialize(webpacker)
     @webpacker = webpacker
@@ -38,6 +38,8 @@ class Webpacker::Compiler
   end
 
   private
+    attr_reader :webpacker
+
     def last_compilation_digest
       compilation_digest_path.read if compilation_digest_path.exist? && config.public_manifest_path.exist?
     end
@@ -60,7 +62,11 @@ class Webpacker::Compiler
     def run_webpack
       logger.info "Compiling…"
 
-      stdout, sterr , status = Open3.capture3(webpack_env, "#{RbConfig.ruby} ./bin/webpack")
+      stdout, sterr , status = Open3.capture3(
+        webpack_env,
+        "#{RbConfig.ruby} ./bin/webpack",
+        chdir: File.expand_path(config.root_path)
+      )
 
       if status.success?
         logger.info "Compiled all packs in #{config.public_output_path}"
@@ -75,17 +81,19 @@ class Webpacker::Compiler
     def default_watched_paths
       [
         *config.resolved_paths_globbed,
-        "#{config.source_path.relative_path_from(Rails.root)}/**/*",
+        "#{config.source_path.relative_path_from(config.root_path)}/**/*",
         "yarn.lock", "package.json",
         "config/webpack/**/*"
       ].freeze
     end
 
     def compilation_digest_path
-      config.cache_path.join(".last-compilation-digest-#{Webpacker.env}")
+      config.cache_path.join(".last-compilation-digest-#{webpacker.env}")
     end
 
     def webpack_env
+      return env unless defined?(ActionController::Base)
+
       env.merge("WEBPACKER_ASSET_HOST"        => ActionController::Base.helpers.compute_asset_host,
                 "WEBPACKER_RELATIVE_URL_ROOT" => ActionController::Base.relative_url_root)
     end

--- a/lib/webpacker/dev_server.rb
+++ b/lib/webpacker/dev_server.rb
@@ -1,4 +1,6 @@
 class Webpacker::DevServer
+  DEFAULT_ENV_PREFIX = "WEBPACKER_DEV_SERVER".freeze
+
   # Configure dev server connection timeout (in seconds), default: 0.01
   # Webpacker.dev_server.connect_timeout = 1
   cattr_accessor(:connect_timeout) { 0.01 }
@@ -58,9 +60,13 @@ class Webpacker::DevServer
     fetch(:pretty)
   end
 
+  def env_prefix
+    config.dev_server.fetch(:env_prefix, DEFAULT_ENV_PREFIX)
+  end
+
   private
     def fetch(key)
-      ENV["WEBPACKER_DEV_SERVER_#{key.upcase}"] || config.dev_server.fetch(key, defaults[key])
+      ENV["#{env_prefix}_#{key.upcase}"] || config.dev_server.fetch(key, defaults[key])
     end
 
     def defaults

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -1,4 +1,11 @@
 module Webpacker::Helper
+  # Returns current Webpacker instance.
+  # Could be overriden to use multiple Webpacker
+  # configurations within the same app (e.g. with engines)
+  def current_webpacker
+    Webpacker.instance
+  end
+
   # Computes the relative path for a given Webpacker asset.
   # Return relative path using manifest.json and passes it to asset_path helper
   # This will use asset_path internally, so most of their behaviors will be the same.
@@ -11,8 +18,8 @@ module Webpacker::Helper
   #   # In production mode:
   #   <%= asset_pack_path 'calendar.css' %> # => "/packs/calendar-1016838bab065ae1e122.css"
   def asset_pack_path(name, **options)
-    unless stylesheet?(name) && Webpacker.dev_server.running? && Webpacker.dev_server.hot_module_replacing?
-      asset_path(Webpacker.manifest.lookup!(name), **options)
+    unless stylesheet?(name) && current_webpacker.dev_server.running? && current_webpacker.dev_server.hot_module_replacing?
+      asset_path(current_webpacker.manifest.lookup!(name), **options)
     end
   end
 
@@ -28,8 +35,8 @@ module Webpacker::Helper
   #   # In production mode:
   #   <%= asset_pack_url 'calendar.css' %> # => "http://example.com/packs/calendar-1016838bab065ae1e122.css"
   def asset_pack_url(name, **options)
-    unless Webpacker.dev_server.running? && Webpacker.dev_server.hot_module_replacing?
-      asset_url(Webpacker.manifest.lookup!(name), **options)
+    unless current_webpacker.dev_server.running? && current_webpacker.dev_server.hot_module_replacing?
+      asset_url(current_webpacker.manifest.lookup!(name), **options)
     end
   end
 
@@ -40,7 +47,7 @@ module Webpacker::Helper
   #  <%= image_pack_tag 'application.png', size: '16x10', alt: 'Edit Entry' %>
   #  <img alt='Edit Entry' src='/packs/application-k344a6d59eef8632c9d1.png' width='16' height='10' />
   def image_pack_tag(name, **options)
-    image_tag(asset_path(Webpacker.manifest.lookup!(name)), **options)
+    image_tag(asset_path(current_webpacker.manifest.lookup!(name)), **options)
   end
 
   # Creates a script tag that references the named pack file, as compiled by webpack per the entries list
@@ -72,7 +79,7 @@ module Webpacker::Helper
   #   <%= stylesheet_pack_tag 'calendar', 'data-turbolinks-track': 'reload' %> # =>
   #   <link rel="stylesheet" media="screen" href="/packs/calendar-1016838bab065ae1e122.css" data-turbolinks-track="reload" />
   def stylesheet_pack_tag(*names, **options)
-    unless Webpacker.dev_server.running? && Webpacker.dev_server.hot_module_replacing?
+    unless current_webpacker.dev_server.running? && current_webpacker.dev_server.hot_module_replacing?
       stylesheet_link_tag(*sources_from_pack_manifest(names, type: :stylesheet), **options)
     end
   end
@@ -83,7 +90,7 @@ module Webpacker::Helper
     end
 
     def sources_from_pack_manifest(names, type:)
-      names.map { |name| Webpacker.manifest.lookup!(pack_name_with_extension(name, type: type)) }
+      names.map { |name| current_webpacker.manifest.lookup!(pack_name_with_extension(name, type: type)) }
     end
 
     def pack_name_with_extension(name, type:)

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -25,7 +25,7 @@ class CompilerTest < Minitest::Test
     assert_equal Webpacker.compiler.send(:default_watched_paths), [
       "app/assets/**/*",
       "/etc/yarn/**/*",
-      "test/test_app/app/javascript/**/*",
+      "app/javascript/**/*",
       "yarn.lock",
       "package.json",
       "config/webpack/**/*"


### PR DESCRIPTION
## Context

I'm working on the application consisting of multiple engines. Some of these engines provide user interface.

We wanted to make our engines as isolated as possible (though keeping in the same monorepo); hence we needed our webpack(-er) to be isolated too: separate `package.json`, dev server, compilation process.

It turned out that it could be done with Webpacker if we replace the _global_ `Webpacker.instance` usage with the _local_ instance–i.e. if we "fix" dependency injection.

**NOTE:** this PR should considered as an experimental (though the functionality has been extracted from the production app); I'd like to discuss this approach first of all.

**NOTE 2:** this PR doesn't introduce any backward compatibility changes and only deals with the internals.
 
## Related tickets

https://github.com/rails/webpacker/issues/348


## What's inside?

- `Compiler` class refactored to use `@webpacker` instance instead of `Webpacker` (
https://github.com/rails/webpacker/commit/7a0a58c108e8dbd338702fea0e42dd594a0ba5eb)
- Added `webpacker` option to `DevServerProxy` to make it possible to use with non-default instance (
https://github.com/rails/webpacker/commit/53c8a777df30eb8a8dd6088a2179d766a4e2f617)
- Added explicit `chdir` for scripts (`webpack`, `webpack-dev-server`) to make it possible to run not only from the app root (
https://github.com/rails/webpacker/commit/e2bc2363cccaadd3a9b71092cafcbcd610bc527b)
- Added `current_webpacker` to `Helper` to make it possible to override the default Webpacker (
https://github.com/rails/webpacker/commit/aa2aabd71835261587e7afbcb5dfbb728433a585)
- Added `env_prefix` config param to `dev_server` section of `webpacker.yml` to make it possible to use different env variable for different webpackers (https://github.com/rails/webpacker/pull/1808/commits/32fd72eeb6dcf61cfd09c7465301565712299de5)

## Usage example

Suppose that we have a Rails engine `MyEngine`.

To add an isolated Webpacker configuration to that gem we need:
- Add `config/webpacker.yml` and `config/webpack/*.js` files
- Add `bin/webpack` and `bin/webpack-dev-server` files
- Configure engine's instance:

```ruby
module MyEngine
  ROOT_PATH = Pathname.new(File.join(__dir__, ".."))

  class << self
    def webpacker
      @webpacker ||= ::Webpacker::Instance.new(
        root_path: ROOT_PATH,
        config_path: ROOT_PATH.join("config/webpacker.yml")
      )
    end
  end
end
```

- Configure dev server proxy

```ruby
module MyEngine
  class Engine < ::Rails::Engine
    initializer "webpacker.proxy" do |app|
        insert_middleware = begin
                            MyEngine.webpacker.config.dev_server.present?
                          rescue
                            nil
                          end
        next unless insert_middleware

        app.middleware.insert_before(
          0, "Webpacker::DevServerProxy",
          ssl_verify_none: true,
          webpacker: MyEngine.webpacker
        )
      end
  end
end
```

- (optional) If you have multiple webpacker, you would probably want to run multiple dev servers at a time, and hence be able to configure their setting though env vars (we do use env vars within a docker-compose dev env):

```yml
# webpacker.yml
# ...
development:
  # ...
  dev_server:
    env_prefix: "MY_ENGINE_WEBPACKER_DEV_SERVER"
    # ...
```

- Configure helper:

```ruby
require "webpacker/helper"

module MyEngine
  module ApplicationHelper
    include ::Webpacker::Helper

    def current_webpacker
      MyEngine.webpacker
    end
  end
end
```

Now you can use `stylesheet_pack_tag` and `javascript_pack_tag` from within your engine.

- Add Rake task to compile assets in production (`rake my_engine:webpacker:compile`)

```ruby
namespace :my_engine do
  namespace :webpacker do
    desc "Install deps with yarn"
    task :yarn_install do
      Dir.chdir(File.join(__dir__, "../..")) do
        system "yarn install --no-progress --production"
      end
    end

    desc "Compile JavaScript packs using webpack for production with digests"
    task compile: [:yarn_install", :environment] do
      Webpacker.with_node_env("production") do
          if MyEngine.webpacker.commands.compile
            # Successful compilation!
          else
            # Failed compilation
            exit!
          end
      end
    end
  end
end
```

I think, most of this work could be automated via generators in the future, but that's not the scope of this PR: here I want to slightly change the Webpacker design to make it more flexible.