### PR TITLE
Fix proxy for chunked streaming templates

### DIFF
--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -8,13 +8,6 @@ class Webpacker::DevServerProxy < Rack::Proxy
     super
   end
 
-  def rewrite_response(response)
-    _status, headers, _body = response
-    headers.delete "transfer-encoding" unless headers["transfer-encoding"] == "chunked"
-    headers.delete "content-length" if dev_server.running? && dev_server.https?
-    response
-  end
-
   def perform_request(env)
     if env["PATH_INFO"].start_with?("/#{public_output_uri_path}") && dev_server.running?
       env["HTTP_HOST"] = env["HTTP_X_FORWARDED_HOST"] = env["HTTP_X_FORWARDED_SERVER"] = dev_server.host_with_port

--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -10,7 +10,7 @@ class Webpacker::DevServerProxy < Rack::Proxy
 
   def rewrite_response(response)
     _status, headers, _body = response
-    headers.delete "transfer-encoding"
+    headers.delete "transfer-encoding" unless headers["transfer-encoding"] == "chunked"
     headers.delete "content-length" if dev_server.running? && dev_server.https?
     response
   end


### PR DESCRIPTION
Fixes #2195 

Webpacker is currently incompatible with Rails template streaming (Transfer-Encoding: chunked) in development. Firstly it prevents streaming; the whole layout blocks. Secondly it inserts junk into the page that breaks rendering in browsers.

This patch fixes it. I'm unclear on why we even need to proxy everything, or why the proxy is messing with headers. Nonetheless, [this line](https://github.com/rails/webpacker/blob/cc98e59652f22c723fac0308199cff5a42ad49ce/lib/webpacker/dev_server_proxy.rb#L13) deletes the header that is needed for streaming to work, which this patch amends. It also fixes the junk in the page, I assume because deleting that header when the server is streaming leads to an invalid format. 