### PR TITLE
Fix assets clean step

### DIFF
--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -8,7 +8,7 @@ class Webpacker::Commands
   def clean(count = 2)
     if config.public_output_path.exist? && config.public_manifest_path.exist? && versions.count > count
       versions.drop(count).flat_map(&:last).each do |file|
-        File.delete(file) if File.exist?(file)
+        File.delete(file) if File.file?(file)
         logger.info "Removed #{file}"
       end
     end


### PR DESCRIPTION
File.exists? return true for directories and it is causing issue in assets clean step

```
rake aborted!
Errno::EISDIR: Is a directory @ apply2files - /home/circleci/project/public/packs-test/js
/home/circleci/project/vendor/bundle/ruby/2.6.0/gems/webpacker-4.2.1/lib/webpacker/commands.rb:11:in `delete'
```