### PR TITLE
Initialize Vue instance with $mount()

### DIFF
--- a/lib/install/examples/vue/hello_vue.js
+++ b/lib/install/examples/vue/hello_vue.js
@@ -9,11 +9,10 @@ import Vue from 'vue'
 import App from '../app.vue'
 
 document.addEventListener('DOMContentLoaded', () => {
-  const el = document.body.appendChild(document.createElement('hello'))
   const app = new Vue({
-    el,
     render: h => h(App)
-  })
+  }).$mount()
+  document.body.appendChild(app.$el)
 
   console.log(app)
 })


### PR DESCRIPTION
Vue CLI now uses `$mount()` to initialize a Vue app, so probably best to go with the most up-to-date convention. You also don't need to create a dummy element to add the app to the DOM.