### PR TITLE
Update EnforceStyle for Layout/IndentationConsistency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,7 +49,7 @@ Style/HashSyntax:
 # extra level of indentation.
 Layout/IndentationConsistency:
   Enabled: true
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
 
 # Two spaces, no tabs (for indentation).
 Layout/IndentationWidth:


### PR DESCRIPTION
Given the release of RuboCop 0.74.0 (https://github.com/rubocop-hq/rubocop/releases/tag/v0.74.0), `EnforcedStyle: rails` is now obsolete, use `EnforcedStyle: indented_internal_methods` instead.