### PR TITLE
Fix elm source directory

### DIFF
--- a/lib/install/elm.rb
+++ b/lib/install/elm.rb
@@ -30,7 +30,7 @@ say "Updating webpack paths to include .elm file extension"
 insert_into_file Webpacker.config.config_path, "- .elm\n".indent(4), after: /\s+extensions:\n/
 
 say "Updating Elm source location"
-gsub_file "elm.json", /\"\src\"\n/,
+gsub_file "elm.json", /\"src\"\n/,
   %("#{Webpacker.config.source_path.relative_path_from(Rails.root)}"\n)
 
 say "Updating .gitignore to include elm-stuff folder"


### PR DESCRIPTION
Thanks for the awesome project!

The Elm command works very well, but when I deployed it I got this error:
```json
ERROR in ./app/javascript/Main.elm
Module build failed (from ./node_modules/elm-webpack-loader/index.js):
Error: Compiler process exited with error Compilation failed
-- BAD JSON ----------------------------------------------------------- elm.json

The "source-directories" in your elm.json lists the following directory:

    src

I cannot find that directory though! Is it missing? Is there a typo?


    at ChildProcess.<anonymous> (/tmp/build_715c2058eb6a018a8ea92d5be3d114bf/node_modules/node-elm-compiler/dist/index.js:131:35)
    at ChildProcess.emit (events.js:189:13)
    at maybeClose (internal/child_process.js:970:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)
 @ ./app/javascript/packs/hello_elm.js 4:0-25 4:156-159
```

The fix is simple, though: the installer was supposed to replace `"src"` by `"app/javascript"`, but there was a typo. This PR fixes it.