### PR TITLE
Include the Webpacker host on the web/app service

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,6 +1,6 @@
 # Docker
 
-To setup webpacker with a dockerized Rails application is trivial.
+To setup webpacker with a dockerized Rails application.
 
 First, add a new service for webpacker in docker-compose.yml:
 
@@ -50,6 +50,24 @@ and create an env file to load environment variables from:
 NODE_ENV=development
 RAILS_ENV=development
 WEBPACKER_DEV_SERVER_HOST=0.0.0.0
+```
+
+then add the webpacker host name environment variable to the web/app service:
+
+```Dockerfile
+  web:
+    build:
+      context: .
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    volumes:
+      - .:/usr/src/app
+    ports:
+      - "3000:3000"
+    environment:
+      - DATABASE_URL=postgres://postgres@db
+      - WEBPACKER_DEV_SERVER_HOST=webpacker
+    depends_on:
+      - db
 ```
 
 Lastly, rebuild your container:


### PR DESCRIPTION
The environment variable for WEBPACKER_DEV_SERVER_HOST is required for the web/app container to be able to proxy /packs requests to the webpack-dev-server container. Otherwise the rails app will compile on-demand locally.

After struggling for a while, I discovered 2 issues that helped shine some light on the problem, ultimately discovering that only the one environment variable was needed.

* https://github.com/rails/webpacker/issues/863
* https://github.com/rails/webpacker/issues/1019