### PR TITLE
Syntax error if left as string.

### DIFF
--- a/docs/engines.md
+++ b/docs/engines.md
@@ -203,7 +203,7 @@ or if you prefer to keep your engine-related configuration within the engine its
 module MyEngine
   class Engine < ::Rails:Engine
     config.app_middleware.use(
-      "Rack::Static",
+      Rack::Static,
       urls: ["/my-engine-packs"], root: "my_engine/public"
     )
   end


### PR DESCRIPTION
When I ran `rails webpacker:install`, it complained about this being a string. So I just removed the quotes, and everything worked.