### PR TITLE
Remove ^ from webpack-dev-server@^3.1.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ You can run following commands to upgrade Webpacker to the latest stable version
 bundle update webpacker
 rails webpacker:binstubs
 yarn upgrade @rails/webpacker --latest
-yarn add webpack-dev-server@^3.1.14
+yarn add webpack-dev-server@3.1.14
 
 # Or to install a latest release (including pre-releases)
 yarn add @rails/webpacker@next


### PR DESCRIPTION
When I run `yarn add webpack-dev-server@^3.1.14`, I've got no matches found: webpack-dev-server@^3.1.14.

It works great by removing the ^