### PR TITLE
Use flatted to compare object equality

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "compression-webpack-plugin": "^2.0.0",
     "css-loader": "^2.0.1",
     "file-loader": "^2.0.0",
+    "flatted": "^2.0.0",
     "glob": "^7.1.3",
     "js-yaml": "^3.12.0",
     "mini-css-extract-plugin": "^0.5.0",

--- a/package/utils/helpers.js
+++ b/package/utils/helpers.js
@@ -1,3 +1,5 @@
+const { stringify } = require('flatted/cjs')
+
 const isObject = value => typeof value === 'object'
   && value !== null
   && (value.length === undefined || value.length === null)
@@ -17,7 +19,7 @@ const isStrPath = (key) => {
 
 const isArray = value => Array.isArray(value)
 
-const isEqual = (target, source) => JSON.stringify(target) === JSON.stringify(source)
+const isEqual = (target, source) => stringify(target) === stringify(source)
 
 const canMerge = value => isObject(value) || isArray(value)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3053,6 +3053,11 @@ flat-cache@^1.2.1:
     rimraf "~2.6.2"
     write "^0.2.1"
 
+flatted@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
+  integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
+
 flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"


### PR DESCRIPTION
Issue #1856 where an error occurs if there is a circular JSON reference somewhere in the config. This PR introduces the [`flatted`](https://www.npmjs.com/package/flatted) package which can stringify those circular references.