### PR TITLE
Exclude Rails Edge (6.0) + Ruby 2.4 or lower build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,7 @@ matrix:
   exclude:
     - rvm: 2.3.8
       gemfile: gemfiles/Gemfile-rails-edge
+    - rvm: 2.4.5
+      gemfile: gemfiles/Gemfile-rails-edge
+    - rvm: 2.5.3
+      gemfile: gemfiles/Gemfile-rails-edge


### PR DESCRIPTION
Rails Edge (6.0) requires Ruby 2.5 or higher.
https://github.com/rails/rails/commit/1b7c3222e86b98ce886110ae0860ba62e35e2299

This PR excludes the following error matrix from Travis CI.

```console
$ bundle install
Fetching https://github.com/rails/rails.git
Fetching https://github.com/rails/arel.git
Fetching https://github.com/rubocop-hq/rubocop.git
Fetching gem metadata from https://rubygems.org/.............
Fetching gem metadata from https://rubygems.org/..........
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
activesupport-6.0.0.alpha requires ruby version >= 2.5.0, which is incompatible
with the current version, ruby 2.4.5p335
The command "bundle install" failed and exited with 5 during .
```

https://travis-ci.org/rails/webpacker/jobs/472092576#L887-L897