### PR TITLE
Add gemfiles .lock files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ yarn-debug.log*
 yarn-error.log*
 .yarn-integrity
 /log
+gemfiles/*.lock


### PR DESCRIPTION
When testing with specific Gemfiles .lock files are being created within
the gemfiles/ directory which are not committed. This change makes it
easier to deal with them in version control.