### PR TITLE
Update node-sass to 4.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "glob": "^7.1.6",
     "js-yaml": "^3.13.1",
     "mini-css-extract-plugin": "^0.8.0",
-    "node-sass": "^4.13.0",
+    "node-sass": "^4.13.1",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "path-complete-extname": "^1.0.0",
     "pnp-webpack-plugin": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5186,10 +5186,10 @@ node-releases@^1.1.38:
   dependencies:
     semver "^6.3.0"
 
-node-sass@^4.13.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.0.tgz#b647288babdd6a1cb726de4545516b31f90da066"
-  integrity sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==
+node-sass@^4.13.1:
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.1.tgz#9db5689696bb2eec2c32b98bfea4c7a2e992d0a3"
+  integrity sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"


### PR DESCRIPTION
Running `yarn audit` fails on vulnerable node-sass@^4.13.0.
Affected versions of node-sass are vulnerable to Denial of Service
(DoS). Crafted objects passed to the renderSync function may trigger C++
assertions.
More information: https://www.npmjs.com/advisories/961