### PR TITLE
Directly call webpack from compiler

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -10,6 +10,10 @@ class Webpacker::Compiler
   # Webpacker::Compiler.env['FRONTEND_API_KEY'] = 'your_secret_key'
   cattr_accessor(:env) { {} }
 
+  # Additional options passed to webpack
+  # Webpacker::Compiler.opts = %w[--debug]
+  cattr_accessor(:opts) { [] }
+
   delegate :config, :logger, to: :webpacker
 
   def initialize(webpacker)
@@ -66,7 +70,7 @@ class Webpacker::Compiler
 
       stdout, stderr, status = Open3.capture3(
         webpack_env,
-        "yarn webpack --progress --color --config config/webpack/#{ENV['NODE_ENV']}.js",
+        "yarn webpack --progress --color --config config/webpack/#{ENV['NODE_ENV']}.js #{opts.join(' ')}",
         chdir: File.expand_path(config.root_path)
       )
 

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -66,7 +66,7 @@ class Webpacker::Compiler
 
       stdout, stderr, status = Open3.capture3(
         webpack_env,
-        "#{RbConfig.ruby} ./bin/webpack",
+        "yarn webpack --progress --color --config config/webpack/#{ENV['NODE_ENV']}.js",
         chdir: File.expand_path(config.root_path)
       )
 
@@ -102,6 +102,8 @@ class Webpacker::Compiler
       return env unless defined?(ActionController::Base)
 
       env.merge("WEBPACKER_ASSET_HOST"        => ENV.fetch("WEBPACKER_ASSET_HOST", ActionController::Base.helpers.compute_asset_host),
-                "WEBPACKER_RELATIVE_URL_ROOT" => ENV.fetch("WEBPACKER_RELATIVE_URL_ROOT", ActionController::Base.relative_url_root))
+                "WEBPACKER_RELATIVE_URL_ROOT" => ENV.fetch("WEBPACKER_RELATIVE_URL_ROOT", ActionController::Base.relative_url_root),
+                "NODE_ENV" => ENV.fetch("NODE_ENV", webpacker.env)
+              )
     end
 end

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class CompilerTest < Minitest::Test
+class CompilerTest < Webpacker::Test
   def remove_compilation_digest_path
     Webpacker.compiler.send(:compilation_digest_path).tap do |path|
       path.delete if path.exist?
@@ -15,12 +15,27 @@ class CompilerTest < Minitest::Test
     remove_compilation_digest_path
   end
 
+  def test_command
+    with_rails_env("development") do
+      assert_equal Webpacker.compiler.send(:webpack_command), "yarn webpack --progress --color --config config/webpack/development.js"
+    end
+  end
+
   def test_custom_environment_variables
     assert_nil Webpacker.compiler.send(:webpack_env)["FOO"]
     Webpacker.compiler.env["FOO"] = "BAR"
     assert Webpacker.compiler.send(:webpack_env)["FOO"] == "BAR"
   ensure
     Webpacker.compiler.env = {}
+  end
+
+  def test_custom_opts
+    assert_equal Webpacker.compiler.opts, []
+
+    Webpacker.compiler.opts = %w[--debug]
+    assert_equal Webpacker.compiler.send(:webpack_command), "yarn webpack --progress --color --config config/webpack/production.js --debug"
+  ensure
+    Webpacker.compiler.opts = []
   end
 
   def test_default_watched_paths

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -19,6 +19,10 @@ class CompilerTest < Webpacker::Test
     with_rails_env("development") do
       assert_equal Webpacker.compiler.send(:webpack_command), "yarn webpack --progress --color --config config/webpack/development.js"
     end
+
+    with_rails_env("test") do
+      assert_equal Webpacker.compiler.send(:webpack_command), "yarn webpack --progress --color --config config/webpack/test.js"
+    end
   end
 
   def test_custom_environment_variables


### PR DESCRIPTION
Changes compiler to directly invoke webpack instead of calling another binstub, that invokes webpack. The actual problem is not clear since the compiler hangs indefinitely, when using the old setup. 

Here are some compilation results, with new changes: 

### Before change:

Compiler hangs indefinitely on Heroku and locally takes about 10 minutes (Macbook Pro). 

After change
----

### Without cache:

<img width="716" alt="Screenshot 2019-09-17 at 12 28 28" src="https://user-images.githubusercontent.com/771039/65039630-9b6e1180-d94a-11e9-95e6-e67f53746ed4.png">

### With cache: 

<img width="713" alt="Screenshot 2019-09-17 at 12 25 37" src="https://user-images.githubusercontent.com/771039/65039629-9b6e1180-d94a-11e9-93b4-1e504d6a5f81.png">

### With opts: 

<img width="718" alt="Screenshot 2019-09-17 at 12 33 54" src="https://user-images.githubusercontent.com/771039/65039631-9b6e1180-d94a-11e9-8756-0e400c091abd.png">
