### PR TITLE
Fix doc to follow new options structure for css-loader v3

### DIFF
--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -189,9 +189,10 @@ const { environment } = require('@rails/webpacker')
 const merge = require('webpack-merge')
 
 const myCssLoaderOptions = {
-  modules: true,
+  modules: {
+    localIdentName: '[name]__[local]___[hash:base64:5]'
+  },
   sourceMap: true,
-  localIdentName: '[name]__[local]___[hash:base64:5]'
 }
 
 const CSSLoader = environment.loaders.get('sass').use.find(el => el.loader === 'css-loader')


### PR DESCRIPTION
Fixed the doc to follow the new structure of options for css-loader v3.
ref: https://github.com/rails/webpacker/pull/2130
       https://github.com/webpack-contrib/css-loader#object