### PR TITLE
Disable streaming for proxy if Rails env test

### DIFF
--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -5,6 +5,7 @@ class Webpacker::DevServerProxy < Rack::Proxy
 
   def initialize(app = nil, opts = {})
     @webpacker = opts.delete(:webpacker) || Webpacker.instance
+    opts[:streaming] = false if Rails.env.test? && !opts.key?(:streaming)
     super
   end
 


### PR DESCRIPTION
Closes #2163

This fixes an issue that causes a crash if using webpack-dev-server for testing.