### PR TITLE
set configured path to railties config

### DIFF
--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -91,6 +91,6 @@ class Webpacker::Engine < ::Rails::Engine
   end
 
   initializer "webpacker.set_source" do |app|
-    config.javascript_path = Webpacker.config.source_path.relative_path_from(Rails.root.join("app")).to_s
+    app.config.javascript_path = Webpacker.config.source_path.relative_path_from(Rails.root.join("app")).to_s
   end
 end

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -89,4 +89,8 @@ class Webpacker::Engine < ::Rails::Engine
       end
     end
   end
+
+  initializer "webpacker.set_source" do
+    config.javascript_path = Webpacker.config.source_path.relative_path_from(Rails.root.join("app")).to_s
+  end
 end

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -90,7 +90,7 @@ class Webpacker::Engine < ::Rails::Engine
     end
   end
 
-  initializer "webpacker.set_source" do
+  initializer "webpacker.set_source" do |app|
     config.javascript_path = Webpacker.config.source_path.relative_path_from(Rails.root.join("app")).to_s
   end
 end


### PR DESCRIPTION
This change goes along with rails pull request rails/rails#36803 and issue rails/rails#36799

On initialization, we set the configured Webpacker path so that rails will exclude that path from autoloading.