### PR TITLE
Enforced nokogiri >= 1.10.4 due to CVE-2019-5477

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem "rails"
 gem "rake", ">= 11.1"
 gem "rack-proxy", require: false
+gem "nokogiri", ">= 1.10.4"
 
 group :test do
   gem "minitest", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     nio4r (2.3.1)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     parallel (1.17.0)
     parser (2.6.3.0)
@@ -142,6 +142,7 @@ DEPENDENCIES
   bundler (>= 1.3.0)
   byebug
   minitest (~> 5.0)
+  nokogiri (>= 1.10.4)
   rack-proxy
   rails
   rake (>= 11.1)


### PR DESCRIPTION
We've found that the latest `webpacker` is pulling `nokogiri 1.10.3` which is known to be vulnerable to the command injection via the `Kernel.open` method ([CVE-2019-5477](https://nvd.nist.gov/vuln/detail/CVE-2019-5477)).

This pull request locks `nokogiri` at `1.10.4` which is considered safe.