### PR TITLE
stylesheet_pack_tag: raise when file not found in development environment

### DIFF
--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -101,8 +101,9 @@ module Webpacker::Helper
   #   <%= stylesheet_pack_tag 'calendar', 'data-turbolinks-track': 'reload' %> # =>
   #   <link rel="stylesheet" media="screen" href="/packs/calendar-1016838bab065ae1e122.css" data-turbolinks-track="reload" />
   def stylesheet_pack_tag(*names, **options)
+    sources = sources_from_manifest_entries(names, type: :stylesheet)
     if current_webpacker_instance.config.extract_css?
-      stylesheet_link_tag(*sources_from_manifest_entries(names, type: :stylesheet), **options)
+      stylesheet_link_tag(*sources, **options)
     end
   end
 


### PR DESCRIPTION
**Currently:**
In development environment, `stylesheet_pack_tag` does not raise an error when a stylesheet is not present.

**New behavior:**
When `stylesheet_pack_tag` is called, lookup for stylesheets under all environments in order to raise an error when one is missing.
This neither changes the input nor the output of `stylesheet_pack_tag`.