### PR TITLE
Turn off hot reload for svelte

### DIFF
--- a/lib/install/loaders/svelte.js
+++ b/lib/install/loaders/svelte.js
@@ -3,7 +3,7 @@ module.exports = {
   use: [{
     loader: 'svelte-loader',
     options: {
-      hotReload: true
+      hotReload: false
     }
   }],
 }


### PR DESCRIPTION
Hot reload is not working for svelte 3 and webpack at the time of writing.

It causes `Cannot read property 'fragment' of undefined component`.
Turning it off solves the issue.

References:
https://github.com/sveltejs/svelte-loader#hot-reload
https://github.com/sveltejs/svelte-loader/issues/74#issuecomment-453949921
https://github.com/sveltejs/svelte/issues/2894#issuecomment-496634139