### PR TITLE
Use [contenhash] instead of [chunkhash] for JavaScript

### DIFF
--- a/package/environments/__tests__/base.js
+++ b/package/environments/__tests__/base.js
@@ -31,8 +31,8 @@ describe('Environment', () => {
 
     test('should return output', () => {
       const config = environment.toWebpackConfig()
-      expect(config.output.filename).toEqual('js/[name]-[chunkhash].js')
-      expect(config.output.chunkFilename).toEqual('js/[name]-[chunkhash].chunk.js')
+      expect(config.output.filename).toEqual('js/[name]-[contenthash].js')
+      expect(config.output.chunkFilename).toEqual('js/[name]-[contenthash].chunk.js')
     })
 
     test('should return default loader rules for each file in config/loaders', () => {

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -83,8 +83,8 @@ const getModulePaths = () => {
 const getBaseConfig = () => new ConfigObject({
   mode: 'production',
   output: {
-    filename: 'js/[name]-[chunkhash].js',
-    chunkFilename: 'js/[name]-[chunkhash].chunk.js',
+    filename: 'js/[name]-[contenthash].js',
+    chunkFilename: 'js/[name]-[contenthash].chunk.js',
     hotUpdateChunkFilename: 'js/[id]-[hash].hot-update.js',
     path: config.outputPath,
     publicPath: config.publicPath


### PR DESCRIPTION
Hi!

After upgrading webpacker from `3.5.5` to `4.0.2`, I experienced the same issue as below:

[Inconsistent file names when building on multiple servers · Issue \#1215 · rails/webpacker](https://github.com/rails/webpacker/issues/1215)

I investigated the cause and found the following webpack issue:

[Webpack 4 chunkhash/contenthash can vary between builds · Issue \#7179 · webpack/webpack](https://github.com/webpack/webpack/issues/7179)

> TLDR: Use [contenthash] instead of [chunkhash] to ensure that every asset (output file) has a stable hash based on it's contents > (only).
>
> [chunkhash] isn't very 'stable' as it can change when e.g a module of a chunk is moved for some reason etc etc (It's always hard to tell why and will always be based on how [chunkhash] works (in terms of browser caching)). For predictable long term (browser) caching the contents of the asset are the only reliable hashing source since browsers cache files based on Map { url => content } relations without any knowledge of webpack chunks or the like...

As mentioned above, [chunkhash] seems occasionaly to be unstable.
Therefore, to ensure that every built files have consistent hash names based on it's contents,
this PR replace [chunkhash] with [contenthash].