### PR TITLE
Remove deprecated option of resolve-url-loader and make code correct to be executed before "css" instead of "sass"

### DIFF
--- a/docs/css.md
+++ b/docs/css.md
@@ -147,10 +147,10 @@ yarn add resolve-url-loader
 const { environment } = require('@rails/webpacker')
 
 // resolve-url-loader must be used before sass-loader
-environment.loaders.get('sass').use.splice(-1, 0, {
+environment.loaders.get('css').use.splice(-1, 0, {
   loader: 'resolve-url-loader',
   options: {
-    attempts: 1
+    // the resolve-url-loader options
   }
 });
 ```


### PR DESCRIPTION
Hey everyone! :+1: 

The current code example does not work with the latest version of webpacker gem (3.x) and the latest version of resolve-url-loader (3.x).

@gauravtiwari 