### PR TITLE
Finally fix CDN

### DIFF
--- a/package/config.js
+++ b/package/config.js
@@ -40,5 +40,6 @@ const getPublicPath = () => {
 }
 
 config.publicPath = getPublicPath()
+config.publicPathWithoutCDN = `/${config.public_output_path}/`
 
 module.exports = config

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -46,7 +46,7 @@ const getPluginList = () => {
       integrity: false,
       entrypoints: true,
       writeToDisk: true,
-      publicPath: true
+      publicPath: config.publicPathWithoutCDN
     })
   )
   return result


### PR DESCRIPTION
Fixes https://github.com/rails/webpacker/issues/1845

Fixes the final missing piece, manifest doesn't include CDN URI, YAY!

Views and Inside JS code:

<img width="904" alt="screenshot 2019-03-03 at 18 52 17" src="https://user-images.githubusercontent.com/771039/53699998-e2008200-3de5-11e9-92b9-403e0bfae0fd.png">

Manifest:

<img width="784" alt="screenshot 2019-03-03 at 18 52 35" src="https://user-images.githubusercontent.com/771039/53699999-e2008200-3de5-11e9-8f4e-5044d009a0e1.png">
