### PR TITLE
Use default setting in browserslistrc

### DIFF
--- a/lib/install/config/.browserslistrc
+++ b/lib/install/config/.browserslistrc
@@ -1,1 +1,1 @@
-> 1%
+defaults


### PR DESCRIPTION
Follow-up to #1878 

Current browserslist defaults are `> 0.5%, last 2 versions, Firefox ESR, not dead` (see https://github.com/browserslist/browserslist#full-list).

Reasons:
* (Keep in mind that an individual version of the browser must exceed the percentage. It is not the usage of the entire browser for all versions.)
* `> 1%` is extremely limiting, to an absurdity. On mobile, it lacks Samsung Browser, Firefox, Android Browser, and many others common in different countries like Baidu and QQ. On desktop it lacks Opera. For the browsers it does have, it typically only has one version, the very latest (e.g. it lacks relatively recent versions of Safari used on common iPhones).
* The browserslist defaults incorporate a number of intelligent decisions. It uses the more reasonable 0.5%, requires the latest two versions even if they do not meet the percentage, includes Firefox ESR, and specially excludes certain ancient, unsupported "dead" browsers like IE 10 and under.
* It's the default.

See https://browsersl.ist/?q=defaults and https://browsersl.ist/?q=>1%25 for a (regularly updated) list of the browsers returned by each query.