### PR TITLE
fixing angular example app polyfills imports to work with core-js@3

### DIFF
--- a/lib/install/examples/angular/hello_angular/polyfills.ts
+++ b/lib/install/examples/angular/hello_angular/polyfills.ts
@@ -38,8 +38,8 @@
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /** Evergreen browsers require these. **/
-import 'core-js/es6/reflect';
-import 'core-js/es7/reflect';
+import 'core-js/es/reflect';
+import 'core-js/proposals/reflect-metadata';
 
 
 /**


### PR DESCRIPTION
This pull request fixes the example application installed when webpacker=angular is selected. It was using old core-js@2 imports.