### PR TITLE
Remove yarn note from deployment doc

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -73,11 +73,11 @@ server {
 Webpacker out-of-the-box provides CDN support using your Rails app `config.action_controller.asset_host` setting. If you already have [CDN](http://guides.rubyonrails.org/asset_pipeline.html#cdns) added in your Rails app
 you don't need to do anything extra for Webpacker, it just works.
 
-## Capistrano		
+## Capistrano
 
-### Assets compiling on every deployment even if JavaScript and CSS files are not changed		
+### Assets compiling on every deployment even if JavaScript and CSS files are not changed
 
-Make sure you have `public/packs` and `node_modules` in `:linked_dirs`		
+Make sure you have `public/packs` and `node_modules` in `:linked_dirs`
 
 ```ruby		
 append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/packs", ".bundle", "node_modules"		

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -72,3 +72,14 @@ server {
 
 Webpacker out-of-the-box provides CDN support using your Rails app `config.action_controller.asset_host` setting. If you already have [CDN](http://guides.rubyonrails.org/asset_pipeline.html#cdns) added in your Rails app
 you don't need to do anything extra for Webpacker, it just works.
+
+## Capistrano		
+
+### Assets compiling on every deployment even if JavaScript and CSS files are not changed		
+
+Make sure you have `public/packs` and `node_modules` in `:linked_dirs`		
+
+```ruby		
+append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/packs", ".bundle", "node_modules"		
+```		
+

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -79,7 +79,7 @@ you don't need to do anything extra for Webpacker, it just works.
 
 Make sure you have `public/packs` and `node_modules` in `:linked_dirs`
 
-```ruby		
-append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/packs", ".bundle", "node_modules"		
-```		
+```ruby
+append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/packs", ".bundle", "node_modules"
+```
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -72,30 +72,3 @@ server {
 
 Webpacker out-of-the-box provides CDN support using your Rails app `config.action_controller.asset_host` setting. If you already have [CDN](http://guides.rubyonrails.org/asset_pipeline.html#cdns) added in your Rails app
 you don't need to do anything extra for Webpacker, it just works.
-
-## Capistrano
-
-### Assets compiling on every deployment even if JavaScript and CSS files are not changed
-
-Make sure you have `public/packs` and `node_modules` in `:linked_dirs`
-
-```ruby
-append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/packs", ".bundle", "node_modules"
-```
-
-If you have `node_modules` added to `:linked_dirs` you'll need to run yarn install before `deploy:assets:precompile`, so you can add this code snippet at the bottom deploy.rb
-
-```ruby
-before "deploy:assets:precompile", "deploy:yarn_install"
-namespace :deploy do
-  desc "Run rake yarn install"
-  task :yarn_install do
-    on roles(:web) do
-      within release_path do
-        execute("cd #{release_path} && yarn install --silent --no-progress --no-audit --no-optional")
-      end
-    end
-  end
-end
-```
-


### PR DESCRIPTION
Because webpacker runs `yarn install` anyway during `assets:precompile`, we should not run this task again.

related discussion: https://github.com/rails/webpacker/pull/2008