### PR TITLE
Remove needless require from `splitChunks` example [ci skip]

### DIFF
--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -269,7 +269,6 @@ For the full configuration options of SplitChunks, see the [Webpack documentatio
 
 ```js
 // config/webpack/environment.js
-const WebpackAssetsManifest = require('webpack-assets-manifest');
 
 // Enable the default config
 environment.splitChunks()


### PR DESCRIPTION
This require added in f46bd639220948a1c0dccf14dc86e243e758cc49 but didn't use since c4cf2e99c2ae4dffdd2942c1d2282936b8aaf36e.