### PR TITLE
Upgrade the upgrade (instructions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,10 @@ yarn add webpack-dev-server@^3.1.14
 
 # Or to install a latest release (including pre-releases)
 yarn add @rails/webpacker@next
+
+# After a major-version upgrade (eg. webpacker 3 to 4)
+rm .babelrc
+bundle exec rails webpacker:install # or webpacker:install:react
 ```
 
 ### Yarn Integrity


### PR DESCRIPTION
After a major-version upgrade (eg. webpacker 3 to 4), I found it necessary to run the `webpacker:install` task, to update (replace) files such as `babel.config.js`

I barely know what I'm doing, so if there's a better way, please correct me.