### PR TITLE
Use RAILS_ENV in runner webpack config.

### DIFF
--- a/lib/webpacker/runner.rb
+++ b/lib/webpacker/runner.rb
@@ -11,7 +11,7 @@ module Webpacker
 
       @app_path              = File.expand_path(".", Dir.pwd)
       @node_modules_bin_path = ENV["WEBPACKER_NODE_MODULES_BIN_PATH"] || `yarn bin`.chomp
-      @webpack_config        = File.join(@app_path, "config/webpack/#{ENV["NODE_ENV"]}.js")
+      @webpack_config        = File.join(@app_path, "config/webpack/#{ENV["RAILS_ENV"]}.js")
 
       unless File.exist?(@webpack_config)
         $stderr.puts "webpack config #{@webpack_config} not found, please run 'bundle exec rails webpacker:install' to install Webpacker with default configs or add the missing config file for your custom environment."


### PR DESCRIPTION
This allows to have webpack configs for other environments then development, test and production. For example using environment staging.js.