### PR TITLE
Exit before precompile task if yarn:install or webpacker:yarn_install install fails

### DIFF
--- a/lib/tasks/webpacker/yarn_install.rake
+++ b/lib/tasks/webpacker/yarn_install.rake
@@ -2,5 +2,16 @@ namespace :webpacker do
   desc "Support for older Rails versions. Install all JavaScript dependencies as specified via Yarn"
   task :yarn_install do
     system "yarn install --no-progress"
+
+    exit(1) unless $?.success?
+  end
+end
+
+# safe workaround for adding action
+namespace :yarn do
+  task :install do
+    Rake::Task["yarn:install"].enhance do
+      exit(1) unless $?.success?
+    end
   end
 end

--- a/lib/tasks/webpacker/yarn_install.rake
+++ b/lib/tasks/webpacker/yarn_install.rake
@@ -7,11 +7,15 @@ namespace :webpacker do
   end
 end
 
-# safe workaround for adding action
-namespace :yarn do
-  task :install do
-    Rake::Task["yarn:install"].enhance do
-      exit(1) unless $?.success?
-    end
+def enhance_yarn_install
+  Rake::Task["yarn:install"].enhance do
+    exit(1) unless $?.success?
   end
+end
+
+if Rake::Task.task_defined?("yarn:install")
+  enhance_yarn_install
+else
+  # this is mainly for pre-5.x era
+  Rake::Task.define_task("yarn:install" => "webpacker:yarn_install")
 end


### PR DESCRIPTION
Solving problem for issue: #2185 

**How to test PR**:
1. Turn off internet connection
2. Run `rake assets:precompile`
3. Should now exit out before `Compiling...` (which current behavior is it still compiles)

**Please note**:
- This seems hacky, but after going at this for a bit it seemed to be only solution that didn't pollute `webpacker` Rake task scope, easiest to read, and least interference with current code base.
- If anyone has any idea on how to test this feature I'm all ears.