### PR TITLE
compiler: Use environmental variables instead of overwrite

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -90,7 +90,7 @@ class Webpacker::Compiler
     def webpack_env
       return env unless defined?(ActionController::Base)
 
-      env.merge("WEBPACKER_ASSET_HOST"        => ActionController::Base.helpers.compute_asset_host,
-                "WEBPACKER_RELATIVE_URL_ROOT" => ActionController::Base.relative_url_root)
+      env.merge("WEBPACKER_ASSET_HOST"        => ENV.fetch("WEBPACKER_ASSET_HOST", ActionController::Base.helpers.compute_asset_host),
+                "WEBPACKER_RELATIVE_URL_ROOT" => ENV.fetch("WEBPACKER_RELATIVE_URL_ROOT", ActionController::Base.relative_url_root))
     end
 end

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -63,4 +63,14 @@ class CompilerTest < Minitest::Test
   def test_compilation_digest_path
     assert_equal Webpacker.compiler.send(:compilation_digest_path).basename.to_s, "last-compilation-digest-#{Webpacker.env}"
   end
+
+  def test_external_env_variables
+    assert_equal Webpacker.compiler.send(:webpack_env)["WEBPACKER_ASSET_HOST"], ActionController::Base.helpers.compute_asset_host
+    assert_equal Webpacker.compiler.send(:webpack_env)["WEBPACKER_RELATIVE_URL_ROOT"], ActionController::Base.relative_url_root
+
+    ENV["WEBPACKER_ASSET_HOST"] = "foo.bar"
+    ENV["WEBPACKER_RELATIVE_URL_ROOT"] = "/baz"
+    assert_equal Webpacker.compiler.send(:webpack_env)["WEBPACKER_ASSET_HOST"], "foo.bar"
+    assert_equal Webpacker.compiler.send(:webpack_env)["WEBPACKER_RELATIVE_URL_ROOT"], "/baz"
+  end
 end


### PR DESCRIPTION
Webpacker uses 2 specific environmental variables (WEBPACKER_ASSET_HOST
and WEBPACKER_RELATIVE_URL) that are set during boot. There is no way
that this variables can be overwritten. This patch makes use of the
external variables or falls back to the default behavior.

This partially solves #1922 as we can set WEBPACKER_ASSET_HOST to an empty
string and then the links will be relative to the asset