### PR TITLE
Make `Webpacker::Manifest#lookup` public API

### DIFF
--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -18,6 +18,12 @@ class Webpacker::Manifest
     @data = load
   end
 
+  # Computes the relative path for a given Webpacker asset using manifest.json.
+  # If no asset is found, returns nil.
+  #
+  # Example:
+  #
+  #   Webpacker.manifest.lookup('calendar.js') # => "/packs/calendar-1016838bab065ae1e122.js"
   def lookup(name, pack_type = {})
     compile if compiling?
 
@@ -39,6 +45,7 @@ class Webpacker::Manifest
     end
   end
 
+  # Like lookup, except that if no asset is found, raises a Webpacker::Manifest::MissingEntryError.
   def lookup!(name, pack_type = {})
     lookup(name, pack_type) || handle_missing_entry(name)
   end


### PR DESCRIPTION
I'm using [Service Workers](https://developers.google.com/web/fundamentals/primers/service-workers/?hl=en) with this gem. To register a Service Worker in a browser, the path of `sw.js` file is needed.

```js
navigator.serviceWorker.register('/path-to-sw.js')
```

But `Webpacker::Manifest#lookup` and `Webpacker::Manifest#lookup!` seem to be nodoc. Could you make them public API? My usage of these methods is following:

```erb
<!--app/views/layouts/application.html.erb-->

<!DOCTYPE html>
<html>
  <head>
   <script>
     window.serviceWorkerPath = "<%= Webpacker.manifest.lookup!('sw.js') %>";
   </script>
   <link href="/manifest.json" rel="manifest">
(snip)
```

```js
// app/javascript/packs/application.js

document.addEventListener("DOMContentLoaded", () => {
  if ('serviceWorker' in navigator) {
    navigator.serviceWorker.register(window.serviceWorkerPath);
  }
});
```