### PR TITLE
Add a new javascript_packs_with_chunks_tag tag helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 **Please note that Webpacker 3.1.0 and 3.1.1 have some serious bugs so please consider using either 3.0.2 or 3.2.0**
 
+## [4.0.0] - Unreleased
+
+### Fixed
+ - Issue with javascript_pack_tag asset duplication [#1898](https://github.com/rails/webpacker/pull/1898)
+
+
+### Added
+ - `javascript_packs_with_chunks_tag` helper, which creates html tags
+  for a pack and all the dependent chunks, when using splitchunks.
+
+```erb
+<%= javascript_packs_with_chunks_tag 'calendar', 'map', 'data-turbolinks-track': 'reload' %>
+
+<script src="/packs/vendor-16838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+<script src="/packs/calendar~runtime-16838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+<script src="/packs/calendar-1016838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+<script src="/packs/map~runtime-16838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+<script src="/packs/map-16838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+```
+
+**Important:** Pass all your pack names when using `javascript_packs_with_chunks_tag`
+helper otherwise you will get duplicated chunks on the page.
+
+```erb
+<%# DO %>
+<%= javascript_packs_with_chunks_tag 'calendar', 'map' %>
+
+<%# DON'T %>
+<%= javascript_packs_with_chunks_tag 'calendar' %>
+<%= javascript_packs_with_chunks_tag 'map' %>
+```
+
 ## [4.0.0.rc.2] - 2018-12-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -142,6 +142,31 @@ can use the `asset_pack_path` helper:
 <img src="<%= asset_pack_path 'images/logo.svg' %>" />
 ```
 
+If you are using new webpack 4 split chunks API, then consider using `javascript_packs_with_chunks_tag` helper, which creates html
+tags for a pack and all the dependent chunks.
+
+```erb
+<%= javascript_packs_with_chunks_tag 'calendar', 'map', 'data-turbolinks-track': 'reload' %>
+
+<script src="/packs/vendor-16838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+<script src="/packs/calendar~runtime-16838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+<script src="/packs/calendar-1016838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+<script src="/packs/map~runtime-16838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+<script src="/packs/map-16838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+```
+
+**Important:** Pass all your pack names when using `javascript_packs_with_chunks_tag`
+helper otherwise you will get duplicated chunks on the page.
+
+```erb
+<%# DO %>
+<%= javascript_packs_with_chunks_tag 'calendar', 'map' %>
+
+<%# DON'T %>
+<%= javascript_packs_with_chunks_tag 'calendar' %>
+<%= javascript_packs_with_chunks_tag 'map' %>
+```
+
 **Note:** In order for your styles or static assets files to be available in your view,
 you would need to link them in your "pack" or entry file.
 

--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -267,32 +267,36 @@ For the full configuration options of SplitChunks, see the [Webpack documentatio
 // config/webpack/environment.js
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 
-const splitChunks = {
-  optimization: {
-    splitChunks: {
-      chunks: 'all'
-    },
-  },
-};
+// Enable the default config
+environment.splitChunks()
 
-environment.config.merge(splitChunks);
-
-// Should override the existing manifest plugin
-environment.plugins.insert(
-  'Manifest',
-  new WebpackAssetsManifest({
-    entrypoints: true, // default in rails is false
-    writeToDisk: true, // rails defaults copied from webpacker
-    publicPath: true // rails defaults copied from webpacker
-  })
-)
+// or using custom config
+environment.splitChunks((config) => Object.assign({}, config, { optimization: { splitChunks: false }}))
 ```
 
-To use the `javascript_pack_tag` or the `stylesheet_pack_tag` with `SplitChunks` or `RuntimeChunks` you can refer to the packs as usual.
+Then use, `javascript_packs_with_chunks_tag` helper to include all the transpiled
+packs with the chunks in your view, which creates html tags for all the chunks.
 
 ```erb
-javascript_pack_tag "your-entrypoint-javascript-file"
-stylesheet_pack_tag "your-entrypoint-stylesheet-file"
+<%= javascript_packs_with_chunks_tag 'calendar', 'map', 'data-turbolinks-track': 'reload' %>
+
+<script src="/packs/vendor-16838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+<script src="/packs/calendar~runtime-16838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+<script src="/packs/calendar-1016838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+<script src="/packs/map~runtime-16838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+<script src="/packs/map-16838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+```
+
+**Important:** Pass all your pack names when using this helper otherwise you will
+get duplicated chunks on the page.
+
+```erb
+<%# DO %>
+<%= javascript_packs_with_chunks_tag 'calendar', 'map' %>
+
+<%# DON'T %>
+<%= javascript_packs_with_chunks_tag 'calendar' %>
+<%= javascript_packs_with_chunks_tag 'map' %>
 ```
 
 For the old configuration with the CommonsChunkPlugin see below. **Note** that this functionality is deprecated in Webpack V4.

--- a/package/environments/development.js
+++ b/package/environments/development.js
@@ -9,7 +9,6 @@ module.exports = class extends Base {
 
     if (devServer.hmr) {
       this.plugins.append('HotModuleReplacement', new webpack.HotModuleReplacementPlugin())
-      this.plugins.append('NamedModules', new webpack.NamedModulesPlugin())
       this.config.output.filename = '[name]-[hash].js'
     }
 

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -64,7 +64,7 @@ class HelperTest < ActionView::TestCase
       %(<script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js"></script>\n) +
         %(<script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js"></script>\n) +
         %(<script src="/packs/application-k344a6d59eef8632c9d1.js"></script>),
-      javascript_pack_tag("application")
+      javascript_packs_with_chunks_tag("application")
   end
 
   def test_stylesheet_pack_tag

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -22,6 +22,10 @@ class ManifestTest < Minitest::Test
     assert_nil Webpacker.manifest.lookup("foo.js")
   end
 
+  def test_lookup_chunks_nil
+    assert_nil Webpacker.manifest.lookup_pack_with_chunks("foo.js")
+  end
+
   def test_lookup_success
     assert_equal Webpacker.manifest.lookup("bootstrap.js"), "/packs/bootstrap-300631c4f0e0f9c865bc.js"
   end
@@ -33,6 +37,6 @@ class ManifestTest < Minitest::Test
       "/packs/application-k344a6d59eef8632c9d1.js"
     ]
 
-    assert_equal Webpacker.manifest.lookup!("application", type: :javascript), application_entrypoints
+    assert_equal Webpacker.manifest.lookup_pack_with_chunks!("application", type: :javascript), application_entrypoints
   end
 end


### PR DESCRIPTION
This PR adds a new chunks helper that addresses issues outlined here: https://github.com/rails/webpacker/issues/1835

Fixes #1835 
----

```erb
<%= javascript_packs_with_chunks_tag 'hello_react', 'application', 'hello_vue', 'data-turbolinks-track': 'reload' %>
```

which outputs following html, with depedencies de-deduped 

```html
<script src="/packs/runtime~hello_react-26febc8eea663e32aadb.js" data-turbolinks-track="reload"></script>
<script src="/packs/0-d471c80da3d3a8a51c72.chunk.js" data-turbolinks-track="reload"></script>
<script src="/packs/1-8ef1f3ec1d6838a685eb.chunk.js" data-turbolinks-track="reload"></script>
<script src="/packs/hello_react-d26893900192b71057ec.chunk.js" data-turbolinks-track="reload"></script>
<script src="/packs/runtime~application-2a426143d8d4ad5ac92e.js" data-turbolinks-track="reload"></script>
<script src="/packs/application-c45c132bb54ceeafd2e5.chunk.js" data-turbolinks-track="reload"></script>
<script src="/packs/runtime~hello_vue-b068488867759681a7da.js" data-turbolinks-track="reload"></script>
<script src="/packs/2-4bd0417a6b1fb648dbf1.chunk.js" data-turbolinks-track="reload"></script>
<script src="/packs/hello_vue-7e0743cde157093b96bb.chunk.js" data-turbolinks-track="reload"></script>
```

`javascript_packs_with_chunks_tag` is introduced to handle new webpack split chunks API: https://webpack.js.org/plugins/split-chunks-plugin/

```json
 "application": {
      "js": [
        "/packs/runtime~application-2a426143d8d4ad5ac92e.js",
        "/packs/0-d471c80da3d3a8a51c72.chunk.js",
        "/packs/application-c45c132bb54ceeafd2e5.chunk.js"
      ],
      "js.map": [
        "/packs/runtime~application-2a426143d8d4ad5ac92e.js.map",
        "/packs/0-d471c80da3d3a8a51c72.chunk.js.map",
        "/packs/application-c45c132bb54ceeafd2e5.chunk.js.map"
      
``` 

`javascript_pack_tag`, will keep working the same way as before, so no breaking changes there. 

```erb
<%# This will include all deps + pack %>
<%= javascript_packs_with_chunks_tag "stimulus", "hello_stimulus" %>

<%# this will include transpiled packs only, no deps (if using split chunks) %>
<%= javascript_pack_tag "stimulus" %>
<%= javascript_pack_tag "hello_stimulus" %>
```


```erb
<%# DO %>
<%= javascript_packs_with_chunks_tag 'calendar', 'map' %>

<%# DON'T %>
<%= javascript_packs_with_chunks_tag 'calendar' %>
<%= javascript_packs_with_chunks_tag 'map' %>
```

Thanks @javan, could you please review?
