### PR TITLE
[BUG] Add resolved paths to app-code babel compile

### DIFF
--- a/package/rules/babel.js
+++ b/package/rules/babel.js
@@ -1,12 +1,12 @@
 const { join, resolve } = require('path')
-const { cache_path: cachePath, source_path: sourcePath } = require('../config')
+const { cache_path: cachePath, source_path: sourcePath, resolved_paths: resolvedPaths } = require('../config')
 const { nodeEnv } = require('../env')
 
 // Process application Javascript code with Babel.
 // Uses application .babelrc to apply any transformations
 module.exports = {
   test: /\.(js|jsx|mjs)?(\.erb)?$/,
-  include: resolve(sourcePath),
+  include: [sourcePath, ...resolvedPaths].map(p => resolve(p)),
   exclude: /node_modules/,
   use: [
     {


### PR DESCRIPTION
After we split the `node_module` compiling from the [app code compiling](https://github.com/rails/webpacker/pull/1823), we left out `resolved_paths`.  I first noticed this after I upgraded to `v4.0.0.rc.3` from `v4.0.0.rc.2`. 

[This commit](https://github.com/rails/webpacker/blob/9e671a3ebe368cfdc624309a9b4a55e998f87186/package/rules/node_modules.js#L8) has now created the whitelist of `node_module` compiled code, which left my `resolved_paths` out of the loop (neither compiled by accident by the old node_module config, nor compiled by the babel config because it only looks at the `source_path`)

#### For people providing `resolved_paths != []` 
I realize not every project is using `resolved_paths` but without this you get very confusing errors if your `source_path` code is depending on `resolved_path` code. I think whatever performance penalty you get from this should be expected given it's clearly stated that `resolved_paths` are not-ideal elsewhere.

It's hard to imagine this would be unexpected/unwanted for people specifying `resolved_paths` because it was probably happening in Webpacker 3.x anyway 

#### For people providing `resolved_paths === []` 
For people not using `resolved_paths` this will have no effect. 