### PR TITLE
Revert "Remove context from file loader (#1914)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ environment.config.merge({ devtool: 'none' })
 module.exports = environment.toWebpackConfig()
 ```
 
+- Reintroduced `context` to the file loader. Reverting the simpler paths change
+
 
 ## [4.0.0.rc.7] - 2019-01-25
 

--- a/package/environments/__tests__/base.js
+++ b/package/environments/__tests__/base.js
@@ -31,8 +31,8 @@ describe('Environment', () => {
 
     test('should return output', () => {
       const config = environment.toWebpackConfig()
-      expect(config.output.filename).toEqual('js/[name]-[chunkhash].js')
-      expect(config.output.chunkFilename).toEqual('js/[name]-[chunkhash].chunk.js')
+      expect(config.output.filename).toEqual('[name]-[chunkhash].js')
+      expect(config.output.chunkFilename).toEqual('[name]-[chunkhash].chunk.js')
     })
 
     test('should return default loader rules for each file in config/loaders', () => {

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -36,8 +36,8 @@ const getPluginList = () => {
   result.append(
     'MiniCssExtract',
     new MiniCssExtractPlugin({
-      filename: 'css/[name]-[contenthash:8].css',
-      chunkFilename: 'css/[name]-[contenthash:8].chunk.css'
+      filename: '[name]-[contenthash:8].css',
+      chunkFilename: '[name]-[contenthash:8].chunk.css'
     })
   )
   result.append(
@@ -83,9 +83,9 @@ const getModulePaths = () => {
 const getBaseConfig = () => new ConfigObject({
   mode: 'production',
   output: {
-    filename: 'js/[name]-[chunkhash].js',
-    chunkFilename: 'js/[name]-[chunkhash].chunk.js',
-    hotUpdateChunkFilename: 'js/[id]-[hash].hot-update.js',
+    filename: '[name]-[chunkhash].js',
+    chunkFilename: '[name]-[chunkhash].chunk.js',
+    hotUpdateChunkFilename: '[id]-[hash].hot-update.js',
     path: config.outputPath,
     publicPath: config.publicPath
   },

--- a/package/rules/file.js
+++ b/package/rules/file.js
@@ -1,4 +1,5 @@
-const { static_assets_extensions: fileExtensions } = require('../config')
+const { join } = require('path')
+const { source_path: sourcePath, static_assets_extensions: fileExtensions } = require('../config')
 
 module.exports = {
   test: new RegExp(`(${fileExtensions.join('|')})$`, 'i'),
@@ -6,7 +7,8 @@ module.exports = {
     {
       loader: 'file-loader',
       options: {
-        name: 'media/[name]-[hash:8].[ext]'
+        name: '[path][name]-[hash].[ext]',
+        context: join(sourcePath)
       }
     }
   ]


### PR DESCRIPTION
This reverts changes to how assets are managed introduced in RC6. The
changes themselves were introduced to fix #1887 but I couldn't draw a
line between the issue and how these changes were meant to address it.
Additionally, they didn't appear to help the user who made the initial
request and caused a host of other problems.

This appears to be the potential cause for #1938, #1915, #1947, and #1922.

This reverts commit 35ec3aee4fd1cf4bb9fa5303fe83a5838b9d9409.