### PR TITLE
Allow compile option to be settable

### DIFF
--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -15,6 +15,10 @@ class Webpacker::Configuration
     fetch(:dev_server)
   end
 
+  def compile=(value)
+    data[:compile] = value
+  end
+
   def compile?
     fetch(:compile)
   end


### PR DESCRIPTION
Similar to `check_yarn_integrity=`, the [changes](https://github.com/rails/webpacker/pull/1359) to `RAILS_ENV`/`NODE_ENV` setting has made it basically impossible to mix pre-compilation with on-the-fly compilation for a given RAILS_ENV.

In my setup, I precompile assets in CI, run them through tests (RAILS_ENV=test), and deploy them to production (RAILS_ENV=production) all based on the same precompiled assets.

The two options I have are:
1. Create a separate `RAILS_ENV=test_ci` and change those settings in `webpacker.yml` to conform with that. Maintaining multiple RAILS_ENV's is confusing and not worth the effort in my opinion.
2. Require _local_ `RAILS_ENV=test` to use pre-compilation. That is not a good development experience.

I would use this setter to basically conditionally turn on the `compile` flag based on whether the `ENV['CI']` flag was set (very common in pretty much every CI provider). I used to hack around this pre-3.5.x by just changing the `NODE_ENV` on the fly. This no longer works.

As a maintainer @gauravtiwari I can understand why you might not be interested in allowing _another_ form of configuration, but I think maybe leaving it undocumented could be one way to provide `sharp tools`. Alternatively, my `sharp tools` can be directly altering the `@data` hash of Webpacker configuration. Maybe that is sufficient, but curious to hear your thoughts.

P.S. The other hack I'm doing is sym-linking `packs` to `packs-test` in CI, so that prod/test seamlessly use the same pre-compiled `packs` location