### PR TITLE
Move bundle arguments to bundle install command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-bundler_args: --jobs 3 --retry 3
 dist: xenial
 before_install:
   - gem install rubygems-update && update_rubygems
@@ -28,7 +27,7 @@ cache:
   yarn: true
 
 install:
-  - bundle install
+  - bundle install --jobs 3 --retry 3
   - nvm install 10
   - node -v
   - npm i -g yarn


### PR DESCRIPTION
When customizing the installation phase, the default `bundle install --jobs 3 --retry 3` command is overwritten, so supplying the `bundle_args` doesn't actually do anything. Moving them to our customized installation phase makes it work as intended.

https://travis-ci.org/rails/webpacker/jobs/538471273#L243
https://docs.travis-ci.com/user/job-lifecycle/#customizing-the-installation-phase