### PR TITLE
Fix devtool example to 'disable sourcemaps'

### DIFF
--- a/docs/v4-upgrade.md
+++ b/docs/v4-upgrade.md
@@ -104,7 +104,7 @@ If you want to keep the old behavior source maps can be disabled in any environm
 // config/webpack/production.js
 
 const environment = require('./environment')
-environment.config.merge({ devtool: 'none' })
+environment.config.merge({ devtool: false })
 
 module.exports = environment.toWebpackConfig()
 ```


### PR DESCRIPTION
According to https://webpack.js.org/configuration/devtool#devtool the correct way to disable sourcemaps is `false`, not `'none'`.