### PR TITLE
Fix build badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Webpacker
 
-![travis-ci status](https://api.travis-ci.org/rails/webpacker.svg?branch=master)
+[![Build Status](https://travis-ci.org/rails/webpacker.svg?branch=master)](https://travis-ci.org/rails/webpacker)
 [![node.js](https://img.shields.io/badge/node-%3E%3D%206.14.0-brightgreen.svg)](https://nodejs.org/en/)
 [![Gem](https://img.shields.io/gem/v/webpacker.svg)](https://github.com/rails/webpacker)
 


### PR DESCRIPTION
Previously this linked to the badge image itself instead of Travis.