### PR TITLE
Improve webpacker:clear task

### DIFF
--- a/lib/tasks/webpacker/clean.rake
+++ b/lib/tasks/webpacker/clean.rake
@@ -4,9 +4,9 @@ require "webpacker/configuration"
 
 namespace :webpacker do
   desc "Remove old compiled webpacks"
-  task :clean, [:keep] => ["webpacker:verify_install", :environment] do |_, args|
+  task :clean, [:keep, :age] => ["webpacker:verify_install", :environment] do |_, args|
     Webpacker.ensure_log_goes_to_stdout do
-      Webpacker.clean(Integer(args.keep || 2))
+      Webpacker.clean(Integer(args.keep || 2), Integer(args.age || 3600))
     end
   end
 end

--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -5,12 +5,34 @@ class Webpacker::Commands
     @webpacker = webpacker
   end
 
-  def clean(count = 2)
-    if config.public_output_path.exist? && config.public_manifest_path.exist? && versions.count > count
-      versions.drop(count).flat_map(&:last).each do |file|
-        File.delete(file) if File.file?(file)
-        logger.info "Removed #{file}"
-      end
+  # Cleanup old assets in the compile directory. By default it will
+  # keep the latest version, 2 backups created within the past hour.
+  #
+  # Examples
+  #
+  #   To force only 1 backup to be kept, set count=1 and age=0.
+  #
+  #   To only keep files created within the last 10 minutes, set count=0 and
+  #   age=600.
+  #
+  def clean(count = 2, age = 3600)
+    if config.public_output_path.exist? && config.public_manifest_path.exist?
+      versions
+        .sort
+        .reverse
+        .each_with_index
+        .drop_while do |(mtime, _), index|
+          max_age = [0, Time.now - Time.at(mtime)].max
+          max_age < age && index < count
+        end
+        .each do |(_, files), index|
+          files.each do |file|
+            if File.file?(file)
+              File.delete(file)
+              logger.info "Removed #{file}"
+            end
+          end
+        end
     end
 
     true
@@ -37,14 +59,16 @@ class Webpacker::Commands
       manifest_config = Dir.glob("#{config.public_manifest_path}*")
 
       packs = all_files - manifest_config - current_version
-      packs.group_by { |file| File.mtime(file).utc.to_i }.sort.reverse
+      packs.reject { |file| File.directory?(file) }.group_by { |file| File.mtime(file).utc.to_i }
     end
 
     def current_version
-      manifest.refresh.values.map do |value|
+      packs = manifest.refresh.values.map do |value|
         next if value.is_a?(Hash)
 
-        File.join(config.root_path, "public", value)
+        File.join(config.root_path, "public", "#{value}*")
       end.compact
+
+      Dir.glob(packs).uniq
     end
 end


### PR DESCRIPTION
Fixes: https://github.com/rails/webpacker/issues/2441

By default it will keep the latest version, 2 backups created within the past hour (same as sprockets). To force only 1 backup to be kept, set `count=1` and `age=0`. To only keep files created within the last 10 minutes, set `count=0` and `age=600`.

```bash
bundle exec rails "webpacker:clean[1, 0]"
bundle exec rails "webpacker:clean[0, 10]"
bundle exec rails webpacker:clean
```
  