### PR TITLE
Print STDOUT on failed compilation (fixed #2190)

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -75,6 +75,7 @@ class Webpacker::Compiler
         logger.error "#{stderr}" unless stderr.empty?
       else
         logger.error "Compilation failed:\n#{stderr}"
+        logger.error "#{stdout}" unless stdout.empty?
       end
 
       if config.webpack_compile_output?

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -74,8 +74,8 @@ class Webpacker::Compiler
         logger.info "Compiled all packs in #{config.public_output_path}"
         logger.error "#{stderr}" unless stderr.empty?
       else
-        logger.error "Compilation failed:\n#{stderr}"
-        logger.error "#{stdout}" unless stdout.empty?
+        non_empty_streams = [stdout, stderr].delete_if(&:empty?)
+        logger.error "Compilation failed:\n#{non_empty_streams.join("\n\n")}"
       end
 
       if config.webpack_compile_output?

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -73,13 +73,13 @@ class Webpacker::Compiler
       if status.success?
         logger.info "Compiled all packs in #{config.public_output_path}"
         logger.error "#{stderr}" unless stderr.empty?
+
+        if config.webpack_compile_output?
+          logger.info stdout
+        end
       else
         non_empty_streams = [stdout, stderr].delete_if(&:empty?)
         logger.error "Compilation failed:\n#{non_empty_streams.join("\n\n")}"
-      end
-
-      if config.webpack_compile_output?
-        logger.info stdout
       end
 
       status.success?


### PR DESCRIPTION
This fixes #2190.

The issue is that some errors that webpack prints out go to `STDOUT` rather than `STDERR`, but `STDOUT` gets swallowed.

One such instance was that declaring `const` twice. Before this fix no error would be printed, now it is printed out correctly.

_@jebw was the first one proposing such solution, I don't want to take the credit, but at the same time this needs to get fixed, so I'm submitting this PR._