### PR TITLE
Configure deep assign to allow an array as a path

### DIFF
--- a/package/utils/__tests__/deep_assign.js
+++ b/package/utils/__tests__/deep_assign.js
@@ -11,6 +11,14 @@ describe('deepAssign()', () => {
     expect(deepAssign(object, path, value)).toEqual(expectation)
   })
 
+  test('deeply assigns array of properties', () => {
+    const object = { foo: {} }
+    const path = ['foo', 'bar.baz']
+    const value = { x: 1, y: 2 }
+    const expectation = { foo: { 'bar.baz': { x: 1, y: 2 } } }
+    expect(deepAssign(object, path, value)).toEqual(expectation)
+  })
+
   test('allows assignment of a literal false', () => {
     const object = { foo: { bar: { } } }
     const path = 'foo.bar'

--- a/package/utils/deep_assign.js
+++ b/package/utils/deep_assign.js
@@ -4,7 +4,7 @@ const deepMerge = require('./deep_merge')
 const deepAssign = (obj, path, value) => {
   if (!value && value !== false) throw new Error(`Value can't be ${value}`)
 
-  const keys = path.split('.')
+  const keys = Array.isArray(path) ? path : path.split('.')
   const key = keys.pop()
 
   const objRef = keys.reduce((acc, currentValue) => {


### PR DESCRIPTION
Deep assign separated a path on periods, creating keys for each period separated value in the string.

I created a check to allow a path as either a period separated string or an array of keys. I also included a test to check for deep assigning with an array.