### PR TITLE
Add support for debugging Webpack config

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,14 @@
 # Troubleshooting
 
+## Debugging your webpack config
+
+1. Read the error message carefully. The error message will tell you the precise key value
+   that is not matching what Webpack expects.
+2. Put a `debugger` statement in your Webpack configuration and run `bin/webpack --debug`. 
+   If you have a node debugger installed, you'll see the Chrome debugger for your webpack
+   config. For example, install the Chrome extension [NiM](https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj) and 
+   set the option for the dev tools to open automatically. For more details on debugging,
+   see the official [Webpack docs on debugging](https://webpack.js.org/contribute/debugging/#devtools)
 
 ## ENOENT: no such file or directory - node-sass
 

--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -51,6 +51,12 @@ module Webpacker
         else
           ["yarn", "webpack-dev-server"]
         end
+
+        if ARGV.include?("--debug")
+          cmd = [ "node", "--inspect-brk"] + cmd
+          ARGV.delete("--debug")
+        end
+
         cmd += ["--config", @webpack_config]
         cmd += ["--progress", "--color"] if @pretty
 

--- a/lib/webpacker/webpack_runner.rb
+++ b/lib/webpacker/webpack_runner.rb
@@ -11,6 +11,12 @@ module Webpacker
       else
         ["yarn", "webpack"]
       end
+
+      if ARGV.include?("--debug")
+        cmd = [ "node", "--inspect-brk"] + cmd
+        ARGV.delete("--debug")
+      end
+
       cmd += ["--config", @webpack_config] + @argv
 
       Dir.chdir(@app_path) do


### PR DESCRIPTION
This change adds a --debug option to bin/webpack

Put a `debugger` statement in your Webpack configuration and run `bin/webpack --debug`. 
   If you have a node debugger installed, you'll see the Chrome debugger for your webpack
   config. For example, install the Chrome extension [NiM](https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj) and 
   set the option for the dev tools to open automatically. For more details on debugging,
   see the official [Webpack docs on debugging](https://webpack.js.org/contribute/debugging/#devtools).

![2019-03-17_21-24-23](https://user-images.githubusercontent.com/1118459/54513367-5285c380-48fb-11e9-89f5-b36a6e0a175c.png)

![2019-03-17_21-25-35](https://user-images.githubusercontent.com/1118459/54513390-5f0a1c00-48fb-11e9-8d83-ab5077a294c0.png)

