### PR TITLE
Adding support for Reason and ReasonReact applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,23 @@ The Elm library and its core packages will be added via Yarn and Elm.
 An example `Main.elm` app will also be added to your project in `app/javascript`
 so that you can experiment with Elm right away.
 
+### Reason with ReasonReact
+
+To use Webpacker with [Reason](https://reasonml.github.io/) and [ReasonReact](https://reasonml.github.io/reason-react/en/),
+create a new Rails 5.1+ app using `--webpack=reason` option:
+
+```
+# Rails 5.1+
+rails new myapp --webpack=reason
+```
+
+(or run `bundle exec rails webpacker:install:reason` on a Rails app already setup with Webpacker).
+
+The [BuckleScript](https://bucklescript.github.io/en/) compiler and its core packages will be added
+via Yarn. An example `App.re` app will also be added to your project in `app/javascript`
+so that you can experiment with Reason and ReasonReact right away.
+
+
 ### Stimulus
 
 To use Webpacker with [Stimulus](http://stimulusjs.org), create a

--- a/lib/install/examples/reason/App.re
+++ b/lib/install/examples/reason/App.re
@@ -1,0 +1,3 @@
+let embed = (target) => {
+	ReactDOMRe.render(<Greeting name="Reason" />, target);
+};

--- a/lib/install/examples/reason/Greeting.re
+++ b/lib/install/examples/reason/Greeting.re
@@ -1,0 +1,15 @@
+/* For more examples please have a look at:
+   https://reasonml.github.io/reason-react/docs/en/counter
+*/
+
+let component = ReasonReact.statelessComponent("Greeting");
+
+let make = (~name, _children) => {
+  ...component,
+  render: _self => {
+    let msg = {j|Hello $(name)!|j};
+    <button>
+      {ReasonReact.string(msg)}
+    </button>
+  }
+};

--- a/lib/install/examples/reason/bsconfig.json
+++ b/lib/install/examples/reason/bsconfig.json
@@ -1,0 +1,24 @@
+/* This is the BuckleScript configuration file. Note that this is a comment;
+  BuckleScript comes with a JSON parser that supports comments and trailing
+  comma. If this screws with your editor highlighting, please tell us by filing
+  an issue! */
+{
+  "name": "reason-on-webpacker",
+  "reason": {
+    "react-jsx": 2
+  },
+  "sources": {
+    "dir" : "app/javascript",
+    "subdirs" : true
+  },
+  "package-specs": [{
+    "module": "es6",
+    "in-source": true
+  }],
+  "suffix": ".bs.js",
+  "namespace": true,
+  "bs-dependencies": [
+    "reason-react"
+  ],
+  "refmt": 3
+}

--- a/lib/install/examples/reason/hello_reason.js
+++ b/lib/install/examples/reason/hello_reason.js
@@ -1,0 +1,12 @@
+// Run this example by adding <%= javascript_pack_tag "hello_reason" %> to the
+// head of your layout file, like app/views/layouts/application.html.erb.
+// It will render "Hello Reason!" within a button on the page.
+
+import * as App from "../App.re";
+
+document.addEventListener('DOMContentLoaded', () => {
+  const target = document.createElement('div')
+
+  document.body.appendChild(target)
+  App.embed(target);
+});

--- a/lib/install/loaders/bucklescript.js
+++ b/lib/install/loaders/bucklescript.js
@@ -1,0 +1,10 @@
+module.exports = {
+  test: /\.(re|ml)(\.erb)?$/,
+  use: [{
+    loader: 'bs-loader',
+    options: {
+      module: 'es6',
+      inSource: true
+    }
+  }]
+}

--- a/lib/install/reason.rb
+++ b/lib/install/reason.rb
@@ -1,0 +1,36 @@
+require "webpacker/configuration"
+
+say "Copying bucklescript (reason to javascript) loader to config/webpack/loaders"
+copy_file "#{__dir__}/loaders/bucklescript.js", Rails.root.join("config/webpack/loaders/bucklescript.js").to_s
+
+say "Adding BuckleScript loader to config/webpack/environment.js"
+insert_into_file Rails.root.join("config/webpack/environment.js").to_s,
+  "const bsLoader =  require('./loaders/bucklescript')\n",
+  after: "require('@rails/webpacker')\n"
+
+say "Prependig BuckleScript loader in the loaders list in config/webpack/environment.js"
+insert_into_file Rails.root.join("config/webpack/environment.js").to_s,
+  "environment.loaders.prepend('bucklescript', bsLoader)\n",
+  before: "module.exports"
+
+say "Copying BuckleScript configuration to project"
+copy_file "#{__dir__}/examples/reason/bsconfig.json", Rails.root.join("bsconfig.json").to_s
+
+say "Copying Reason example file to #{Webpacker.config.source_entry_path}"
+copy_file "#{__dir__}/examples/reason/hello_reason.js",
+  "#{Webpacker.config.source_entry_path}/hello_reason.js"
+
+say "Copying Reason app files to #{Webpacker.config.source_path}"
+copy_file "#{__dir__}/examples/reason/Greeting.re", "#{Webpacker.config.source_path}/Greeting.re"
+copy_file "#{__dir__}/examples/reason/App.re", "#{Webpacker.config.source_path}/App.re"
+
+say "Installing all Reason and ReasonReact dependencies"
+run "yarn add bs-platform bs-loader react react-dom reason-react"
+
+say "Updating webpack paths to include .re file extension"
+insert_into_file Webpacker.config.config_path, "- .re\n".indent(4), after: /\s+extensions:\n/
+
+say "Updating .gitignore to exclude unnecessary bucklescript generated files"
+insert_into_file ".gitignore", "\n# Ignore bucklescript generated files.\n.merlin\n.bsb.lock\n/lib/bs\n\n", after: "/node_modules\n"
+
+say "Webpacker now supports Reason and ReasonReact ⚛ 🎉", :green

--- a/lib/tasks/installers.rake
+++ b/lib/tasks/installers.rake
@@ -2,6 +2,7 @@ installers = {
   "Angular": :angular,
   "Elm": :elm,
   "React": :react,
+  "Reason": :reason,
   "Vue": :vue,
   "Erb": :erb,
   "Coffee": :coffee,


### PR DESCRIPTION
I would like to contribute support for Reason applications to this project. The following changes setup the necessary changes to compile and run Reason applications. Furthermore, it includes a small ReasonReact application to get started right away. Comments and feedback are welcomed.