### PR TITLE
coerce https yaml config to boolean

### DIFF
--- a/lib/webpacker/dev_server.rb
+++ b/lib/webpacker/dev_server.rb
@@ -31,7 +31,7 @@ class Webpacker::DevServer
   end
 
   def https?
-    case fetch(:https)
+    case !!fetch(:https)
     when true, "true"
       true
     else

--- a/lib/webpacker/dev_server.rb
+++ b/lib/webpacker/dev_server.rb
@@ -31,8 +31,8 @@ class Webpacker::DevServer
   end
 
   def https?
-    case !!fetch(:https)
-    when true, "true"
+    case fetch(:https)
+    when true, "true", Hash
       true
     else
       false


### PR DESCRIPTION
This is a proposed solution to this discussion: https://github.com/rails/webpacker/issues/2000

Allows passing https configuration to the webpacker dev server within `webpacker.yml`

Before this PR if you configured webpacker.yml like:

```yml
  dev_server:
    https:
      key: './config/ssl/key.pem'
      cert: './config/ssl/cert.pem'
```

The https configuration would be passed to webpacker but the webpacker DevServerProxy would not recognize `https` being enabled. Therefore it would set `env["HTTPS"] = env["HTTP_X_FORWARDED_SSL"] = "off"` causing errors. 