### PR TITLE
Remove defaults based on webpack mode development

### DIFF
--- a/package/environments/development.js
+++ b/package/environments/development.js
@@ -14,11 +14,7 @@ module.exports = class extends Base {
 
     this.config.merge({
       mode: 'development',
-      cache: true,
       devtool: 'cheap-module-source-map',
-      output: {
-        pathinfo: true
-      },
       devServer: {
         clientLogLevel: 'none',
         compress: devServer.compress,


### PR DESCRIPTION
Default of cache is true:
https://webpack.js.org/configuration/other-options/#cache

Default of pathinfo is true:
https://webpack.js.org/configuration/output/#outputpathinfo