### PR TITLE
Enable static asset extensions to be overwritten from app config

### DIFF
--- a/package/__tests__/config.js
+++ b/package/__tests__/config.js
@@ -63,4 +63,16 @@ describe('Config', () => {
       '.jpg'
     ])
   })
+
+  test('should return static assets extensions as listed in app config', () => {
+    expect(config.static_assets_extensions).toEqual([
+      '.jpg',
+      '.jpeg',
+      '.png',
+      '.gif',
+      '.tiff',
+      '.ico',
+      '.svg',
+    ])
+  })
 })

--- a/package/config.js
+++ b/package/config.js
@@ -17,6 +17,9 @@ const defaults = getDefaultConfig()
 const app = safeLoad(readFileSync(configPath), 'utf8')[railsEnv]
 
 if (isArray(app.extensions) && app.extensions.length) delete defaults.extensions
+if (isArray(app.static_assets_extensions) && app.static_assets_extensions.length) {
+  delete defaults.static_assets_extensions
+}
 
 const config = deepMerge(defaults, app)
 config.outputPath = resolve(config.public_root_path, config.public_output_path)

--- a/test/test_app/config/webpacker.yml
+++ b/test/test_app/config/webpacker.yml
@@ -28,11 +28,6 @@ default: &default
     - .tiff
     - .ico
     - .svg
-    - .eot
-    - .otf
-    - .ttf
-    - .woff
-    - .woff2
 
   extensions:
     - .mjs


### PR DESCRIPTION
Currently you can only add more custom static asset extensions to app's webpacker config. If you remove some of them (e.g. for them to be loaded by url-loader) the default webpacker config merges them back in

So let's treat them the same way we do the usual extensions i.e. delete the default list if there's a user-provided one