### PR TITLE
Fix typo in webpack docs

### DIFF
--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -146,7 +146,7 @@ environment.loaders.insert('svg', {
       }
     }
   ])
-}, { after: 'file' })
+}, { before: 'file' })
 
 const fileLoader = environment.loaders.get('file')
 fileLoader.exclude = /\.(svg)$/i


### PR DESCRIPTION
### Why this was needed
The comment suggests that the loader should be appended before the file loader. In the example code `after` is used.

### How I fixed it
Fixed the typo