### PR TITLE
configure engine asset delivery path from within engine

### DIFF
--- a/docs/engines.md
+++ b/docs/engines.md
@@ -166,7 +166,7 @@ or if you prefer to keep your engine-related configuration within the engine its
 module MyEngine
   class Engine < ::Rails:Engine
     config.app_middleware.use(
-      "Rack::Statuc",
+      "Rack::Static",
       urls: ["/my-engine-packs"], root: "my_engine/public"
     )
   end

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -159,5 +159,18 @@ config.middleware.use(
   urls: ["/my-engine-packs"], root: "my_engine/public"
 )
 ```
+or if you prefer to keep your engine-related configuration within the engine itself
+
+```ruby
+# my-engine-root/lib/my-engine/engine.rb
+module MyEngine
+  class Engine < ::Rails:Engine
+    config.app_middleware.use(
+      "Rack::Statuc",
+      urls: ["/my-engine-packs"], root: "my_engine/public"
+    )
+  end
+end
+```
 
 **NOTE:** in the example above we assume that your `public_output_path` is set to `my-engine-packs` in your engine's `webpacker.yml`.


### PR DESCRIPTION
b/c it's tidier to keep engine-related configuration within the engine itself!