### PR TITLE
Fix TypeScript file extension regex in typescript loader.

### DIFF
--- a/lib/install/loaders/typescript.js
+++ b/lib/install/loaders/typescript.js
@@ -1,7 +1,7 @@
 const PnpWebpackPlugin = require('pnp-webpack-plugin')
 
 module.exports = {
-  test: /\.(ts|tsx)?(\.erb)?$/,
+  test: /\.tsx?(\.erb)?$/,
   use: [
     {
       loader: 'ts-loader',


### PR DESCRIPTION
It was previously not requiring the ts/tsx extension on files.

Regex example: https://regex101.com/r/youtO6/1

Fixes #1708