### PR TITLE
Require babel-plugin-module-resolver name fix

### DIFF
--- a/docs/assets.md
+++ b/docs/assets.md
@@ -61,7 +61,7 @@ Specify the plugin in your `babel.config.js` with the custom root or alias. Here
 ```js
 {
   plugins: [
-    [require("module-resolver").default, {
+    [require("babel-plugin-module-resolver").default, {
       "root": ["./app"],
       "alias": {
         "assets": "./assets"


### PR DESCRIPTION
require babel-plugin-module-resolver instead of module-resolver