### PR TITLE
Allow NODE_ENV to be overridden in webpacker:compile task

### DIFF
--- a/lib/tasks/webpacker/compile.rake
+++ b/lib/tasks/webpacker/compile.rake
@@ -26,7 +26,18 @@ end
 namespace :webpacker do
   desc "Compile JavaScript packs using webpack for production with digests"
   task compile: ["webpacker:verify_install", :environment] do
-    Webpacker.with_node_env("production") do
+    node_env = "production"
+
+    if ENV.has_key?("NODE_ENV")
+      node_env = ENV["NODE_ENV"]
+
+      if node_env != "production"
+        $stdout.puts "Using NODE_ENV=#{ENV["NODE_ENV"]} from local "\
+          "environment instead of default NODE_ENV=production"
+      end
+    end
+
+    Webpacker.with_node_env(node_env) do
       ensure_log_goes_to_stdout do
         if Webpacker.compile
           # Successful compilation!


### PR DESCRIPTION
Closes #1558

Since users might have a default `NODE_ENV=development` set in their `.envrc` or `.env` file, I added a warning message letting them know that they were choosing a different `NODE_ENV` than the default `production` value. I think this will help avoid opaque compilation bugs.