### PR TITLE
Add changelog entry with @babel/polyfill upgrade instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@
 
 Please see the diff
 
+### Breaking changes
+
+ - [`@babel/polyfill`](https://babeljs.io/docs/en/next/babel-polyfill.html) [doesn't make it possible to provide a smooth migration path from `core-js@2` to `core-js@3`](https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md#babelpolyfill): for this reason, it was decided to deprecate `@babel/polyfill` in favor of separate inclusion of required parts of `core-js` and `regenerator-runtime`. [#2031](https://github.com/rails/webpacker/pull/2031)
+
+In each of your `/packs/*.js` files, change this:
+```js
+import "@babel/polyfill";
+```
+to this:
+```js
+import "core-js/stable";
+import "regenerator-runtime/runtime";
+```
+
+Don't forget install those dependencies directly!
+
+```sh
+yarn add --save core-js regenerator-runtime
+```
+
 ## [4.0.2] - 2019-03-06
 
 - Bump the version on npm


### PR DESCRIPTION
Taking @connorshea's suggestion from https://github.com/rails/webpacker/pull/2031#issuecomment-483065730 to warn users who were using `@babel/polyfill`. With https://github.com/rails/webpacker/pull/2031 merged, users who upgrade will need to remove `import '@babel/polyfill'` from their pack files and add the replacements to those files and their `package.json`. 