### PR TITLE
Fix inconsistent hash generation in environments with randomized build paths

### DIFF
--- a/package/utils/get_style_rule.js
+++ b/package/utils/get_style_rule.js
@@ -15,11 +15,14 @@ const styleLoader = {
 }
 
 const getStyleRule = (test, modules = false, preprocessors = []) => {
+  const options = modules ? { include: /\.module\.[a-z]+$/ } : { exclude: /\.module\.[a-z]+$/ }
+  const sourceMap = options.devtool === 'none'
+
   const use = [
     {
       loader: 'css-loader',
       options: {
-        sourceMap: true,
+        sourceMap,
         importLoaders: 2,
         localIdentName: '[name]__[local]___[hash:base64:5]',
         modules
@@ -34,8 +37,6 @@ const getStyleRule = (test, modules = false, preprocessors = []) => {
     },
     ...preprocessors
   ]
-
-  const options = modules ? { include: /\.module\.[a-z]+$/ } : { exclude: /\.module\.[a-z]+$/ }
 
   if (config.extract_css) {
     use.unshift(MiniCssExtractPlugin.loader)


### PR DESCRIPTION
Fixes https://github.com/rails/webpacker/issues/2003

Use the `devtool` option to conditionally disable sourcemap generation in css-loader. 

The `devtool` setting was used because it is the recommended way to disable sourcemaps from the v4 upgrade docs: https://github.com/rails/webpacker/blob/master/docs/v4-upgrade.md#source-maps-enabled-by-default