### PR TITLE
fix doc. config webpacker with docker for autoreload

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -18,6 +18,15 @@ services:
       - '3035:3035'
 ```
 
+Second, change the webpack-dev-server host to the service name of the docker-compose in config/webpacker.yml:
+
+```yaml
+development:
+  <<: *default
+  dev_server:
+    host: webpacker
+```
+
 add nodejs and yarn as dependencies in Dockerfile,
 
 ```dockerfile


### PR DESCRIPTION
The setup guide in the document has one problem. If you modify the code, it will not be autoreload and it will be compiled every time you manually refresh the page.