### PR TITLE
Added favicon_pack_tag to generate favicon links

### DIFF
--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -50,6 +50,16 @@ module Webpacker::Helper
     image_tag(resolve_path_to_image(name), **options)
   end
 
+  # Creates a link tag for a favicon that references the named pack file.
+  #
+  # Example:
+  #
+  #  <%= favicon_pack_tag 'mb-icon.png', rel: 'apple-touch-icon', type: 'image/png' %>
+  #  <link href="/packs/mb-icon-k344a6d59eef8632c9d1.png" rel="apple-touch-icon" type="image/png" />
+  def favicon_pack_tag(name, **options)
+    favicon_link_tag(resolve_path_to_image(name), **options)
+  end
+
   # Creates a script tag that references the named pack file, as compiled by webpack per the entries list
   # in config/webpack/shared.js. By default, this list is auto-generated to match everything in
   # app/javascript/packs/*.js. In production mode, the digested reference is automatically looked up.

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -52,6 +52,24 @@ class HelperTest < ActionView::TestCase
       image_pack_tag("media/images/nested/image.jpg", size: "16x10", alt: "Edit Entry")
   end
 
+  def test_favicon_pack_tag
+    assert_equal \
+      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/application-k344a6d59eef8632c9d1.png\" />",
+      favicon_pack_tag("application.png", rel: "apple-touch-icon", type: "image/png")
+    assert_equal \
+      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/media/images/mb-icon-c38deda30895059837cf.png\" />",
+      favicon_pack_tag("mb-icon.png", rel: "apple-touch-icon", type: "image/png")
+    assert_equal \
+      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/media/images/mb-icon-c38deda30895059837cf.png\" />",
+      favicon_pack_tag("media/images/mb-icon.png", rel: "apple-touch-icon", type: "image/png")
+    assert_equal \
+      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/media/images/nested/mb-icon-c38deda30895059837cf.png\" />",
+      favicon_pack_tag("nested/mb-icon.png", rel: "apple-touch-icon", type: "image/png")
+    assert_equal \
+      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/media/images/nested/mb-icon-c38deda30895059837cf.png\" />",
+      favicon_pack_tag("media/images/nested/mb-icon.png", rel: "apple-touch-icon", type: "image/png")
+  end
+
   def test_javascript_pack_tag
     assert_equal \
       %(<script src="/packs/bootstrap-300631c4f0e0f9c865bc.js"></script>),

--- a/test/test_app/public/packs/manifest.json
+++ b/test/test_app/public/packs/manifest.json
@@ -7,6 +7,8 @@
   "fonts/fa-regular-400.woff2": "/packs/fonts/fa-regular-400-944fb546bd7018b07190a32244f67dc9.woff2",
   "media/images/image.jpg": "/packs/media/images/image-c38deda30895059837cf.jpg",
   "media/images/nested/image.jpg": "/packs/media/images/nested/image-c38deda30895059837cf.jpg",
+  "media/images/mb-icon.png": "/packs/media/images/mb-icon-c38deda30895059837cf.png",
+  "media/images/nested/mb-icon.png": "/packs/media/images/nested/mb-icon-c38deda30895059837cf.png",
   "entrypoints": {
     "application": {
       "js": [


### PR DESCRIPTION
There is no way at the moment to generate a favicon link that uses a webpacker managed image. This PR adds `favicon_pack_tag` that behaves in a similar way to `image_pack_tag`, but instead of an image tag, it produces a favicon link.