### PR TITLE
Fix: use env_prefix in dev_server.js

### DIFF
--- a/package/__tests__/dev_server.js
+++ b/package/__tests__/dev_server.js
@@ -20,6 +20,21 @@ describe('DevServer', () => {
     expect(devServer.port).toEqual('5000')
   })
 
+  test('with custom env prefix', () => {
+    const config = require('../config')
+    config.dev_server.env_prefix = 'TEST_WEBPACKER_DEV_SERVER_'
+
+    process.env.NODE_ENV = 'development'
+    process.env.RAILS_ENV = 'development'
+    process.env.TEST_WEBPACKER_DEV_SERVER_HOST = '0.0.0.0'
+    process.env.TEST_WEBPACKER_DEV_SERVER_PORT = 5000
+
+    const devServer = require('../dev_server')
+    expect(devServer).toBeDefined()
+    expect(devServer.host).toEqual('0.0.0.0')
+    expect(devServer.port).toEqual('5000')
+  })
+
   test('with NODE_ENV and RAILS_ENV set to production', () => {
     process.env.RAILS_ENV = 'production'
     process.env.NODE_ENV = 'production'

--- a/package/dev_server.js
+++ b/package/dev_server.js
@@ -9,8 +9,10 @@ const fetch = (key) => {
 const devServerConfig = config.dev_server
 
 if (devServerConfig) {
+  const envPrefix = config.dev_server.env_prefix || 'WEBPACKER_DEV_SERVER_'
+
   Object.keys(devServerConfig).forEach((key) => {
-    const envValue = fetch(`WEBPACKER_DEV_SERVER_${key.toUpperCase().replace(/_/g, '')}`)
+    const envValue = fetch(`${envPrefix}${key.toUpperCase().replace(/_/g, '')}`)
     if (envValue !== undefined) devServerConfig[key] = envValue
   })
 }


### PR DESCRIPTION
Follow-up for #1836 (https://github.com/rails/webpacker/pull/1836/commits/f07bd9499cef018ea0b522653cc35a92d1ede254).