### PR TITLE
'node_modules' compilation should be configurable through webpacker.yml

### DIFF
--- a/docs/v4-upgrade.md
+++ b/docs/v4-upgrade.md
@@ -73,12 +73,14 @@ One change to take into consideration, is that Webpacker 4 transpiles the
 `node_modules` folder with the `babel-loader`. This folder used to be ignored by
 Webpacker 3. The new behavior helps in case some library contains ES6 code, but in
 some cases it can lead to issues. To avoid running `babel-loader` in the
-`node_modules` folder, replicating the same behavior as Webpacker 3, the
-following code can be added to `config/webpack/environment.js`:
+`node_modules` folder, replicating the same behavior as Webpacker 3, set
+`compile_dependencies` to `false`
 
-```javascript
-environment.loaders.delete('nodeModules')
-```
+```yml
+  default: &default
+     # other stuff
+     compile_dependencies: false
+  ```
 
 Alternatively, in order to skip only a specific library in the `node_modules`
 folder, this code can be added:

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -19,6 +19,9 @@ default: &default
   # Extract and emit a css file
   extract_css: false
 
+  # Compile node_modules in addition to source files
+  compile_dependencies: true
+
   static_assets_extensions:
     - .jpg
     - .jpeg

--- a/package/environments/__tests__/base.js
+++ b/package/environments/__tests__/base.js
@@ -44,6 +44,17 @@ describe('Environment', () => {
       expect(configRules.length).toEqual(8)
     })
 
+    test('should not include node_modules rule if compile_dependencies is false', () => {
+      require('../../config').compile_dependencies = false
+      environment = new Environment()
+
+      const config = environment.toWebpackConfig()
+      const defaultRules = Object.keys(rules)
+      const configRules = config.module.rules
+
+      expect(configRules.length).toEqual(defaultRules.length)
+    })
+
     test('should return default plugins', () => {
       const config = environment.toWebpackConfig()
       expect(config.plugins.length).toEqual(4)

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -22,7 +22,9 @@ const config = require('../config')
 
 const getLoaderList = () => {
   const result = new ConfigList()
-  Object.keys(rules).forEach(key => result.append(key, rules[key]))
+  Object.keys(rules)
+    .filter(rule => rule !== 'nodeModules' || (rule === 'nodeModules' && config.compile_dependencies))
+    .forEach(key => result.append(key, rules[key]))
   return result
 }
 

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -22,9 +22,10 @@ const config = require('../config')
 
 const getLoaderList = () => {
   const result = new ConfigList()
-  Object.keys(rules)
-    .filter(rule => rule !== 'nodeModules' || (rule === 'nodeModules' && config.compile_dependencies))
-    .forEach(key => result.append(key, rules[key]))
+  const ruleKeys = config.compile_dependencies
+    ? Object.keys(rules)
+    : Object.keys(rules).filter(rule => rule !== 'nodeModules')
+  ruleKeys.forEach(key => result.append(key, rules[key]))
   return result
 }
 


### PR DESCRIPTION
1. The `nodeModules` rule should be configurable, not buried in a v4 upgrade doc
1. I think the default of `true` is overly defensive/paranoid, and will likely cause compilation speeds to go _way_ down.
    - in future versions I think we should reverse this default