### PR TITLE
Add default DefinePlugin configuration

### DIFF
--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -48,6 +48,13 @@ default: &default
     - .jpeg
     - .jpg
 
+  define_plugin:
+    enabled: true
+    mapping:
+      typeof document: "'object'"
+      typeof self: "'object'"
+      typeof window: "'object'"
+
 development:
   <<: *default
   compile: true

--- a/package/__tests__/config.js
+++ b/package/__tests__/config.js
@@ -63,4 +63,15 @@ describe('Config', () => {
       '.jpg'
     ])
   })
+
+  test('should return define_plugin config as listed in app config', () => {
+    expect(config.define_plugin).toEqual({
+      enabled: true,
+      mapping: {
+        'typeof document': "'object'",
+        'typeof self': "'object'",
+        'typeof window': "'object'"
+      }
+    })
+  })
 })

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -49,6 +49,14 @@ const getPluginList = () => {
       publicPath: true
     })
   )
+
+  if (config.define_plugin && config.define_plugin.enabled) {
+    result.append(
+      'Define',
+      new webpack.DefinePlugin(config.define_plugin.mapping)
+    )
+  }
+
   return result
 }
 


### PR DESCRIPTION
Isomorphic javascript libraries may include conditionals like:
```
if (typeof window !== 'undefined')
```
or:
```
if (typeof document === 'undefined')
```
or perhaps (to match a window context or a worker context):
```
if (typeof self !== 'undefined')
```
in order to run additional code based on the runtime environment (e.g. to apply some default behavior when running in a browser environment, or to polyfill a browser API only when running in a nodejs environment).

However, once these libraries are consumed in an application, it is typically known at build-time what the runtime environment will be. In such cases, it's recommended to use something like the [`DefinePlugin`][1] to replace these conditions with constant values so that the minifier can optimize the conditionals and remove dead code where applicable.

Since webpacker is targeted at compiling javascript for Rails applications that run in the browser, it would be helpful to provide a default `DefinePlugin` configuration targeted towards the browser
environment. In particular, defining `typeof window`, `typeof self`, and `typeof document` to `'object'` is generally a good practice. So that's what this change provides.

This is still fully configurable. The default configuration can be completely disabled by setting `define_plugin.enabled` to `false` in the application's `webpacker.yml`, and the `define_plugin.mapping` can be customized, too.

[1]: https://webpack.js.org/plugins/define-plugin/