### PR TITLE
Clarify nodeModules loader in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,14 @@
   extract_css: true
   ```
   - Separate rule to compile node modules
-  (fixes cases where ES6 libraries were included in the app code) [#1823](https://github.com/rails/webpacker/pull/1823)
+  (fixes cases where ES6 libraries were included in the app code) [#1823](https://github.com/rails/webpacker/pull/1823).
+      
+    In previous versions only application code was transpiled. Now everything in `node_modules` transpiled with Babel. In some cases it could break your build ([#1892](https://github.com/rails/webpacker/issues/1892)).
+    
+    [`nodeModules` loader](https://github.com/rails/webpacker/pull/1823/files#diff-456094c8451b5774db50028dfecf4aa8) ignores `config.babel.js` and uses hard-coded `'@babel/preset-env', { modules: false }` config.
+    
+    To keep previous behavior, remove `nodeModules` loader specifying `environment.loaders.delete('nodeModules');` in your `config/webpack/environment.js` file.
+  
   - File loader extensions API [#1823](https://github.com/rails/webpacker/pull/1823)
   ```yml
   # webpacker.yml


### PR DESCRIPTION
New `nodeModules` loader significantly change behavior.
It's specified in **Breaking changes** section but description is quite small.

As example, @javan have issue with `nodeModules` loader (#1892). Also, in my build it breaks `mapbox-gl` package (https://github.com/mapbox/mapbox-gl-js/issues/3422).

This PR adds more details to `CHANGELOG.md` about `nodeModules` loader and receipt to keep previous behavior.