### PR TITLE
Fix package.json engine semver ranges (node.js >=8.9 <13, yarn >=1 <2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "engines": {
     "node": ">=8.9.0",
-    "yarn": ">=1.0.0"
+    "yarn": ">=1 <2"
   },
   "dependencies": {
     "@babel/core": "^7.7.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib/install/config/webpacker.yml"
   ],
   "engines": {
-    "node": ">=8.16.0",
+    "node": ">=8.9.0",
     "yarn": ">=1.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib/install/config/webpacker.yml"
   ],
   "engines": {
-    "node": ">=8.9.0",
+    "node": ">=8.9 <13",
     "yarn": ">=1 <2"
   },
   "dependencies": {


### PR DESCRIPTION
8.16 is somewhat arbitrary as far as I can tell, so this allows earlier 8.x releases of node.js as the engine so that 8.9, 8.10, 8.12, etc from Ubuntu 18.04 LTS can install this package.

See #2228 comments for interest.