### PR TITLE
Fix env_prefix consitency between Ruby and JS

### DIFF
--- a/package/__tests__/dev_server.js
+++ b/package/__tests__/dev_server.js
@@ -22,7 +22,7 @@ describe('DevServer', () => {
 
   test('with custom env prefix', () => {
     const config = require('../config')
-    config.dev_server.env_prefix = 'TEST_WEBPACKER_DEV_SERVER_'
+    config.dev_server.env_prefix = 'TEST_WEBPACKER_DEV_SERVER'
 
     process.env.NODE_ENV = 'development'
     process.env.RAILS_ENV = 'development'

--- a/package/dev_server.js
+++ b/package/dev_server.js
@@ -9,10 +9,10 @@ const fetch = (key) => {
 const devServerConfig = config.dev_server
 
 if (devServerConfig) {
-  const envPrefix = config.dev_server.env_prefix || 'WEBPACKER_DEV_SERVER_'
+  const envPrefix = config.dev_server.env_prefix || 'WEBPACKER_DEV_SERVER'
 
   Object.keys(devServerConfig).forEach((key) => {
-    const envValue = fetch(`${envPrefix}${key.toUpperCase().replace(/_/g, '')}`)
+    const envValue = fetch(`${envPrefix}_${key.toUpperCase().replace(/_/g, '')}`)
     if (envValue !== undefined) devServerConfig[key] = envValue
   })
 }


### PR DESCRIPTION
Fix bug introduced in #1858.

Env prefix shouldn't contain the trailing underscore (that's the current behaviour in Ruby lib). 
