### PR TITLE
Make css-loader an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "babel-plugin-macros": "^2.4.2",
     "case-sensitive-paths-webpack-plugin": "^2.1.2",
     "compression-webpack-plugin": "^2.0.0",
-    "css-loader": "^2.0.1",
     "file-loader": "^2.0.0",
     "flatted": "^2.0.0",
     "glob": "^7.1.3",
@@ -49,6 +48,9 @@
     "webpack-assets-manifest": "^3.1.1",
     "webpack-cli": "^3.1.2",
     "webpack-sources": "^1.3.0"
+  },
+  "optionalDependencies": {
+    "css-loader": "^2.0.1"
   },
   "devDependencies": {
     "eslint": "^5.10.0",


### PR DESCRIPTION
I think that many people do not use css-loader, and those
people should not be forced to install it.

Disclaimer: I'm primarily a ruby programmer, so if there are
related changes outside of package.json that I am missing, sorry,
and thanks for your help.