### PR TITLE
Use gemspec in rails-edge Gemfile

### DIFF
--- a/gemfiles/Gemfile-rails-edge
+++ b/gemfiles/Gemfile-rails-edge
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-gem "webpacker", path: ".."
+gemspec path: "../"
 
 gem "rails", github: "rails/rails"
 gem "arel", github: "rails/arel"


### PR DESCRIPTION
This should make rubocop be installed and the Travis build for
rails-edge not fail on a missing rubocop executable.

I missed this in https://github.com/rails/webpacker/pull/2098/commits/5a6088d95d9a38c85000ebd80d9ea67dfc052ff5