### PR TITLE
Fix: compiling failure when rails server launch with -d (daemon)

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -60,7 +60,7 @@ class Webpacker::Compiler
     def run_webpack
       logger.info "Compiling…"
 
-      stdout, sterr , status = Open3.capture3(webpack_env, "#{RbConfig.ruby} ./bin/webpack")
+      stdout, sterr , status = Open3.capture3(webpack_env, "#{RbConfig.ruby} ./bin/webpack", chdir: File.expand_path(config.root_path))
 
       if status.success?
         logger.info "Compiled all packs in #{config.public_output_path}"


### PR DESCRIPTION
Hello,
I found a bug in webpacker v3.5.5:

It is failed compiling when rails server is lauched with `-d` option.
like:

```
[Webpacker] Compiling…
[Webpacker] Compilation failed:
/home/tak/.rbenv/versions/2.5.3/bin/ruby: No such file or directory -- ./bin/webpack (LoadError)
```

I think it is caused by current working directory differ between Rails server is daemon or not.

I found this issue is fixed on the master at https://github.com/rails/webpacker/commit/3d4b7b31b39b20a67aa574b62831786955b4f442#diff-d372bcc3fac8ad71a96a2cc49d03bfacR64,
but 3.5.x still has this issue.

I think this small patch is fixed this case, but I'm not sure to affect other case.

Thank you.
