### PR TITLE
Fixed typo behing -> behind

### DIFF
--- a/docs/webpack-dev-server.md
+++ b/docs/webpack-dev-server.md
@@ -38,7 +38,7 @@ If you use Nginx in development to proxy requests to your Rails server from
 another domain, like `myapp.dev`, the Webpacker middleware will be able to
 forward requests for "packs" to the webpack dev server.
 
-If you're using `inline` mode behing Nginx, you may also need to provide the
+If you're using `inline` mode behind Nginx, you may also need to provide the
 hostname to webpack dev server so it can initiate the websocket connection for
 live reloading ([Webpack
 docs](https://webpack.js.org/configuration/dev-server/#devserver-public)).


### PR DESCRIPTION
`behing` -> `behind`

I am just guessing it is `behind` here. Please comment if that needs to something else.