### PR TITLE
Fix Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
 
 install:
   - bundle install
-  - nvm install node
+  - nvm install 10
   - node -v
   - npm i -g yarn
   - yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ script:
   - bundle exec rake test
 matrix:
   allow_failures:
-  - gemfile: gemfiles/Gemfile-rails-edge
+    - gemfile: gemfiles/Gemfile-rails-edge
+    - rvm: ruby-head
   exclude:
     - rvm: 2.3.8
       gemfile: gemfiles/Gemfile-rails-edge

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gemspec
 
 gem "rails"
 gem "rake", ">= 11.1"
-gem "rubocop", git: "https://github.com/rubocop-hq/rubocop.git", require: false
 gem "rack-proxy", require: false
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,3 @@
-GIT
-  remote: https://github.com/rubocop-hq/rubocop.git
-  revision: dc69686abf10d9f38ed3a39037fab76ae8874138
-  specs:
-    rubocop (0.65.0)
-      jaro_winkler (~> 1.5.1)
-      parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
-      psych (>= 3.1.0)
-      rainbow (>= 2.2.2, < 4.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.4.0)
-
 PATH
   remote: .
   specs:
@@ -91,11 +77,9 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
-    parallel (1.14.0)
-    parser (2.6.0.0)
+    parallel (1.17.0)
+    parser (2.6.3.0)
       ast (~> 2.4.0)
-    powerpack (0.1.2)
-    psych (3.1.0)
     rack (2.0.6)
     rack-proxy (0.6.5)
       rack
@@ -127,6 +111,13 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (12.3.2)
+    rubocop (0.68.1)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.6)
     ruby-progressbar (1.10.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -139,7 +130,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unicode-display_width (1.4.1)
+    unicode-display_width (1.5.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -154,7 +145,7 @@ DEPENDENCIES
   rack-proxy
   rails
   rake (>= 11.1)
-  rubocop!
+  rubocop (< 0.69)
   webpacker!
 
 BUNDLED WITH

--- a/gemfiles/Gemfile-rails-edge
+++ b/gemfiles/Gemfile-rails-edge
@@ -7,7 +7,6 @@ gem "webpacker", path: ".."
 gem "rails", github: "rails/rails"
 gem "arel", github: "rails/arel"
 gem "rake", ">= 11.1"
-gem "rubocop", git: "https://github.com/rubocop-hq/rubocop.git", require: false
 gem "rack-proxy", require: false
 gem "minitest", "~> 5.0"
 gem "byebug"

--- a/gemfiles/Gemfile-rails.4.2.x
+++ b/gemfiles/Gemfile-rails.4.2.x
@@ -1,10 +1,9 @@
 source "https://rubygems.org"
 
-gem "webpacker", path: ".."
+gemspec path: "../"
 
 gem "rails", "~> 4.2.0"
 gem "rake", ">= 11.1"
-gem "rubocop", git: "https://github.com/rubocop-hq/rubocop.git", require: false
 gem "rack-proxy", require: false
 gem "minitest", "~> 5.0"
 gem "byebug"

--- a/gemfiles/Gemfile-rails.5.0.x
+++ b/gemfiles/Gemfile-rails.5.0.x
@@ -1,10 +1,9 @@
 source "https://rubygems.org"
 
-gem "webpacker", path: ".."
+gemspec path: "../"
 
 gem "rails", "~> 5.0.0"
 gem "rake", ">= 11.1"
-gem "rubocop", git: "https://github.com/rubocop-hq/rubocop.git", require: false
 gem "rack-proxy", require: false
 gem "minitest", "~> 5.0"
 gem "byebug"

--- a/gemfiles/Gemfile-rails.5.1.x
+++ b/gemfiles/Gemfile-rails.5.1.x
@@ -1,10 +1,9 @@
 source "https://rubygems.org"
 
-gem "webpacker", path: ".."
+gemspec path: "../"
 
 gem "rails", "~> 5.1.0"
 gem "rake", ">= 11.1"
-gem "rubocop", git: "https://github.com/rubocop-hq/rubocop.git", require: false
 gem "rack-proxy", require: false
 gem "minitest", "~> 5.0"
 gem "byebug"

--- a/gemfiles/Gemfile-rails.5.2.x
+++ b/gemfiles/Gemfile-rails.5.2.x
@@ -1,10 +1,9 @@
 source "https://rubygems.org"
 
-gem "webpacker", path: ".."
+gemspec path: "../"
 
 gem "rails", "~> 5.2.0"
 gem "rake", ">= 11.1"
-gem "rubocop", git: "https://github.com/rubocop-hq/rubocop.git", require: false
 gem "rack-proxy", require: false
 gem "minitest", "~> 5.0"
 gem "byebug"

--- a/webpacker.gemspec
+++ b/webpacker.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rack-proxy",    ">= 0.6.1"
 
   s.add_development_dependency "bundler", "~> 1.12"
+  s.add_development_dependency "rubocop", "< 0.69"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")


### PR DESCRIPTION
# tl;dr

This PR is only concerned about getting green builds, not fixing the underlying
issues that caused it to go red in the first place. Proposed solutions are being
described below and are up for discussion.

### node version

`nvm install node` will install the latest node version, which is 12 as
of writing. Because of a problem in the resolved node-sass version this
makes the builds fail.

To get green builds until a proper fix for node 12 is introduced we'll
install node 10, which is a LTS release, while 11 will be EOL in June
2019.

@rokumatsumoto is maybe working on a fix, but I think green builds,
especially for third party PRs are an important intermediate step.

https://github.com/rails/webpacker/issues/2077
https://github.com/sass/node-sass/pull/2633
https://github.com/nodejs/nan/issues/849
https://github.com/nodejs/Release

### RuboCop version

RuboCop 0.69.0 dropped support for Ruby 2.2, making RuboCop fail when it
was installed since it pointed to the git repo instead of a specific
version.

Is there any reason why dev dependencies are declared in each and every Gemfile
instead of as a dev dependency inside the `.gemspec` file? I moved RuboCop to
the `.gemspec` to avoid duplication.

https://github.com/rubocop-hq/rubocop/blob/v0.69.0/CHANGELOG.md#changes

### Testing with `ruby-head`

These might – currently – not be related to Ruby itself, but to the fact that
[bundler 2.1.0.pre.1 was installed](https://travis-ci.org/rails/webpacker/jobs/535281447#L527-L537), which is as of writing not supported by 
webpacker ([`~> 1.12` is used](https://github.com/rails/webpacker/blob/v4.0.2/webpacker.gemspec#L24)).

But this is to get the CI builds green again.

### Proposed solutions going forward

#### Use `.gemspec` file more

I don't know if there's a specific reason to have so many development
dependencies inside Gemfiles instead of the `.gemspec` file, but I think it
would make sense to have more of them in `.gemspec` to avoid duplication.

#### Relax bundler version constraint

Currently bundler is locked to a version `< 2`, see [here](https://github.com/rails/webpacker/blob/v4.0.2/webpacker.gemspec#L24). I think it would make 
sense to allow bundler 2 as well since it's the current stable release. There
might be problems with CI, but it can be dealt with, especially once Rails 6 is
released, dropping Rails 4.2 support might make sense for webpacker as well. And
Rails 4.2 is the only Rails release explicitly [wanting bundler 1.x](https://github.com/rails/rails/blob/4-2-stable/rails.gemspec#L30).

#### Node.js versions

I think it could make sense to drop Node.js 6 support since it will be EOL very
soon (probably around the time Rails 6 is released, so it would make sense to
have a major release of webpacker with a little cleanup.

That being said, we could consider testing with all supported Node.js versions,
as we've seen always using the latest version might lead to an unstable CI
system. It would probably make test runs much longer if we test all LTS
versions, but it's something to consider. At least testing with a specific LTS
release and the latest version (think `ruby-head`).

#### Dropping Ruby 2.2 support

I'm not sure if this is an options since Rails 5 supports Ruby 2.2.2 and higher,
but since the ecosystem (see RuboCop in this PR) is moving forward, it might
make sense.

Note that testing with Ruby 2.2 was [removed over a year ago](https://github.com/rails/webpacker/pull/1393).