### PR TITLE
Update debugging instructions

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,11 +4,13 @@
 
 1. Read the error message carefully. The error message will tell you the precise key value
    that is not matching what Webpack expects.
-2. Put a `debugger` statement in your Webpack configuration and run `bin/webpack --debug`.
+2. Put a `debugger` statement in your Webpack configuration and run `bin/webpack --debug-webpacker`.
    If you have a node debugger installed, you'll see the Chrome debugger for your webpack
    config. For example, install the Chrome extension [NiM](https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj) and
    set the option for the dev tools to open automatically. For more details on debugging,
    see the official [Webpack docs on debugging](https://webpack.js.org/contribute/debugging/#devtools)
+3. Any arguments that you add to bin/webpack get sent to webpack. For example, you can pass `--debug` to switch loaders to debug mode. See [webpack CLI debug options](https://webpack.js.org/api/cli/#debug-options) for more information on the available options.
+4. You can also pass additional options to the command to run the webpack-dev-server and start the webpack-dev-server with the option `--debug-webpacker`
 
 ## ENOENT: no such file or directory - node-sass
 

--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -52,7 +52,7 @@ module Webpacker
           ["yarn", "webpack-dev-server"]
         end
 
-        if ARGV.include?("--debug-webpacker")
+        if @argv.include?("--debug-webpacker")
           cmd = [ "node", "--inspect-brk"] + cmd
         end
 

--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -52,9 +52,8 @@ module Webpacker
           ["yarn", "webpack-dev-server"]
         end
 
-        if ARGV.include?("--debug")
+        if ARGV.include?("--debug-webpacker")
           cmd = [ "node", "--inspect-brk"] + cmd
-          ARGV.delete("--debug")
         end
 
         cmd += ["--config", @webpack_config]

--- a/lib/webpacker/webpack_runner.rb
+++ b/lib/webpacker/webpack_runner.rb
@@ -12,9 +12,8 @@ module Webpacker
         ["yarn", "webpack"]
       end
 
-      if ARGV.include?("--debug")
+      if @argv.include?("--debug-webpacker")
         cmd = [ "node", "--inspect-brk"] + cmd
-        ARGV.delete("--debug")
       end
 
       cmd += ["--config", @webpack_config] + @argv


### PR DESCRIPTION
Since webpack supports a --debug option and since we pass
all additional args to webpack, we don't want to overload
the --debug option.