### PR TITLE
Use zopfli for gzip compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@babel/plugin-transform-runtime": "^7.6.2",
     "@babel/preset-env": "^7.7.1",
     "@babel/runtime": "^7.7.2",
+    "@gfx/zopfli": "1.0.14",
     "babel-loader": "^8.0.6",
     "babel-plugin-dynamic-import-node": "^2.3.0",
     "babel-plugin-macros": "^2.6.1",

--- a/package/environments/production.js
+++ b/package/environments/production.js
@@ -2,6 +2,7 @@ const TerserPlugin = require('terser-webpack-plugin')
 const CompressionPlugin = require('compression-webpack-plugin')
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
 const safePostCssParser = require('postcss-safe-parser')
+const zopfli = require('@gfx/zopfli')
 const Base = require('./base')
 
 module.exports = class extends Base {
@@ -12,8 +13,9 @@ module.exports = class extends Base {
       'Compression',
       new CompressionPlugin({
         filename: '[path].gz[query]',
-        algorithm: 'gzip',
+        algorithm: zopfli.gzip,
         cache: true,
+        compressionOptions: { numiterations: 15 },
         test: /\.(js|css|html|json|ico|svg|eot|otf|ttf|map)$/
       })
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,6 +700,13 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@gfx/zopfli@1.0.14":
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/@gfx/zopfli/-/zopfli-1.0.14.tgz#52319e9bce0482f03ff02845e13fd95bb0ec7152"
+  integrity sha512-3BuC4gWCvNz5fd2VdVSOQegtv1lTGT8DUTuqvE6M16uAjgBod+vhHCXTlKMtZA4s2+z3IDAgQm/k3RkhYNodiA==
+  dependencies:
+    base64-js "^1.3.0"
+
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"
@@ -1441,7 +1448,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==


### PR DESCRIPTION
Zopfli is a compression by Google. It produces files compatible with gzip, but the compression time is much higher. That makes it ideal for asset pre-compilation. The idea (and as far as I know - the implementation too) is similar to Brotli, but with backwards compatibility to gzip and slightly lower compression ratios.

The implementation I suggest drops node's gzip and replaces it with [@gfx/zopfli](https://www.npmjs.com/package/@gfx/zopfli). This implementation of zopfli uses web assembly and is portable (so no native components and compilation). It runs on Node 8+. I could provide a gzip fallback for older node versions, but that doesn't seem necessary as [the requirements of webpacker cover that](https://github.com/rails/webpacker/blob/c7292e9/package.json#L11).

Here are size comparisons for files from a real-life project I work on:

<table>
  <tr>
    <th>Uncompressed</td>
    <th>GZip</td>
    <th>Zopfli</td>
    <th>Brotli</td>
  </tr>
  <tr>
    <td>890 KiB</td>
    <td>224 KiB</td>
    <td>216 KiB</td>
    <td>183 KiB</td>
  </tr>
  <tr>
    <td>1.74 MiB</td>
    <td>431 KiB</td>
    <td>416 KiB</td>
    <td>343 KiB</td>
  </tr>
  <tr>
    <td>716 KiB</td>
    <td>132 KiB</td>
    <td>126 KiB</td>
    <td>102 KiB</td>
  </tr>
</table>

Each line is a separate file. I've hidden the filenames as they are irrelevant. All files are **minified JavaScript**. I cannot provide size comparisons for CSS (or other formats) at the moment. But from previous experience I can confirm they are very similar.