### PR TITLE
Add installer for jest

### DIFF
--- a/lib/install/examples/jest/hello_jest.js
+++ b/lib/install/examples/jest/hello_jest.js
@@ -1,0 +1,10 @@
+export default class HelloJest {
+  constructor(a, b) {
+    this.a = a;
+    this.b = b;
+  }
+
+  sum() {
+    return this.a + this.b;
+  }
+}

--- a/lib/install/examples/jest/hello_jest.spec.js
+++ b/lib/install/examples/jest/hello_jest.spec.js
@@ -1,0 +1,10 @@
+import HelloJest from 'packs/hello_jest';
+
+describe('HelloJest', () => {
+  describe('#sum', () => {
+    it('returns the correct sum', () => {
+      const helloJest = new HelloJest(1,2);
+      expect(helloJest.sum()).toEqual(3);
+    });
+  });
+});

--- a/lib/install/jest.rb
+++ b/lib/install/jest.rb
@@ -1,0 +1,39 @@
+require "webpacker/configuration"
+
+say "Copying the example test files"
+tests_folder = "#{defined?(RSpec) ? 'spec' : 'test'}/javascripts"
+
+copy_file "#{__dir__}/examples/jest/hello_jest.js",
+          "#{Webpacker.config.source_entry_path}/hello_jest.js"
+copy_file "#{__dir__}/examples/jest/hello_jest.spec.js",
+          "#{Webpacker.config.root_path.join(tests_folder)}/hello_jest.spec.js"
+
+say "Updating package.json"
+package_json = JSON.parse(File.read(Rails.root.join("package.json")))
+relative_source_path = Webpacker.config.source_path.relative_path_from(Webpacker.config.root_path)
+
+jest_config = {
+  "scripts" => {
+    "test" => "jest",
+    "test:watch" => "jest --watch"
+  },
+  "jest" => {
+    "roots" => [relative_source_path.to_s, tests_folder],
+    "moduleDirectories" => ["node_modules", relative_source_path.to_s],
+    "transform" => {
+      "^.+\\.js?$" => "babel-jest"
+    }
+  }
+}
+
+order_list = %w(name private jest dependencies devDependencies)
+new_package_json = jest_config.deep_merge(package_json).sort_by do |key, value|
+  order_list.index(key) || Float::INFINITY
+end.to_h
+
+File.write(Rails.root.join("package.json"), JSON.pretty_generate(new_package_json))
+
+say "Installing all Jest dependencies"
+run "yarn add --dev jest babel-jest"
+
+say "Webpacker now supports Jest 🎉. Execute 'yarn test' to run your tests.", :green

--- a/lib/tasks/installers.rake
+++ b/lib/tasks/installers.rake
@@ -6,7 +6,8 @@ installers = {
   "Erb": :erb,
   "Coffee": :coffee,
   "Typescript": :typescript,
-  "Stimulus": :stimulus
+  "Stimulus": :stimulus,
+  "Jest": :jest
 }.freeze
 
 dependencies = {

--- a/test/rake_tasks_test.rb
+++ b/test/rake_tasks_test.rb
@@ -14,6 +14,7 @@ class RakeTasksTest < Minitest::Test
     assert_includes output, "webpacker:install:elm"
     assert_includes output, "webpacker:install:react"
     assert_includes output, "webpacker:install:vue"
+    assert_includes output, "webpacker:install:jest"
     assert_includes output, "webpacker:verify_install"
   end
 


### PR DESCRIPTION
This PR adds support for the command `webpacker:install:jest`.
The command will install jest and add a couple of files as an example, saving you from the pain of configuring it manually.

Personally, I would propose to have it installed by default when installing webpacker. What is nice about Rails (and puts it one step in front of other frameworks) is to have a development environment that **just works**. 

In such an environment, I expect to have a testing framework for my Javascript ready to use. As Rails provides minitest out-of-the-box, it should also provide jest, to start writing tests immediately.


Things to consider: 

* I put the tests under the `test/javascripts` folder. Should this go under webpacker configuration file?

* Shall I write tests? I didn't see tests for the other installers. I have an idea on how to run the tests for these rake commands. you can see it here: https://github.com/coorasse/webpacker/commit/5195aef0a113b62fe9ba4275235ae9fd6c954476
