### PR TITLE
Updated example of json loader usage

### DIFF
--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -69,12 +69,13 @@ yarn add json-loader
 // config/webpack/environment.js
 const { environment } = require('@rails/webpacker')
 
-environment.loaders.append('json', {
+const jsonLoader = {
   test: /\.json$/,
   use: 'json-loader'
-})
+}
 
-const jsonLoader = environment.loaders.get('json')
+// Insert json loader at the end of list
+environment.loaders.append('json', jsonLoader)
 
 // Insert json loader at the top of list
 environment.loaders.prepend('json', jsonLoader)

--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -74,6 +74,8 @@ environment.loaders.append('json', {
   use: 'json-loader'
 })
 
+const jsonLoader = environment.loaders.get('json')
+
 // Insert json loader at the top of list
 environment.loaders.prepend('json', jsonLoader)
 


### PR DESCRIPTION
Corrected wrong example of usage
Blind copying and pasting leads to `ReferenceError`