### PR TITLE
Only include configured extensions when generating the watched files digest

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -86,7 +86,7 @@ class Webpacker::Compiler
     def default_watched_paths
       [
         *config.resolved_paths_globbed,
-        "#{config.source_path.relative_path_from(config.root_path)}/**/*",
+        config.source_path_globbed,
         "yarn.lock", "package.json",
         "config/webpack/**/*"
       ].freeze

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -23,12 +23,16 @@ class Webpacker::Configuration
     root_path.join(fetch(:source_path))
   end
 
+  def source_path_globbed
+    globbed_path_with_extensions(source_path.relative_path_from(root_path))
+  end
+
   def resolved_paths
     fetch(:resolved_paths)
   end
 
   def resolved_paths_globbed
-    resolved_paths.map { |p| "#{p}/**/*" }
+    resolved_paths.map { |p| globbed_path_with_extensions(p) }
   end
 
   def source_entry_path
@@ -101,5 +105,9 @@ class Webpacker::Configuration
     def defaults
       @defaults ||= \
         HashWithIndifferentAccess.new(YAML.load_file(File.expand_path("../../install/config/webpacker.yml", __FILE__))[env])
+    end
+
+    def globbed_path_with_extensions(path)
+      "#{path}/**/*{#{extensions.join(',')}}"
     end
 end

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -25,9 +25,9 @@ class CompilerTest < Minitest::Test
 
   def test_default_watched_paths
     assert_equal Webpacker.compiler.send(:default_watched_paths), [
-      "app/assets/**/*",
-      "/etc/yarn/**/*",
-      "app/javascript/**/*",
+      "app/assets/**/*{.mjs,.js,.sass,.scss,.css,.module.sass,.module.scss,.module.css,.png,.svg,.gif,.jpeg,.jpg}",
+      "/etc/yarn/**/*{.mjs,.js,.sass,.scss,.css,.module.sass,.module.scss,.module.css,.png,.svg,.gif,.jpeg,.jpg}",
+      "app/javascript/**/*{.mjs,.js,.sass,.scss,.css,.module.sass,.module.scss,.module.css,.png,.svg,.gif,.jpeg,.jpg}",
       "yarn.lock",
       "package.json",
       "config/webpack/**/*"

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -14,6 +14,11 @@ class ConfigurationTest < Webpacker::Test
     assert_equal source_path, @config.source_path.to_s
   end
 
+  def test_source_path_globbed
+    assert_equal @config.source_path_globbed,
+                 "app/javascript/**/*{.mjs,.js,.sass,.scss,.css,.module.sass,.module.scss,.module.css,.png,.svg,.gif,.jpeg,.jpg}"
+  end
+
   def test_source_entry_path
     source_entry_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/app/javascript", "packs").to_s
     assert_equal @config.source_entry_path.to_s, source_entry_path
@@ -48,7 +53,10 @@ class ConfigurationTest < Webpacker::Test
   end
 
   def test_resolved_paths_globbed
-    assert_equal @config.resolved_paths_globbed, ["app/assets/**/*", "/etc/yarn/**/*"]
+    assert_equal @config.resolved_paths_globbed, [
+      "app/assets/**/*{.mjs,.js,.sass,.scss,.css,.module.sass,.module.scss,.module.css,.png,.svg,.gif,.jpeg,.jpg}",
+      "/etc/yarn/**/*{.mjs,.js,.sass,.scss,.css,.module.sass,.module.scss,.module.css,.png,.svg,.gif,.jpeg,.jpg}"
+    ]
   end
 
   def test_extensions


### PR DESCRIPTION
Hey there 👋 

We're using a "component" based approach where we have our template files inside `app/javascript/` next to the corresponding JS and CSS files. We noticed the following issue when running our test suite locally: Whenever we changed a template file, it would trigger a Webpack compile in the next test run. 

It seems this is caused by the logic around watched files and the digest. We hoped to be able to configure this for the test env via the `extensions:` list in `webpacker.yml`. But in `Compiler#watched_files_digest`, all files are considered for the digest, regardless of the extension.

This PR changes that behaviour and only includes the configured extensions for the watched files digest.

I'm not sure if there could be any side effects with this or if this is desirable at all for you. Let me know what you think 🙂.