### PR TITLE
Fix incorrect host forwarding

### DIFF
--- a/lib/webpacker/dev_server_proxy.rb
+++ b/lib/webpacker/dev_server_proxy.rb
@@ -11,7 +11,9 @@ class Webpacker::DevServerProxy < Rack::Proxy
 
   def perform_request(env)
     if env["PATH_INFO"].start_with?("/#{public_output_uri_path}") && dev_server.running?
-      env["HTTP_HOST"] = env["HTTP_X_FORWARDED_HOST"] = env["HTTP_X_FORWARDED_SERVER"] = dev_server.host_with_port
+      env["HTTP_HOST"] = env["HTTP_X_FORWARDED_HOST"] = dev_server.host
+      env["HTTP_X_FORWARDED_SERVER"] = dev_server.host_with_port
+      env["HTTP_PORT"] = env["HTTP_X_FORWARDED_PORT"] = dev_server.port.to_s
       env["HTTP_X_FORWARDED_PROTO"] = env["HTTP_X_FORWARDED_SCHEME"] = dev_server.protocol
       unless dev_server.https?
         env["HTTPS"] = env["HTTP_X_FORWARDED_SSL"] = "off"


### PR DESCRIPTION
Hi!

`HTTP_X_FORWARDED_HOST` should not contain port because otherwise `Rack::Request` will add a default port causing an error like on the screenshot:
![Screenshot from 2020-03-28 01-52-06](https://user-images.githubusercontent.com/33480420/77809089-df2e9a00-7096-11ea-861a-28ae9ae90453.png)

So `HTTP_X_FORWARDED_PORT` should be also sent in order for `Rack::Request` to properly see it..
And casted to String explicitly to satisfy `Net::HTTPHeader`.

Useful when running webpack dev server as a separate service in Docker Compose like here for example:
https://github.com/olzv/rails-vue-template/pull/3/files