### PR TITLE
Fix config file path in error message

### DIFF
--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -16,20 +16,20 @@ module Webpacker
       def load_config
         app_root = Pathname.new(@app_path)
 
-        config = Configuration.new(
+        @config = Configuration.new(
           root_path: app_root,
           config_path: app_root.join("config/webpacker.yml"),
           env: ENV["RAILS_ENV"]
         )
 
-        dev_server = DevServer.new(config)
+        dev_server = DevServer.new(@config)
 
         @hostname          = dev_server.host
         @port              = dev_server.port
         @pretty            = dev_server.pretty?
 
       rescue Errno::ENOENT, NoMethodError
-        $stdout.puts "webpack dev_server configuration not found in #{config.config_path}[#{ENV["RAILS_ENV"]}]."
+        $stdout.puts "webpack dev_server configuration not found in #{@config.config_path}[#{ENV["RAILS_ENV"]}]."
         $stdout.puts "Please run bundle exec rails webpacker:install to install Webpacker"
         exit!
       end
@@ -39,7 +39,7 @@ module Webpacker
         server.close
 
       rescue Errno::EADDRINUSE
-        $stdout.puts "Another program is running on port #{@port}. Set a new port in #{@config_file} for dev_server"
+        $stdout.puts "Another program is running on port #{@port}. Set a new port in #{@config.config_path} for dev_server"
         exit!
       end
 


### PR DESCRIPTION
Fix printing blank instead of config path when the port is already in use.