### PR TITLE
Reduce the output of the webpack-dev-server

### DIFF
--- a/package/environments/development.js
+++ b/package/environments/development.js
@@ -40,7 +40,10 @@ module.exports = class extends Base {
         headers: devServer.headers,
         overlay: devServer.overlay,
         stats: {
-          errorDetails: true
+          entrypoints: false,
+          errorDetails: false,
+          modules: false,
+          moduleTrace: false
         },
         watchOptions: devServer.watch_options
       }


### PR DESCRIPTION
The webpack-dev-server normally outputs a lot of information about how the packages are resolved. During development you are often only interested in the packages that webpack creates after building and the names and sizes of those packages.

After this pull request has been merged, you can always increase logging again by adding the following lines to your `environment.js`:
```javascript
const { environment } = require('@rails/webpacker')

// Reduce the output of the Webpack Dev Server
environment.config.merge({
  devServer: {
    stats: {
      entrypoints: true,
      errorDetails: true,
      modules: true,
      moduleTrace: true
    }
  }
});

module.exports = environment
```

Or run webpack manually instead of the webpack-dev-server. But in my opinion the stats settings in this pull request are a better default.
