### PR TITLE
Remove superflous newline

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -66,7 +66,7 @@ class Webpacker::Compiler
 
       if status.success?
         logger.info "Compiled all packs in #{config.public_output_path}"
-        logger.error "#{stderr}\n" unless stderr.empty?
+        logger.error "#{stderr}" unless stderr.empty?
       else
         logger.error "Compilation failed:\n#{stderr}"
       end


### PR DESCRIPTION
Refer https://github.com/rails/webpacker/pull/1989#discussion_r264003044.

Change to generate an error string:
```diff
diff --git a/bin/webpack b/bin/webpack
index 008ecb22f7..25e9fad946 100755
--- a/bin/webpack
+++ b/bin/webpack
@@ -13,6 +13,8 @@ require "bundler/setup"
 require "webpacker"
 require "webpacker/webpack_runner"
 
+$stderr.puts "ERRORERRORERROR"
+
 APP_ROOT = File.expand_path("..", __dir__)
 Dir.chdir(APP_ROOT) do
   Webpacker::WebpackRunner.run(ARGV)

```

Before this change:
```
vagrant@rails-dev-box:/vagrant/rails/my-test-app$ bundle exec rails webpacker:compile
Compiling…
Compiled all packs in /vagrant/rails/my-test-app/public/packs
ERRORERRORERROR


vagrant@rails-dev-box:/vagrant/rails/my-test-app$
```

After this change:
```
vagrant@rails-dev-box:/vagrant/rails/my-test-app$ bundle exec rails webpacker:compile
Compiling…
Compiled all packs in /vagrant/rails/my-test-app/public/packs
ERRORERRORERROR

vagrant@rails-dev-box:/vagrant/rails/my-test-app$
```

cc @gauravtiwari @dbalatero