### PR TITLE
webpacker.yml: correctly ignore node_modules

### DIFF
--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -49,7 +49,7 @@ development:
     headers:
       'Access-Control-Allow-Origin': '*'
     watch_options:
-      ignored: /node_modules/
+      ignored: '**/node_modules/**'
 
 
 test:


### PR DESCRIPTION
This is a backport of https://github.com/rails/webpacker/pull/1863 to the 3.x branch.