### PR TITLE
webpacker.yml: correctly ignore node_modules

### DIFF
--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -72,7 +72,7 @@ development:
     headers:
       'Access-Control-Allow-Origin': '*'
     watch_options:
-      ignored: /node_modules/
+      ignored: '**/node_modules/**'
 
 
 test:


### PR DESCRIPTION
Hello! I was investigating high CPU usage resulting from the webpack-dev-server on my macbook pro, when I realized that the `node_modules` directory wasn't ignored. Diving a bit deeper `/node_modules/` should be parsed to a js regex, however js-yaml parses it as a string. I think this is due to using [safeLoad](https://github.com/rails/webpacker/blob/master/package/config.js#L17). As a result, files under the `node_modules` directory get watched. This commit switches to using an anymatch pattern which works as expected. My CPU usage dropped dramatically after this. 

Hope this helps!