### PR TITLE
Add possibility to add version to filenames

### DIFF
--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -8,6 +8,7 @@ default: &default
   cache_path: tmp/cache/webpacker
   check_yarn_integrity: false
   webpack_compile_output: true
+  version: 1.0
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -36,8 +36,8 @@ const getPluginList = () => {
   result.append(
     'MiniCssExtract',
     new MiniCssExtractPlugin({
-      filename: 'css/[name]-[contenthash:8].css',
-      chunkFilename: 'css/[name]-[contenthash:8].chunk.css'
+      filename: `css/[name]-[contenthash:8]-${config.version}.css`,
+      chunkFilename: `css/[name]-[contenthash:8]-${config.version}.chunk.css`
     })
   )
   result.append(
@@ -83,8 +83,8 @@ const getModulePaths = () => {
 const getBaseConfig = () => new ConfigObject({
   mode: 'production',
   output: {
-    filename: 'js/[name]-[contenthash].js',
-    chunkFilename: 'js/[name]-[contenthash].chunk.js',
+    filename: `js/[name]-[contenthash]-${config.version}.js`,
+    chunkFilename: `js/[name]-[contenthash]-${config.version}.chunk.js`,
     hotUpdateChunkFilename: 'js/[id]-[hash].hot-update.js',
     path: config.outputPath,
     publicPath: config.publicPath

--- a/package/rules/file.js
+++ b/package/rules/file.js
@@ -1,5 +1,5 @@
 const { join } = require('path')
-const { source_path: sourcePath, static_assets_extensions: fileExtensions } = require('../config')
+const { source_path: sourcePath, static_assets_extensions: fileExtensions, version: version } = require('../config')
 
 module.exports = {
   test: new RegExp(`(${fileExtensions.join('|')})$`, 'i'),
@@ -9,9 +9,9 @@ module.exports = {
       options: {
         name(file) {
           if (file.includes(sourcePath)) {
-            return 'media/[path][name]-[hash].[ext]'
+            return `media/[path][name]-[hash]-${version}.[ext]`
           }
-          return 'media/[folder]/[name]-[hash:8].[ext]'
+          return `media/[folder]/[name]-[hash:8]-${version}.[ext]`
         },
         context: join(sourcePath)
       }


### PR DESCRIPTION
With sprockets / asset pipeline there was a version / prefix config which can be helpful when the asset content hasn't changed, but you want to change the response headers served with the asset, but those headers are cached somewhere like a CDN or user's browser.

This is a very naive approach to introduce a version into the config as it always adds the version even if it does not exist. Please let me know if this feature would be accepted and I'm happy to adapt.