### PR TITLE
Maintain paths when packing images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ environment.config.merge({ devtool: 'none' })
 module.exports = environment.toWebpackConfig()
 ```
 
+- Reintroduced `context` to the file loader. Reverting the simpler paths change
+
 
 ## [4.0.0.rc.7] - 2019-01-25
 

--- a/package/rules/file.js
+++ b/package/rules/file.js
@@ -1,4 +1,5 @@
-const { static_assets_extensions: fileExtensions } = require('../config')
+const { join } = require('path')
+const { source_path: sourcePath, static_assets_extensions: fileExtensions } = require('../config')
 
 module.exports = {
   test: new RegExp(`(${fileExtensions.join('|')})$`, 'i'),
@@ -6,7 +7,8 @@ module.exports = {
     {
       loader: 'file-loader',
       options: {
-        name: 'media/[name]-[hash:8].[ext]'
+        name: 'media/[path][name]-[hash].[ext]',
+        context: join(sourcePath)
       }
     }
   ]


### PR DESCRIPTION
This reverts #1914 which attempted to "simplify" the file paths but
introduced cases where multiple files could overwrite each other.

This is an alternate to #1950, reverting just the copying change but
maintaining `media` as a top level directory.

Fixes #1938
Closes #1950