### PR TITLE
Allows setting of parallelization options

### DIFF
--- a/package/environments/production.js
+++ b/package/environments/production.js
@@ -36,7 +36,7 @@ module.exports = class extends Base {
       optimization: {
         minimizer: [
           new TerserPlugin({
-            parallel: true,
+            parallel: Number.parseInt(process.env.WEBPACKER_PARALLEL) || true,
             cache: true,
             sourceMap: true,
             terserOptions: {

--- a/package/environments/production.js
+++ b/package/environments/production.js
@@ -36,7 +36,7 @@ module.exports = class extends Base {
       optimization: {
         minimizer: [
           new TerserPlugin({
-            parallel: Number.parseInt(process.env.WEBPACKER_PARALLEL) || true,
+            parallel: Number.parseInt(process.env.WEBPACKER_PARALLEL, 10) || true,
             cache: true,
             sourceMap: true,
             terserOptions: {


### PR DESCRIPTION
If you set the parallel option of TersorPlugin to true, resource usage issues may occur.
This problem is noticeable when used on containers, and will fail to fork when the number of CPU cores on hardware is high and the memory usage allowed for the container is low.

This is due to the fact that the number of CPU cores count - 1 process is generated when the parallel option of TersorPlugin is true.

This patch makes it possible to limit the number of parallelizations in the following way.

How to write to `config/initializers/webpacker.rb`
```
Webpacker::Compiler.env['WEBPACKER_PARALLEL'] = '2'
```

or how to write it before doing `require('@rails/webpacker')` in `config/webpack/production.js`
```
process.env.WEBPACKER_PARALLEL = '2'

const environment = require('./environment')
```

I'm sorry if you find something strange because I use Google Translate.