### PR TITLE
Restore Rails Edge (6.0) + Ruby 2.5 build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,5 +39,3 @@ matrix:
       gemfile: gemfiles/Gemfile-rails-edge
     - rvm: 2.4.5
       gemfile: gemfiles/Gemfile-rails-edge
-    - rvm: 2.5.3
-      gemfile: gemfiles/Gemfile-rails-edge


### PR DESCRIPTION
Follow up of #1860.

Ruby 2.5 needs to be built with Rails Edge (6.0).
That is my mistake and I restored it 💦 


