### PR TITLE
Check if request path starts with '/packs/' instead of '/packs'

### DIFF
--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -26,6 +26,6 @@ class Webpacker::DevServerProxy < Rack::Proxy
 
   private
     def public_output_uri_path
-      config.public_output_path.relative_path_from(config.public_path)
+      config.public_output_path.relative_path_from(config.public_path).to_s + "/"
     end
 end


### PR DESCRIPTION
Only checking if it starts with `/packs` can lead to false positives where it forwards requests to
`webpack-dev-server` that don't strictly match the `config.public_output_path` and which can't be
handled by the currently running `webpack-dev-server` process — even requests that don't even have anything to do with webpacker but just happen to start with `/packs`.

Better to pass on the request to Rails unless it is a definite match for the `public_output_path` that
webpacker-dev-server is responsible for.

I have a specific use case that depends on this stricter matching, but it seems like a general problem that would interfere with any Rails routes that start with `/packs`. For example, if you had a route called `/packsel` or `/packser` or `/packs-info`.

This seems like a safe change because `packs` is a directory and we only need proxy requests for files _within_ that directory, which should always have a `/` between `/packs` and the filename.

---

My use case, in case you're curious, is to have a Rails route that lets you view .html screenshots saved by the `capybara-screenshot` gem — but with all the .css and .js assets that it depends on loading correctly instead of showing as a broken/unstyled page. The screenshots reference paths like `/packs-test/js/something-696a0da8689b3f5ee751.js`.

The `bin/webpack-dev-server` process that's running doesn't know anything about the test assets because it's running in development environment (responsible only for `/packs/*` paths), so it shouldn't proxy these `/packs-test/` requests to `webpack-dev-server` (that would just end up in a 404). Instead I want those requests to hit my custom Rails route ...