### PR TITLE
Update docker.md documentation

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -22,14 +22,11 @@ add nodejs and yarn as dependencies in Dockerfile,
 
 ```dockerfile
 FROM ruby:2.4.1
+
 RUN apt-get update -qq
+RUN apt-get install -y build-essential nodejs
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-
-RUN apt-get install -y nodejs
-RUN apt-get update && apt-get install -y yarn
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash
 
 # Rest of the commands....
 ```


### PR DESCRIPTION
Shortening the # of commands needed to install nodejs and yarn as dependencies for working webpacker service.