### PR TITLE
Fix typo in docs/webpack.md

### DIFF
--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -146,7 +146,7 @@ environment.loaders.insert('svg', {
       }
     }
   ])
-}, { after: 'file' })
+}, { before: 'file' })
 
 const fileLoader = environment.loaders.get('file')
 fileLoader.exclude = /\.(svg)$/i


### PR DESCRIPTION
### Why this was needed
Documentations says `To use react svg loader, you should append svg loader before file loader` but in the code example `{ after: 'file' }` is used.

### How I fixed it
swapped `after` with `before`