### PR TITLE
Fix issue with "assets:clean" tasks

### DIFF
--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -16,7 +16,7 @@ class Webpacker::Commands
 
           [version_of_file, File.mtime(version_of_file).utc.to_i]
         end.compact.sort_by(&:last).reverse.drop(count_to_keep).map(&:first)
-      end
+      end.uniq
 
       files_to_be_removed.each { |f| File.delete f }
     end

--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -16,7 +16,7 @@ class Webpacker::Commands
 
           [version_of_file, File.mtime(version_of_file).utc.to_i]
         end.compact.sort_by(&:last).reverse.drop(count_to_keep).map(&:first)
-      end.uniq
+      end
 
       files_to_be_removed.each { |f| File.delete f }
     end
@@ -43,6 +43,6 @@ class Webpacker::Commands
         next process_manifest_hash(value) if value.is_a?(Hash)
 
         File.join(config.root_path, "public", value)
-      end.flatten
+      end.flatten.uniq
     end
 end


### PR DESCRIPTION
## Issue

By using task `bundle exec rake 'assets:clean[3]'` gets error: `Errno::ENOENT: No such file or directory @ apply2files`

## Reason

Generated `manifest.json` file contain this content:

```json
{
  "app.css": "/packs/css/app-bf1542ff.css",
  "app.js": "/packs/js/app-2f5fcfce1c5201c7ae37.js",
  "app.js.map": "/packs/debugging/js/app-2f5fcfce1c5201c7ae37.js.map",
  "entrypoints": {
    "app": {
      "css": [
        "/packs/css/app-bf1542ff.css"
      ],
      "js": [
        "/packs/js/app-2f5fcfce1c5201c7ae37.js"
      ],
      "js.map": [
        "/packs/debugging/js/app-2f5fcfce1c5201c7ae37.js.map"
      ]
    },
    "landing": {
      "css": [
        "/packs/css/landing-b87760de.css"
      ],
      "js": [
        "/packs/js/landing-9ea1a07c26296dbf83d1.js"
      ],
      "js.map": [
        "/packs/debugging/js/landing-9ea1a07c26296dbf83d1.js.map"
      ]
    },
    "mailer": {
      "css": [
        "/packs/css/mailer-b026c729.css"
      ],
      "js": [
        "/packs/js/mailer-99c4577677ba5b22d7b2.js"
      ],
      "js.map": [
        "/packs/debugging/js/mailer-99c4577677ba5b22d7b2.js.map"
      ]
    },
    "print": {
      "css": [
        "/packs/css/print-0e62cc69.css"
      ],
      "js": [
        "/packs/js/print-5a112cec83cf65e54183.js"
      ],
      "js.map": [
        "/packs/debugging/js/print-5a112cec83cf65e54183.js.map"
      ]
    }
  },
  "landing.css": "/packs/css/landing-b87760de.css",
  "landing.js": "/packs/js/landing-9ea1a07c26296dbf83d1.js",
  "landing.js.map": "/packs/debugging/js/landing-9ea1a07c26296dbf83d1.js.map",
  "mailer.css": "/packs/css/mailer-b026c729.css",
  "mailer.js": "/packs/js/mailer-99c4577677ba5b22d7b2.js",
  "mailer.js.map": "/packs/debugging/js/mailer-99c4577677ba5b22d7b2.js.map",
  "print.css": "/packs/css/print-0e62cc69.css",
  "print.js": "/packs/js/print-5a112cec83cf65e54183.js",
  "print.js.map": "/packs/debugging/js/print-5a112cec83cf65e54183.js.map"
}
```

This converted by `process_manifest_hash(manifest_hash)` to:

```json
["/var/www/example/releases/20191204055949/public/packs/css/app-bf1542ff.css",
 "/var/www/example/releases/20191204055949/public/packs/js/app-2f5fcfce1c5201c7ae37.js",
 "/var/www/example/releases/20191204055949/public/packs/debugging/js/app-2f5fcfce1c5201c7ae37.js.map",
 "/var/www/example/releases/20191204055949/public/packs/assets/janbodnar-6a1f51bf6f2b99610c781a771b7db549.jpg",
 "/var/www/example/releases/20191204055949/public/packs/assets/signup_bg_girl-0b2a589a8c60b45ae7859fce11c3d23b.svg",
 "/var/www/example/releases/20191204055949/public/packs/assets/signup_bg_mobile-8c6789d7d6cfeb6f6411cd8bbb761ebb.svg",
 "/var/www/example/releases/20191204055949/public/packs/assets/signup_bg_tablet-146a692125d7f1e9daca3938ba44999b.svg",
 "/var/www/example/releases/20191204055949/public/packs/css/app-bf1542ff.css",
 "/var/www/example/releases/20191204055949/public/packs/js/app-2f5fcfce1c5201c7ae37.js",
 "/var/www/example/releases/20191204055949/public/packs/debugging/js/app-2f5fcfce1c5201c7ae37.js.map",
 "/var/www/example/releases/20191204055949/public/packs/css/landing-b87760de.css",
 "/var/www/example/releases/20191204055949/public/packs/js/landing-9ea1a07c26296dbf83d1.js",
 "/var/www/example/releases/20191204055949/public/packs/debugging/js/landing-9ea1a07c26296dbf83d1.js.map",
 "/var/www/example/releases/20191204055949/public/packs/css/mailer-b026c729.css",
 "/var/www/example/releases/20191204055949/public/packs/js/mailer-99c4577677ba5b22d7b2.js",
 "/var/www/example/releases/20191204055949/public/packs/debugging/js/mailer-99c4577677ba5b22d7b2.js.map",
 "/var/www/example/releases/20191204055949/public/packs/css/print-0e62cc69.css",
 "/var/www/example/releases/20191204055949/public/packs/js/print-5a112cec83cf65e54183.js",
 "/var/www/example/releases/20191204055949/public/packs/debugging/js/print-5a112cec83cf65e54183.js.map",
 "/var/www/example/releases/20191204055949/public/packs/css/landing-b87760de.css",
 "/var/www/example/releases/20191204055949/public/packs/js/landing-9ea1a07c26296dbf83d1.js",
 "/var/www/example/releases/20191204055949/public/packs/debugging/js/landing-9ea1a07c26296dbf83d1.js.map",
 "/var/www/example/releases/20191204055949/public/packs/css/mailer-b026c729.css",
 "/var/www/example/releases/20191204055949/public/packs/js/mailer-99c4577677ba5b22d7b2.js",
 "/var/www/example/releases/20191204055949/public/packs/debugging/js/mailer-99c4577677ba5b22d7b2.js.map",
 "/var/www/example/releases/20191204055949/public/packs/css/print-0e62cc69.css",
 "/var/www/example/releases/20191204055949/public/packs/js/print-5a112cec83cf65e54183.js",
 "/var/www/example/releases/20191204055949/public/packs/debugging/js/print-5a112cec83cf65e54183.js.map"]
```

This lead to duplication for filenames in this array at `files_in_manifest ` (example: `app-2f5fcfce1c5201c7ae37.js`). After collecting information in variable `files_to_be_removed` we get this result:

```json
["/var/www/example/releases/20191204055949/public/packs/js/app-1949e13f6d3c0fe658f0.js", 
"/var/www/example/releases/20191204055949/public/packs/js/app-1949e13f6d3c0fe658f0.js"]
```

As we can see, we marked for remove twice the same file (because we twice search old assets for `app.js`). 

## Solution

By adding `uniq` we can fix this problem.