### PR TITLE
Use three dots instead of ellipsis character

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -62,7 +62,7 @@ class Webpacker::Compiler
     end
 
     def run_webpack
-      logger.info "Compiling…"
+      logger.info "Compiling..."
 
       stdout, stderr, status = Open3.capture3(
         webpack_env,


### PR DESCRIPTION
I'm totally jumping out of the blue here. :)

I just thought that that `Compiling…` looks different (as opposed to `Compiling...`) in my terminal with monospaced font. I haven't seen any other library using ellipsis character.

So I went ahead and made this little change.

Hope that's ok.