### PR TITLE
Pass the elm file to avoid `elm make` getting errors

### DIFF
--- a/lib/install/elm.rb
+++ b/lib/install/elm.rb
@@ -24,7 +24,7 @@ say "Installing all Elm dependencies"
 run "yarn add elm elm-webpack-loader"
 run "yarn add --dev elm-hot-webpack-loader"
 run "yarn run elm init"
-run "yarn run elm make"
+run "yarn run elm make #{Webpacker.config.source_path}/Main.elm"
 
 say "Updating webpack paths to include .elm file extension"
 insert_into_file Webpacker.config.config_path, "- .elm\n".indent(4), after: /\s+extensions:\n/


### PR DESCRIPTION
Hi, there.

I've been getting an error like below every time when I create a Rails app that uses Webpacker and Elm. And I'm trying to fix that. I think why the installer runs `elm make` here is to download its dependencies. So I passed a file for the command instead of just removing the line.

```
root@af38aca366c5:/hi/example# bundle exec rails webpacker:install:elm
(snip)
yarn run v1.13.0
$ /hi/example/node_modules/.bin/elm make
Starting downloads...

  ● elm/browser 1.0.1
  ● elm/virtual-dom 1.0.2
  ● elm/url 1.0.0
  ● elm/time 1.0.0
  ● elm/html 1.0.0
  ● elm/json 1.1.3
  ● elm/core 1.0.2

Dependencies ready!
-- NO INPUT --------------------------------------------------------------------

What should I make though? I need more information, like:

    elm make src/Main.elm
    elm make src/This.elm src/That.elm

However many files you give, I will create one JS file out of them.

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
(snip)
Updating .gitignore to include elm-stuff folder
      insert  .gitignore
Webpacker now supports Elm 🎉
```
