### PR TITLE
Support svelte.erb extension

### DIFF
--- a/lib/install/loaders/svelte.js
+++ b/lib/install/loaders/svelte.js
@@ -1,5 +1,5 @@
 module.exports = {
-  test: /\.svelte$/,
+  test: /\.svelte(\.erb)?$/,
   use: [{
     loader: 'svelte-loader',
     options: {


### PR DESCRIPTION
svelte loader should support svelte.erb extension as well. As same as it support now vue.erb  