### PR TITLE
NodeModules Babel exclude regex

### DIFF
--- a/package/rules/node_modules.js
+++ b/package/rules/node_modules.js
@@ -3,11 +3,11 @@ const { cache_path: cachePath } = require('../config')
 const { nodeEnv } = require('../env')
 
 // Compile standard ES features for JS in node_modules with Babel.
-//   Regex details for exclude: https://regex101.com/r/CglKdg/5/
+//   Regex details for exclude: https://regex101.com/r/SKPnnv/1
 module.exports = {
   test: /\.(js|mjs)$/,
   include: /node_modules/,
-  exclude: /(?:@?babel(?:\/|\\{1,2}|-).+)|regenerator-runtime|core-js|webpack/,
+  exclude: /(?:@?babel(?:\/|\\{1,2}|-).+)|regenerator-runtime|core-js|^webpack$|^webpack-assets-manifest$|^webpack-cli$|^webpack-sources$|^@rails\/webpacker$/,
   use: [
     {
       loader: 'babel-loader',


### PR DESCRIPTION
We had a problem using the module "webpacker-svelte" and IE11 compatibility.
We found out that the module is not processed by babel because of the exclude pattern used for the nodeModules rule.

I changed the regex according to the info here: https://regex101.com/r/CglKdg/5/

Hope this helps!