### PR TITLE
[BUG] Typo in react babel config

### DIFF
--- a/lib/install/examples/react/babel.config.js
+++ b/lib/install/examples/react/babel.config.js
@@ -10,7 +10,7 @@ module.exports = function(api) {
       'Please specify a valid `NODE_ENV` or ' +
         '`BABEL_ENV` environment variables. Valid values are "development", ' +
         '"test", and "production". Instead, received: ' +
-        JSON.stringify(env) +
+        JSON.stringify(currentEnv) +
         '.'
     )
   }


### PR DESCRIPTION
Simple typo in React `babel.config.js` referencing a variable that doesn't exist