### PR TITLE
Define assets:clean task if it doesn't exist

### DIFF
--- a/lib/tasks/webpacker/clean.rake
+++ b/lib/tasks/webpacker/clean.rake
@@ -16,4 +16,6 @@ if Rake::Task.task_defined?("assets:clean")
   Rake::Task["assets:clean"].enhance do
     Rake::Task["webpacker:clean"].invoke
   end
+else
+  Rake::Task.define_task("assets:clean" => "webpacker:clean")
 end


### PR DESCRIPTION
Similar to the behavior of the `assets:precompile` task to handle apps where sprockets isn't used at all.