### PR TITLE
Use rubygems-update 3.0.6 for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 dist: xenial
 before_install:
-  - gem install rubygems-update && update_rubygems
+  - gem install rubygems-update -v 3.0.6 && update_rubygems
   # Rails 4.2 doesn't support bundler 2.0, so we need to lock bundler to
   # v1.17.3. This is just for Ruby 2.5 which ships with bundler 2.x on Travis
   # CI while Ruby 2.6 does not.


### PR DESCRIPTION
The new version of rubygems-update using bundler v2.1.0
https://rubygems.org/gems/rubygems-update
https://github.com/rubygems/rubygems/pull/3028

before:
https://travis-ci.org/rails/webpacker/jobs/625887510
https://travis-ci.org/rails/webpacker/jobs/625428394

after:
https://travis-ci.org/rails/webpacker/jobs/626077984