### PR TITLE
Update resolve-url-loader instructions

### DIFF
--- a/docs/css.md
+++ b/docs/css.md
@@ -213,11 +213,10 @@ const { environment } = require('@rails/webpacker')
 
 // resolve-url-loader must be used before sass-loader
 environment.loaders.get('sass').use.splice(-1, 0, {
-  loader: 'resolve-url-loader',
-  options: {
-    attempts: 1
-  }
+  loader: 'resolve-url-loader'
 });
+
+module.exports = environment
 ```
 
 ## Working with TypeScript


### PR DESCRIPTION
If you include  `options: { attempts: 1 }`, Webpack will give this warning

```
    Module Warning (from ./node_modules/resolve-url-loader/index.js):
    resolve-url-loader: loader misconfiguration
      "attempts" option is defunct (consider "join" option if search is needed)
```

[This commit](https://github.com/bholloway/resolve-url-loader/commit/c7701ca1f3af896eec884477521d0a51df3d0fca) is where that happened, which was [released as `v3.0.0`](https://github.com/bholloway/resolve-url-loader/pull/101).

Also added the `module.exports = environment` to the end, since that's needed too.
