### PR TITLE
Fix test matrix exclusion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,5 @@ matrix:
   allow_failures:
   - gemfile: gemfiles/Gemfile-rails-edge
   exclude:
-    - rvm: 2.3.7
+    - rvm: 2.3.8
       gemfile: gemfiles/Gemfile-rails-edge


### PR DESCRIPTION
This test matrix was excluded by https://github.com/rails/webpacker/pull/1539 due to always failing.
However, https://github.com/rails/webpacker/pull/1777 upgraded Ruby 2.3 version without updating this exclusion.