### PR TITLE
Update docs to reflect Docker best practices for apt-get

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -23,10 +23,23 @@ add nodejs and yarn as dependencies in Dockerfile,
 ```dockerfile
 FROM ruby:2.4.1
 
-RUN apt-get update -qq
-RUN apt-get install -y build-essential nodejs
+RUN apt-get update -qq && apt-get install -y build-essential nodejs \
+ && rm -rf /var/lib/apt/lists/* \
+ && curl -o- -L https://yarnpkg.com/install.sh | bash
 
-RUN curl -o- -L https://yarnpkg.com/install.sh | bash
+# Rest of the commands....
+```
+
+Please note: if using `assets:precompile` in the Dockerfile or have issues with the snippet above then try:
+
+```dockerfile
+FROM ruby:2.4.1
+
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash \
+ && apt-get update && apt-get install -y nodejs && rm -rf /var/lib/apt/lists/* \
+ && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+ && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+ && apt-get update && apt-get install -y yarn && rm -rf /var/lib/apt/lists/*
 
 # Rest of the commands....
 ```


### PR DESCRIPTION
Improve docs for to represent Docker best practices.

Reference to Docker documentation for best practices:
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get

> Always combine RUN apt-get update with apt-get install in the same RUN statement. (Snippet.) Using apt-get update alone in a RUN statement causes caching issues and subsequent apt-get install instructions fail. 