### PR TITLE
Update `gen-typings` and `watch-typings` scripts

### DIFF
--- a/docs/css.md
+++ b/docs/css.md
@@ -106,8 +106,8 @@ Then by adding these lines to your `package.json`:
 
 ```
 "scripts": {
-  "gen-typings": "yarn run tsm app/javascript/**/*.sass",
-  "watch-typings": "yarn run tsm app/javascript/**/*.sass -w"
+  "gen-typings": "yarn run tsm \"app/javascript/**/*.sass\"",
+  "watch-typings": "yarn run tsm \"app/javascript/**/*.sass\" -w"
 },
 ```
 


### PR DESCRIPTION
I get the following error when running these scripts.

```
Only 1 file found for app/javascript/components/Homepage.module.sass. If using a glob pattern (eg: dir/**/*.scss) make sure to wrap in quotes (eg: "dir/**/*.scss").
```

Wrapping in quotes fixed the issue for me.