### PR TITLE
Exclude Rails 4.2 + ruby-head build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,5 @@ matrix:
   exclude:
     - rvm: 2.3.8
       gemfile: gemfiles/Gemfile-rails-edge
+    - rvm: ruby-head
+      gemfile: gemfiles/Gemfile-rails.4.2.x


### PR DESCRIPTION
Rails 4.2 is using `BigDecimal.new`. But `BigDecimal.new` was removed.
Ref: https://github.com/ruby/bigdecimal/commit/d73eca27de842928dd7f4480d7d6e435f50c9bc2

This causes the build of Rails 4.2 + ruby-head to fail.
https://travis-ci.org/rails/webpacker/jobs/462579174#L1292

Let's exclude this in order to keep the build state clean.