### PR TITLE
update deprecated option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,7 +49,7 @@ Style/HashSyntax:
 # extra level of indentation.
 Layout/IndentationConsistency:
   Enabled: true
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
 
 # Two spaces, no tabs (for indentation).
 Layout/IndentationWidth:


### PR DESCRIPTION
rubocop is telling me this option has been renamed
since I bundle install with `--path vendor` 
this is now breaking me CI

thank you
