### PR TITLE
Avoid using RuboCop 0.60.0 to fix failing tests on Travis CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 gem "rails"
 gem "rake", ">= 11.1"
-gem "rubocop", ">= 0.49", require: false
+gem "rubocop", [">= 0.49", "< 0.60"], require: false # 0.60.0 doesn't work on ruby 2.6. When a new version is released, we'll remove this version lock. https://github.com/rubocop-hq/rubocop/issues/6412
 gem "rack-proxy", require: false
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
-    parser (2.5.1.2)
+    parser (2.5.3.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
     rack (2.0.5)
@@ -112,7 +112,7 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (12.3.1)
-    rubocop (0.58.2)
+    rubocop (0.59.2)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
@@ -147,8 +147,8 @@ DEPENDENCIES
   rack-proxy
   rails
   rake (>= 11.1)
-  rubocop (>= 0.49)
+  rubocop (>= 0.49, < 0.60)
   webpacker!
 
 BUNDLED WITH
-   1.16.4
+   1.17.1

--- a/gemfiles/Gemfile-rails-edge
+++ b/gemfiles/Gemfile-rails-edge
@@ -7,7 +7,7 @@ gem "webpacker", path: ".."
 gem "rails", github: "rails/rails"
 gem "arel", github: "rails/arel"
 gem "rake", ">= 11.1"
-gem "rubocop", ">= 0.49", require: false
+gem "rubocop", [">= 0.49", "< 0.60"], require: false
 gem "rack-proxy", require: false
 gem "minitest", "~> 5.0"
 gem "byebug"

--- a/gemfiles/Gemfile-rails.4.2.x
+++ b/gemfiles/Gemfile-rails.4.2.x
@@ -4,7 +4,7 @@ gem "webpacker", path: ".."
 
 gem "rails", "~> 4.2.0"
 gem "rake", ">= 11.1"
-gem "rubocop", ">= 0.49", require: false
+gem "rubocop", [">= 0.49", "< 0.60"], require: false
 gem "rack-proxy", require: false
 gem "minitest", "~> 5.0"
 gem "byebug"

--- a/gemfiles/Gemfile-rails.5.0.x
+++ b/gemfiles/Gemfile-rails.5.0.x
@@ -4,7 +4,7 @@ gem "webpacker", path: ".."
 
 gem "rails", "~> 5.0.0"
 gem "rake", ">= 11.1"
-gem "rubocop", ">= 0.49", require: false
+gem "rubocop", [">= 0.49", "< 0.60"], require: false
 gem "rack-proxy", require: false
 gem "minitest", "~> 5.0"
 gem "byebug"

--- a/gemfiles/Gemfile-rails.5.1.x
+++ b/gemfiles/Gemfile-rails.5.1.x
@@ -4,7 +4,7 @@ gem "webpacker", path: ".."
 
 gem "rails", "~> 5.1.0"
 gem "rake", ">= 11.1"
-gem "rubocop", ">= 0.49", require: false
+gem "rubocop", [">= 0.49",  "< 0.60"], require: false
 gem "rack-proxy", require: false
 gem "minitest", "~> 5.0"
 gem "byebug"

--- a/gemfiles/Gemfile-rails.5.2.x
+++ b/gemfiles/Gemfile-rails.5.2.x
@@ -4,7 +4,7 @@ gem "webpacker", path: ".."
 
 gem "rails", "~> 5.2.0"
 gem "rake", ">= 11.1"
-gem "rubocop", ">= 0.49", require: false
+gem "rubocop", [">= 0.49",  "< 0.60"], require: false
 gem "rack-proxy", require: false
 gem "minitest", "~> 5.0"
 gem "byebug"


### PR DESCRIPTION
It doesn't work on Ruby 2.6.0.
See: https://github.com/rubocop-hq/rubocop/issues/6412

This issue was fixed on RuboCop master.
However it is not released yet.