### PR TITLE
Revert "Exclude Rails 4.2 + ruby-head build (#1825)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,3 @@ matrix:
   exclude:
     - rvm: 2.3.8
       gemfile: gemfiles/Gemfile-rails-edge
-    - rvm: ruby-head
-      gemfile: gemfiles/Gemfile-rails.4.2.x


### PR DESCRIPTION
Follow up of https://github.com/rails/webpacker/pull/1825#issuecomment-447177186.
And this reverts commit c48cf46c667830aac9df832c7afd97591fca580e.

### Summary

This PR restores Rails 4.2 + ruby-head (2.6) build.

Ruby 2.6.0 has been released.
https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/

`BigDecimal.new` has been replaced with deprecation rather than deletion.

```console
% ruby -rbigdecimal -ve 'BigDecimal.new(42)'
ruby 2.6.0p0 (2018-12-25 revision 66547) [x86_64-darwin17]
-e:1: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
```