### PR TITLE
Record the compilation digest even on webpack error

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -19,7 +19,12 @@ class Webpacker::Compiler
   def compile
     if stale?
       run_webpack.tap do |success|
-        record_compilation_digest if success
+        # We used to only record the digest on success
+        # However, the output file is still written on error, (at least with ts-loader), meaning that the
+        # digest should still be updated. If it's not, you can end up in a situation where a recompile doesn't
+        # take place when it should.
+        # See https://github.com/rails/webpacker/issues/2113
+        record_compilation_digest
       end
     else
       true

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -49,14 +49,13 @@ class CompilerTest < Minitest::Test
     end
   end
 
-  def test_staleness_on_compile_fail
+  def test_freshness_on_compile_fail
     status = OpenStruct.new(success?: false)
 
     assert Webpacker.compiler.stale?
     Open3.stub :capture3, [:sterr, :stdout, status] do
-
       Webpacker.compiler.compile
-      assert Webpacker.compiler.stale?
+      assert Webpacker.compiler.fresh?
     end
   end
 


### PR DESCRIPTION
Fixes #2113 

Previously, in #1764, the recording of the compilation digest was ensured to happen only after webpacker ran, but during that fix, it was also made that the digest was only recorded if Webpack succeeded. However, whether Webpack succeeds is not a measure of whether or not webpack emits output, meaning that the digest wouldn't be recorded in the case of a Typescript compilation error, even though new output file(s) were emitted. This divergence could cause either too many or too few compilations, as noted in #2113. This fix still moves the writing of the digest after Webpack runs, but does so _regardless_ of whether Webpack succeeds.