### PR TITLE
Support .(sass|scss).erb

### DIFF
--- a/package/rules/sass.js
+++ b/package/rules/sass.js
@@ -1,6 +1,6 @@
 const getStyleRule = require('../utils/get_style_rule')
 
-module.exports = getStyleRule(/\.(scss|sass)$/i, false, [
+module.exports = getStyleRule(/\.(scss|sass)(\.erb)?$/i, false, [
   {
     loader: 'sass-loader',
     options: { sourceMap: true }


### PR DESCRIPTION
@gauravtiwari maybe I'm misunderstanding [your comment](https://github.com/rails/webpacker/issues/1163#issuecomment-357438020), but it seems that the erb loader forces itself to the front of the loader chain (I checked my loaders and it is first) but the sass loader still needs to be ok with the fact that the file might end with `.erb`