### PR TITLE
Add detailed instructions for HMR

### DIFF
--- a/docs/webpack-dev-server.md
+++ b/docs/webpack-dev-server.md
@@ -35,12 +35,12 @@ web: bundle exec puma -C config/puma.rb
 // app/javascript/app.jsx
 
 import React from 'react';
-+ import { hot } from 'react-hot-loader';
++ import { hot } from 'react-hot-loader/root';
 
 const App = () => <SomeComponent(s) />
 
 - export default App;
-+ export default hot(module)(App);
++ export default hot(App);
 ```
 
 ```diff

--- a/docs/webpack-dev-server.md
+++ b/docs/webpack-dev-server.md
@@ -25,7 +25,7 @@ https://github.com/rails/webpacker#upgrading
 Here's the full set of changes you need to do to get the most out of HMR (this is subject to change, for the latest solution, check the webpack/HMR official documentation links below):
 
 ```diff
-# Procfile.dev
+# Procfile.dev (only if you need/use it)
 web: bundle exec puma -C config/puma.rb
 - webpacker: ./bin/webpack-dev-server
 + webpacker: ./bin/webpack-dev-server --hot
@@ -49,9 +49,7 @@ development:
   dev_server:
 -    hmr: false
 +    hmr: true
-    # Inline should be set to true if using HMR
--    inline: false
-+    inline: true
+# ...
 ```
 
 ```diff


### PR DESCRIPTION
I just enabled HMR in my rails/webpacker project. I couldn't find a single place with all the documented changes needed to be done for it to work fully.*

*work fully => without full page reload after every change and with support for editing project files directly from the browser developer tools

Preview the new markdown here:
https://github.com/rails/webpacker/blob/df59eb47f2eba2863587287d10ab2af6ade6c2bf/docs/webpack-dev-server.md