### PR TITLE
Skip webpacker initialization if we are installing it     

### DIFF
--- a/lib/tasks/webpacker/install.rake
+++ b/lib/tasks/webpacker/install.rake
@@ -5,9 +5,9 @@ namespace :webpacker do
   desc "Install Webpacker in this application"
   task install: [:check_node, :check_yarn] do
     if Rails::VERSION::MAJOR >= 5
-      exec "#{RbConfig.ruby} #{bin_path}/rails app:template LOCATION=#{install_template_path}"
+      exec({ "WEBPACKER_INSTALL_IN_PROGRESS" => "true" }, "#{RbConfig.ruby} #{bin_path}/rails app:template LOCATION=#{install_template_path}")
     else
-      exec "#{RbConfig.ruby} #{bin_path}/rake rails:template LOCATION=#{install_template_path}"
+      exec({ "WEBPACKER_INSTALL_IN_PROGRESS" => "true" }, "#{RbConfig.ruby} #{bin_path}/rake rails:template LOCATION=#{install_template_path}")
     end
   end
 end

--- a/lib/webpacker.rb
+++ b/lib/webpacker.rb
@@ -23,7 +23,7 @@ module Webpacker
   end
 
   delegate :logger, :logger=, :env, to: :instance
-  delegate :config, :compiler, :manifest, :commands, :dev_server, to: :instance
+  delegate :config, :compiler, :manifest, :commands, :dev_server, :installing?, to: :instance
   delegate :bootstrap, :clean, :clobber, :compile, to: :commands
 end
 

--- a/lib/webpacker/instance.rb
+++ b/lib/webpacker/instance.rb
@@ -11,6 +11,10 @@ class Webpacker::Instance
     @env ||= Webpacker::Env.inquire self
   end
 
+  def installing?
+    !ENV["WEBPACKER_INSTALL_IN_PROGRESS"].nil?
+  end
+
   def config
     @config ||= Webpacker::Configuration.new(
       root_path: root_path,


### PR DESCRIPTION
Currently, when the user has not yet run `rails webpacker:install` and thus there's no webpacker configuration, webpacker always shows the following warning:

```
RAILS_ENV=test environment is not defined in config/webpacker.yml, falling back to production environment
```

The above happens in the latest webpacker release. In master, the situation leads to a hard failure, although with a more clear error message:

```
RAILS_ENV=development environment is not defined in config/webpacker.yml, falling back to production environment
rails aborted!
Webpacker configuration file not found /path/to/testapp/config/webpacker.yml. Please run rails webpacker:install Error: No such file or directory @ rb_sysopen - /path/to/testapp/config/webpacker.yml
/path/to/railties/lib/rails/initializable.rb:32:in `instance_exec'
/path/to/railties/lib/rails/initializable.rb:32:in `run'
/path/to/railties/lib/rails/initializable.rb:61:in `block in run_initializers'
/path/to/railties/lib/rails/initializable.rb:60:in `run_initializers'
/path/to/railties/lib/rails/application.rb:364:in `initialize!'
/path/to/testapp/config/environment.rb:5:in `<top (required)>'
/path/to/activesupport/lib/active_support/dependencies.rb:324:in `block in require'
/path/to/activesupport/lib/active_support/dependencies.rb:291:in `load_dependency'
/path/to/activesupport/lib/active_support/dependencies.rb:324:in `require'
/path/to/railties/lib/rails/application.rb:340:in `require_environment!'
/path/to/railties/lib/rails/application.rb:515:in `block in run_tasks_blocks'
/path/to/railties/lib/rails/commands/rake/rake_command.rb:23:in `block in perform'
/path/to/railties/lib/rails/commands/rake/rake_command.rb:20:in `perform'
/path/to/railties/lib/rails/command.rb:47:in `invoke'
/path/to/railties/lib/rails/commands.rb:18:in `<top (required)>'
./bin/rails:4:in `require'
./bin/rails:4:in `<main>'

Caused by:
Errno::ENOENT: No such file or directory @ rb_sysopen - /path/to/testapp/config/webpacker.yml
/path/to/railties/lib/rails/initializable.rb:32:in `instance_exec'
/path/to/railties/lib/rails/initializable.rb:32:in `run'
/path/to/railties/lib/rails/initializable.rb:61:in `block in run_initializers'
/path/to/railties/lib/rails/initializable.rb:60:in `run_initializers'
/path/to/railties/lib/rails/application.rb:364:in `initialize!'
/path/to/testapp/config/environment.rb:5:in `<top (required)>'
/path/to/activesupport/lib/active_support/dependencies.rb:324:in `block in require'
/path/to/activesupport/lib/active_support/dependencies.rb:291:in `load_dependency'
/path/to/activesupport/lib/active_support/dependencies.rb:324:in `require'
/path/to/railties/lib/rails/application.rb:340:in `require_environment!'
/path/to/railties/lib/rails/application.rb:515:in `block in run_tasks_blocks'
/path/to/railties/lib/rails/commands/rake/rake_command.rb:23:in `block in perform'
/path/to/railties/lib/rails/commands/rake/rake_command.rb:20:in `perform'
/path/to/railties/lib/rails/command.rb:47:in `invoke'
/path/to/railties/lib/rails/commands.rb:18:in `<top (required)>'
./bin/rails:4:in `require'
./bin/rails:4:in `<main>'
Tasks: TOP => app:template => environment
(See full trace by running task with --trace)
```

In this case, we're actually in the middle of creating a configuration for webpacker, so I don't think we should show a warning or a hard failure, because the user is doing nothing wrong. She's not trying to boot the application or do any other thing not supposed to work without a configuration.

So, this PR introduces the `Webpacker.installing?` method, which checks for the presence of an environment variable that is set when the `webpacker:install` task is run.

It also updates the `webpacker.yarn_check` initializer to use the same approach, because I don't think webpacker is supposed to work without a configuration file at all, unless we're generating the configuration file itself, so I think this approach is better to solve the same problem the previous condition was fixing (`webpacker.yarn_check` initializer crashing while runinng the `webpacker:install` because of missing configuration).