### PR TITLE
Remove unnecessary `require "rubygems"`

### DIFF
--- a/lib/install/bin/webpack
+++ b/lib/install/bin/webpack
@@ -7,7 +7,6 @@ require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require "rubygems"
 require "bundler/setup"
 
 require "webpacker"

--- a/lib/install/bin/webpack-dev-server
+++ b/lib/install/bin/webpack-dev-server
@@ -7,7 +7,6 @@ require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require "rubygems"
 require "bundler/setup"
 
 require "webpacker"

--- a/test/test_app/bin/webpack
+++ b/test/test_app/bin/webpack
@@ -7,7 +7,6 @@ require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require "rubygems"
 require "bundler/setup"
 
 require "webpacker"

--- a/test/test_app/bin/webpack-dev-server
+++ b/test/test_app/bin/webpack-dev-server
@@ -7,7 +7,6 @@ require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
-require "rubygems"
 require "bundler/setup"
 
 require "webpacker"


### PR DESCRIPTION
In Ruby 1.9 and later, `require "rubygems"` happens automatically.
Therefore, this PR removes those `require` s.