### PR TITLE
Ignore failures on Rails 4.2.x for Ruby head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,5 @@ matrix:
       gemfile: gemfiles/Gemfile-rails-edge
     - rvm: 2.5.3
       gemfile: gemfiles/Gemfile-rails-edge
+    - rvm: ruby-head
+      gemfile: gemfiles/Gemfile-rails.4.2.x


### PR DESCRIPTION
Bundler 2.x drops support for Ruby < 2.3
Rails 4.2 requires Bundler < 2

We could force the entire pipeline to use Bundler 1.x but I don't really see the point of accommodating such EoL releases paired with bleeding edge Ruby. Rails itself doesn't test 4.2 with > 2.5.