### PR TITLE
Change `WEBPACKER_DEV_SERVER_HOST` to `webpacker`

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -39,7 +39,7 @@ and create an env file to load environment variables from:
 ```env
 NODE_ENV=development
 RAILS_ENV=development
-WEBPACKER_DEV_SERVER_HOST=0.0.0.0
+WEBPACKER_DEV_SERVER_HOST=webpacker
 ```
 
 Lastly, rebuild your container:


### PR DESCRIPTION
When using `0.0.0.0` as the host I found that my server that is run as a separate service is not detecting `webpack-dev-server` correctly. `Webpacker.dev_server.running?` in console returns `false`. 

Changing to `webpacker` fixes this issue.