### PR TITLE
Allow other Webpacker rake tasks to be conditionally skipped

### DIFF
--- a/lib/tasks/webpacker/clean.rake
+++ b/lib/tasks/webpacker/clean.rake
@@ -11,11 +11,15 @@ namespace :webpacker do
   end
 end
 
-# Run clean if the assets:clean is run
-if Rake::Task.task_defined?("assets:clean")
-  Rake::Task["assets:clean"].enhance do
-    Rake::Task["webpacker:clean"].invoke
+skip_webpacker_clean = %w(no false n f).include?(ENV["WEBPACKER_PRECOMPILE"])
+
+unless skip_webpacker_clean
+  # Run clean if the assets:clean is run
+  if Rake::Task.task_defined?("assets:clean")
+    Rake::Task["assets:clean"].enhance do
+      Rake::Task["webpacker:clean"].invoke
+    end
+  else
+    Rake::Task.define_task("assets:clean" => "webpacker:clean")
   end
-else
-  Rake::Task.define_task("assets:clean" => "webpacker:clean")
 end

--- a/lib/tasks/webpacker/clobber.rake
+++ b/lib/tasks/webpacker/clobber.rake
@@ -8,9 +8,13 @@ namespace :webpacker do
   end
 end
 
-# Run clobber if the assets:clobber is run
-if Rake::Task.task_defined?("assets:clobber")
-  Rake::Task["assets:clobber"].enhance do
-    Rake::Task["webpacker:clobber"].invoke
+skip_webpacker_clobber = %w(no false n f).include?(ENV["WEBPACKER_PRECOMPILE"])
+
+unless skip_webpacker_clobber
+  # Run clobber if the assets:clobber is run
+  if Rake::Task.task_defined?("assets:clobber")
+    Rake::Task["assets:clobber"].enhance do
+      Rake::Task["webpacker:clobber"].invoke
+    end
   end
 end


### PR DESCRIPTION
Passing the `WEBPACKER_PRECOMPILE` env variable allows Webpacker-specific tasks to be skipped when running `rake assets:precompile`. I'd like to propose the same option be supported for the other tasks that Webpacker enhances (`clean` and `clobber`), for consistency.

Given that `precompile` can be skipped, I think it makes sense to allow users to skip the other asset management tasks, given that they're often used in concert. For example, it's common to run `rake assets:clean assets:precompile` during a build step.