### PR TITLE
Feature: Add support for multiple files per entry

### DIFF
--- a/package/environments/__tests__/base.js
+++ b/package/environments/__tests__/base.js
@@ -29,6 +29,16 @@ describe('Environment', () => {
       )
     })
 
+    test('should return multi file entry points', () => {
+      const config = environment.toWebpackConfig()
+      expect(config.entry.multi_entry.sort()).toEqual(
+          [
+            resolve('app', 'javascript', 'packs', 'multi_entry.css'),
+            resolve('app', 'javascript', 'packs', 'multi_entry.js')
+          ]
+      )
+    })
+
     test('should return output', () => {
       const config = environment.toWebpackConfig()
       expect(config.output.filename).toEqual('js/[name]-[contenthash].js')

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -72,7 +72,7 @@ const getEntryObject = () => {
     let previousPaths = result.get(name)
     if (previousPaths) {
       previousPaths = Array.isArray(previousPaths) ? previousPaths : [previousPaths]
-      previousPaths.append(assetPaths)
+      previousPaths.push(assetPaths)
       assetPaths = previousPaths
     }
 

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -65,11 +65,18 @@ const getEntryObject = () => {
   paths.forEach((path) => {
     const namespace = relative(join(rootPath), dirname(path))
     const name = join(namespace, basename(path, extname(path)))
+    let assetPaths = resolve(path)
 
     // Allows for multiple filetypes per entry (https://webpack.js.org/guides/entry-advanced/)
-    let resultList = result.get(name) || []
-    resultList.push(resolve(path))
-    result.set(name, resultList)
+    // Transforms the config object value to an array with all values under the same name
+    let previousPaths = result.get(name)
+    if(previousPaths){
+      previousPaths = Array.isArray(previousPaths) ? previousPaths : [previousPaths]
+      previousPaths.append(assetPaths)
+      assetPaths = previousPaths
+    }
+
+    result.set(name, assetPaths)
   })
   return result
 }

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -65,7 +65,11 @@ const getEntryObject = () => {
   paths.forEach((path) => {
     const namespace = relative(join(rootPath), dirname(path))
     const name = join(namespace, basename(path, extname(path)))
-    result.set(name, resolve(path))
+
+    // Allows for multiple filetypes per entry (https://webpack.js.org/guides/entry-advanced/)
+    let resultList = result.get(name) || []
+    resultList.push(resolve(path))
+    result.set(name, resultList)
   })
   return result
 }

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -70,7 +70,7 @@ const getEntryObject = () => {
     // Allows for multiple filetypes per entry (https://webpack.js.org/guides/entry-advanced/)
     // Transforms the config object value to an array with all values under the same name
     let previousPaths = result.get(name)
-    if(previousPaths){
+    if (previousPaths) {
       previousPaths = Array.isArray(previousPaths) ? previousPaths : [previousPaths]
       previousPaths.append(assetPaths)
       assetPaths = previousPaths

--- a/test/test_app/app/javascript/packs/multi_entry.css
+++ b/test/test_app/app/javascript/packs/multi_entry.css
@@ -1,0 +1,4 @@
+/*
+ * Dummy file #1 for Multi File Entry points: https://webpack.js.org/guides/entry-advanced/
+ * This file must be named the same
+ */

--- a/test/test_app/app/javascript/packs/multi_entry.js
+++ b/test/test_app/app/javascript/packs/multi_entry.js
@@ -1,0 +1,4 @@
+/*
+ * Dummy file #2 for Multi File Entry points: https://webpack.js.org/guides/entry-advanced/
+ * This file must be named the same
+ */


### PR DESCRIPTION
# Add support for multiple files per entry
## Summary
It is possible to provide different types of files when using an array of values for entry to achieve separate bundles for CSS and JavaScript (and other) files in applications that are not using import for styles in JavaScript (pre Single Page Applications or different reasons).

For additional info: https://webpack.js.org/guides/entry-advanced/

## Community Consideration

This is particularly useful if you are migrating from a per page
css/js organization as was common with rails <= 6

Note this has been a source of confusion and has been PR'd in the past as well. However no one pointed out this is a first class supported feature of webpack that is specifically built for static pages which rails does so well (see link above).

Here are just some of the PR/Issues from the past

- https://github.com/rails/webpacker/issues/185
- https://github.com/rails/webpacker/pull/198
- https://github.com/rails/webpacker/issues/581

## PR changes

Seamlessly (without breaking support for the original single file per entry model) extends the entryPoint algo to extend entrypoints with multiple files when they are found.

So that you can get something like this 
```
  'views/store/static/home': [
    '[redacted]/packs/views/store/static/home.js',
    '[redacted]/packs/views/store/static/home.scss'
  ]
```
and get a single pack with page specific js and css.


This is an updated PR originally from: https://github.com/rails/webpacker/pull/2213, made a mistake of issuing the PR from our master branch. Updated base to include 4.2.2 commits