### PR TITLE
CI: Update matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
-sudo: false
 language: ruby
 before_install:
   - gem update --system
 rvm:
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
   - ruby-head
 gemfile:
   - gemfiles/Gemfile-rails.4.2.x
@@ -37,9 +36,9 @@ matrix:
   exclude:
     - rvm: 2.3.8
       gemfile: gemfiles/Gemfile-rails-edge
-    - rvm: 2.4.5
+    - rvm: 2.4.6
       gemfile: gemfiles/Gemfile-rails-edge
-    - rvm: 2.5.3
+    - rvm: 2.5.5
       gemfile: gemfiles/Gemfile-rails-edge
     - rvm: ruby-head
       gemfile: gemfiles/Gemfile-rails.4.2.x


### PR DESCRIPTION
This PR **updates the CI matrix** to the latest generally available Ruby versions.

Also:

  - Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration