### PR TITLE
change sourcemap quality at production

### DIFF
--- a/package/__tests__/production.js
+++ b/package/__tests__/production.js
@@ -21,7 +21,7 @@ describe('Production environment', () => {
       expect(config.output.path).toEqual(resolve('public', 'packs'))
       expect(config.output.publicPath).toEqual('/packs/')
       expect(config).toMatchObject({
-        devtool: 'source-map',
+        devtool: 'none',
         stats: 'normal'
       })
     })

--- a/package/__tests__/staging.js
+++ b/package/__tests__/staging.js
@@ -21,7 +21,7 @@ describe('Custom environment', () => {
       expect(config.output.path).toEqual(resolve('public', 'packs-staging'))
       expect(config.output.publicPath).toEqual('/packs-staging/')
       expect(config).toMatchObject({
-        devtool: 'source-map',
+        devtool: 'none',
         stats: 'normal'
       })
     })

--- a/package/environments/production.js
+++ b/package/environments/production.js
@@ -30,7 +30,7 @@ module.exports = class extends Base {
     )
 
     this.config.merge({
-      devtool: 'source-map',
+      devtool: 'none',
       stats: 'normal',
       bail: true,
       optimization: {
@@ -38,7 +38,7 @@ module.exports = class extends Base {
           new TerserPlugin({
             parallel: true,
             cache: true,
-            sourceMap: true,
+            sourceMap: false,
             terserOptions: {
               parse: {
                 // Let terser parse ecma 8 code but always output


### PR DESCRIPTION
Current sourcemp state is `sourcemap` at production.
And TerserPlugin's sourceMap option is true.
But soucemap is not necessary at production.
More to say, an Unspecified number of people see development code by soucemap at  `sourcemap`.
So, If the Environment is production, soucemap is good to be hidden.