### PR TITLE
Ignore missing files when cleaning old assets

### DIFF
--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -10,15 +10,21 @@ class Webpacker::Commands
       files_in_manifest = process_manifest_hash(manifest.refresh)
       files_to_be_removed = files_in_manifest.flat_map do |file_in_manifest|
         file_prefix, file_ext = file_in_manifest.scan(/(.*)[0-9a-f]{20}(.*)/).first
-        versions_of_file = Dir.glob("#{file_prefix}*#{file_ext}").grep(/#{file_prefix}[0-9a-f]{20}#{file_ext}/)
-        versions_of_file.map do |version_of_file|
+
+        versions_of_file(file_prefix, file_ext).map do |version_of_file|
           next if version_of_file == file_in_manifest
 
           [version_of_file, File.mtime(version_of_file).utc.to_i]
         end.compact.sort_by(&:last).reverse.drop(count_to_keep).map(&:first)
       end
 
-      files_to_be_removed.each { |f| File.delete f }
+      files_to_be_removed.each do |f|
+        begin
+          File.delete f
+        rescue Errno::ENOENT
+          nil
+        end
+      end
     end
   end
 
@@ -44,5 +50,9 @@ class Webpacker::Commands
 
         File.join(config.root_path, "public", value)
       end.flatten
+    end
+
+    def versions_of_file(file_prefix, file_ext)
+      Dir.glob("#{file_prefix}*#{file_ext}").grep(/#{file_prefix}[0-9a-f]{20}#{file_ext}/)
     end
 end

--- a/test/command_test.rb
+++ b/test/command_test.rb
@@ -30,4 +30,14 @@ class CommandTest < Minitest::Test
       assert Webpacker.commands.clean
     end
   end
+
+  def test_clean_command_does_not_fail_on_missing_files
+    Webpacker.commands.stub(:versions_of_file, %w[v1 v2 v3]) do
+      File.stub(:mtime, OpenStruct.new(utc: 0)) do
+        File.stub :delete, lambda { |n| raise Errno::ENOENT } do
+          Webpacker.clean
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
We ran into this issue when using a staging server and Capistrano.  The staging server would be pushed to with multiple different branches throughout the day, resulting in various stale files.  

Since we're trying to clean up old files, swallowing the 'file not found' errors seems to make sense.

(I had to extract `versions_of_file` to make this more testable.  Hope that's ok.)

Fixes #2372
Complementary to PR #2382