### PR TITLE
Add section in the update guide on how to avoid transpiling of node_modules

### DIFF
--- a/docs/v4-upgrade.md
+++ b/docs/v4-upgrade.md
@@ -60,13 +60,13 @@ get duplicated chunks on the page.
 - If you're using Vue Loader, you'll need to upgrade to [v15](https://vue-loader.vuejs.org/migrating.html) for webpack 4.
 - To see what webpacker generates for a given framework with v4, you may want to re-run `bundle exec rake webpacker:install:FRAMEWORK` and let it override the files for your given JavaScript framework, and then compare them to see what changes you'll need to make.
 
-### Excluding node_modules from babel-loader
+### Excluding node_modules from being transpiled by babel-loader
 
-One change to take into consideration, is that Webpack 4 transpiles the
+One change to take into consideration, is that Webpacker 4 transpiles the
 `node_modules` folder with the `babel-loader`. This folder used to be ignored by
-webpack 3. The new behavior helps in case some library contains ES6 code, but in
+webpacker 3. The new behavior helps in case some library contains ES6 code, but in
 some cases it can lead to issues. To avoid running `babel-loader` in the
-`node_modules` folder, replicating the same behavior of Webpacker 3, the
+`node_modules` folder, replicating the same behavior as Webpacker 3, the
 following code can be added to `config/webpack/environment.js`:
 
 ```javascript

--- a/docs/v4-upgrade.md
+++ b/docs/v4-upgrade.md
@@ -60,6 +60,33 @@ get duplicated chunks on the page.
 - If you're using Vue Loader, you'll need to upgrade to [v15](https://vue-loader.vuejs.org/migrating.html) for webpack 4.
 - To see what webpacker generates for a given framework with v4, you may want to re-run `bundle exec rake webpacker:install:FRAMEWORK` and let it override the files for your given JavaScript framework, and then compare them to see what changes you'll need to make.
 
+### Excluding node_modules from babel-loader
+
+One change to take into consideration, is that Webpack 4 transpiles the
+`node_modules` folder with the `babel-loader`. This folder used to be ignored by
+webpack 3. The new behavior helps in case some library contains ES6 code, but in
+some cases it can lead to issues. To avoid running `babel-loader` in the
+`node_modules` folder, replicating the same behavior of Webpacker 3, the
+following code can be added to `config/webpack/environment.js`:
+
+```javascript
+environment.loaders.delete('nodeModules')
+```
+
+Alternatively, in order to skip only a specific library in the `node_modules`
+folder, this code can be added:
+
+```javascript
+const nodeModulesLoader = environment.loaders.get('nodeModules')
+if (!Array.isArray(nodeModulesLoader.exclude)) {
+  nodeModulesLoader.exclude = (nodeModulesLoader.exclude == null)
+    ? []
+    : [nodeModulesLoader.exclude]
+}
+nodeModulesLoader.exclude.push(/some-library/) // replace `some-library` with
+                                               // the actual path to exclude
+```
+
 ### Example upgrades
 
 This is what an upgrade to Webpacker 4 looked like for existing Rails apps (please contribute yours!):


### PR DESCRIPTION
As this change can surprise users who update from webpack 3, and lead to
issues that are difficult to track down, here is a section on how to
replicate the previous behavior if necessary.

See this discussion for a more detailed explanation of the issue: https://github.com/rails/webpacker/issues/1903#issuecomment-456862100