### PR TITLE
Add image_submit_pack_tag helper

### DIFF
--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -50,6 +50,15 @@ module Webpacker::Helper
     image_tag(resolve_path_to_image(name), **options)
   end
 
+  # Displays an image which when clicked will submit the form.
+  #
+  # Example:
+  #  <%= imagge_submit_pack_tag 'button.png', alt: 'Submit button' %>
+  #  <input type="image" src="/packs/media/images/button-9221496029db7bc81b230307a1627c06.png" alt="Submit button" />
+  def image_submit_pack_tag(name, **options)
+    image_submit_tag(resolve_path_to_image(name), **options)
+  end
+
   # Creates a script tag that references the named pack file, as compiled by webpack per the entries list
   # in config/webpack/shared.js. By default, this list is auto-generated to match everything in
   # app/javascript/packs/*.js. In production mode, the digested reference is automatically looked up.

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -52,6 +52,12 @@ class HelperTest < ActionView::TestCase
       image_pack_tag("media/images/nested/image.jpg", size: "16x10", alt: "Edit Entry")
   end
 
+  def test_image_submit_pack_tag
+    assert_equal \
+      %(<input type="image" src="/packs/media/images/image-c38deda30895059837cf.jpg" alt="Submit button" />),
+      image_submit_pack_tag("image.jpg", alt: "Submit button")
+  end
+
   def test_javascript_pack_tag
     assert_equal \
       %(<script src="/packs/bootstrap-300631c4f0e0f9c865bc.js"></script>),


### PR DESCRIPTION
I'm migrating my project to webpacker.
I've found a lot of `image_submit_tag` in my project.
I've added a monkey patch to add image_submit_pack_tag helper.
This works well for me.

Thanks.