### PR TITLE
Fix middleware name for rails versions in the engine doc

### DIFF
--- a/docs/engines.md
+++ b/docs/engines.md
@@ -50,7 +50,7 @@ module MyEngine
         next unless insert_middleware
 
         app.middleware.insert_before(
-          0, "Webpacker::DevServerProxy",
+          0, Webpacker::DevServerProxy, # "Webpacker::DevServerProxy" if Rails version < 5
           ssl_verify_none: true,
           webpacker: MyEngine.webpacker
         )


### PR DESCRIPTION
This PR fixes engine documentation to change "Webpacker::DevServerProxy" with the one for Rails version 5.