### PR TITLE
Ensure missing entry error message includes asset file type

### DIFF
--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -29,7 +29,7 @@ class Webpacker::Manifest
   end
 
   def lookup_pack_with_chunks!(name, pack_type = {})
-    lookup_pack_with_chunks(name, pack_type) || handle_missing_entry(name)
+    lookup_pack_with_chunks(name, pack_type) || handle_missing_entry(name, pack_type)
   end
 
   # Computes the relative path for a given Webpacker asset using manifest.json.
@@ -46,7 +46,7 @@ class Webpacker::Manifest
 
   # Like lookup, except that if no asset is found, raises a Webpacker::Manifest::MissingEntryError.
   def lookup!(name, pack_type = {})
-    lookup(name, pack_type) || handle_missing_entry(name)
+    lookup(name, pack_type) || handle_missing_entry(name, pack_type)
   end
 
   private
@@ -75,8 +75,8 @@ class Webpacker::Manifest
       "#{name}.#{manifest_type(pack_type)}"
     end
 
-    def handle_missing_entry(name)
-      raise Webpacker::Manifest::MissingEntryError, missing_file_from_manifest_error(name)
+    def handle_missing_entry(name, pack_type)
+      raise Webpacker::Manifest::MissingEntryError, missing_file_from_manifest_error(full_pack_name(name, pack_type[:type]))
     end
 
     def load


### PR DESCRIPTION
Webpack view helpers that indicate pack type in the method name, e.g.
`javascript_pack_tag`, `stylesheet_pack_tag`, support manifest lookup both
with or without the extension in the given file name. For example, given
an existing pack for application.js, all of the following manifest
lookups will succeed:

```
javascript_pack_tag "application"    # or
javascript_pack_tag "application.js"

stylesheet_pack_tag "application"    # or
stylesheet_pack_tag "application.css"
```

When the lookup does not succeed, a helpful error message is displayed.
However, if the ".js" extension is omitted from the helper method
invocation, the error message also omits the pack type. For example:

```
javascript_pack_tag "not-a-pack"
stylesheet_pack_tag "not-a-pack"
```
results in the following error message:

```
Webpacker can't find not-a-pack in
/path/to/app/public/packs/manifest.json
```

The ambiguity is confusing when using both view helpers: does this
indicate the server was looking for the javascript bundle or the
stylesheet?

This changeset resolves the ambiguity. We can leverage the existing support
in the manifest for determining the qualified pack name when printing the 
missing entry info.

Now, for a missing stylesheet such as:

```
stylesheet_pack_tag "not-a-pack"
```

the following error message is generated:

```
Webpacker can't find not-a-pack.css in
/path/to/app/public/packs/manifest.json
```

Also, adds some assertions and extracts a couple shared methods in
manifest_test.rb