### PR TITLE
Remove "Nothing to do" log entry

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -27,7 +27,6 @@ class Webpacker::Compiler
         record_compilation_digest
       end
     else
-      logger.info "Everything's up-to-date. Nothing to do"
       true
     end
   end

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -27,6 +27,7 @@ class Webpacker::Compiler
         record_compilation_digest
       end
     else
+      logger.debug "Everything's up-to-date. Nothing to do"
       true
     end
   end


### PR DESCRIPTION
https://github.com/rails/webpacker/issues/2392

Removes the "Nothing to do" log entry from the `Webpacker::Compiler#compiler` method.

Nothing to do should include logging!