### PR TITLE
wip: fix gzip_static setting on nginx configuration

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -77,7 +77,7 @@ server {
     deny all;
   }
 
-  location ^~ /assets|packs/ {
+  location ~ ^/assets|packs/ {
     gzip_static on;
     brotli_static on; # Optional, see below
     expires max;


### PR DESCRIPTION
This pull request is work in progress.

On this line, directories start with "/assets/" or "/packs/" should be matched. Regular expression should be used in this case.

`^~: If a carat and tilde modifier is present, and if this block is selected as the best non-regular expression match, regular expression matching will not take place.`

[fyi]
If you have encountered similar problem, you can check if your js|css files are compressed or not with the command below. 
```
curl -IH "Content-Encoding: gzip" https://example.com/assets/application-xxxx.js
```
If those files are compressed, it returns "Content-Encoding: gzip" in responses.