### PR TITLE
Add test for check_node, check_yarn tasks

### DIFF
--- a/test/rake_tasks_test.rb
+++ b/test/rake_tasks_test.rb
@@ -52,6 +52,16 @@ class RakeTasksTest < Minitest::Test
                     "Expected only production dependencies to be installed"
   end
 
+  def test_check_node_version
+    output = Dir.chdir(test_app_path) { `rake webpacker:check_node 2>&1` }
+    assert_empty output
+  end
+
+  def test_check_yarn_version
+    output = Dir.chdir(test_app_path) { `rake webpacker:check_yarn 2>&1` }
+    assert_empty output
+  end
+
   private
     def test_app_path
       File.expand_path("test_app", __dir__)


### PR DESCRIPTION
## Purpose

A valid semver engine version could be an illformed gem requirement, which raising an exception during the parsing of this value from the package.json in either of these tasks. 

This caught me by surprise and I would have hoped the test suite would catch it, so I've added two tests—one for each of the `check_` rake tasks. See the failure in the build for more info.

## Approach

Add a test that fails when the engine version in package.json fails to parse in ruby.

