### PR TITLE
Fix link to changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Please note that Webpacker 4.1.0 has an installer bug. Please use 4.2.0 or above**
 
-## [[4.2.1]](https://github.com/rails/webpacker/compare/v4.1.0...v4.2.0) - 2019-12-09
+## [[4.2.1]](https://github.com/rails/webpacker/compare/v4.2.0...v4.2.1) - 2019-12-09
 
 - Fixed issue with webpack clean task [#2389](https://github.com/rails/webpacker/pull/2389)
 


### PR DESCRIPTION
Seems https://github.com/rails/webpacker/commit/6bc19e7df3ed7e8f958b573e793a342a2a69df05 has wrong URL.