### PR TITLE
Remove yarn integrity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ Optional: To fix ["unmet peer dependency" warnings](https://github.com/rails/web
 yarn upgrade
 ```
 
+When `package.json` and/or `yarn.lock` changes, such as when pulling down changes to your local environemnt in a team settings, be sure to keep your NPM packages up-to-date:
+
+```bash
+yarn install
+```
+
 ### Usage
 
 Once installed, you can start writing modern ES6-flavored JavaScript apps right away:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ in which case you may not even need the asset pipeline. This is mostly relevant 
   - [Webpack Configuration](#webpack-configuration)
   - [Custom Rails environments](#custom-rails-environments)
   - [Upgrading](#upgrading)
-  - [Yarn Integrity](#yarn-integrity)
 - [Integrations](#integrations)
   - [React](./docs/integrations.md#react)
   - [Angular with TypeScript](./docs/integrations.md#angular-with-typescript)
@@ -298,26 +297,6 @@ yarn upgrade webpack-dev-server --latest
 
 # Or to install the latest release (including pre-releases)
 yarn add @rails/webpacker@next
-```
-
-### Yarn Integrity
-
-By default, in development, webpacker runs a yarn integrity check to ensure that all local JavaScript packages are up-to-date. This is similar to what bundler does currently in Rails, but for JavaScript packages. If your system is out of date, then Rails will not initialize. You will be asked to upgrade your local JavaScript packages by running `yarn install`.
-
-To turn off this option, you will need to change the default setting in `config/webpacker.yml`:
-
-```yaml
-# config/webpacker.yml
-development:
-  ...
-  # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
-  check_yarn_integrity: false
-```
-
-You may also turn on this feature by adding the config option for any Rails environment in `config/webpacker.yml`:
-
-```yaml
-check_yarn_integrity: true
 ```
 
 ## Integrations

--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ Webpacker::Compiler.watched_paths << 'bower_components'
 
 Webpacker hooks up a new `webpacker:compile` task to `assets:precompile`, which gets run whenever you run `assets:precompile`. If you are not using Sprockets, `webpacker:compile` is automatically aliased to `assets:precompile`. Similar to sprockets both rake tasks will compile packs in production mode but will use `RAILS_ENV` to load configuration from `config/webpacker.yml` (if available).
 
+When compiling assets for production on a remote server, such as a continuous integration environment, it's recommended to use `yarn install --frozen-lockfile` to install NPM packages on the remote host to ensure that the installed packages match the `yarn.lock` file.
+
 ## Docs
 
 - [Development](https://github.com/rails/webpacker#development)

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -6,7 +6,6 @@ default: &default
   public_root_path: public
   public_output_path: packs
   cache_path: tmp/cache/webpacker
-  check_yarn_integrity: false
   webpack_compile_output: true
 
   # Additional paths webpack should lookup modules
@@ -51,9 +50,6 @@ default: &default
 development:
   <<: *default
   compile: true
-
-  # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
-  check_yarn_integrity: true
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -64,11 +64,7 @@ class Webpacker::Configuration
   end
 
   def check_yarn_integrity=(value)
-    data[:check_yarn_integrity] = value
-  end
-
-  def check_yarn_integrity?
-    fetch(:check_yarn_integrity)
+    warn "Webpacker::Configuration#check_yarn_integrity=(value) has been deprecated. The integrity check has been removed from Webpacker so changing this setting will have no effect."
   end
 
   def webpack_compile_output?

--- a/lib/webpacker/railtie.rb
+++ b/lib/webpacker/railtie.rb
@@ -7,49 +7,6 @@ class Webpacker::Engine < ::Rails::Engine
   # Allows Webpacker config values to be set via Rails env config files
   config.webpacker = ActiveSupport::OrderedOptions.new
 
-  initializer "webpacker.set_configs" do |app|
-    if app.config.webpacker.key?(:check_yarn_integrity)
-      Webpacker.config.check_yarn_integrity = app.config.webpacker.check_yarn_integrity
-    end
-  end
-
-  # ================================
-  # Check Yarn Integrity Initializer
-  # ================================
-  #
-  # development (on by default):
-  #
-  #    to turn off:
-  #     - edit config/environments/development.rb
-  #     - add `config.webpacker.check_yarn_integrity = false`
-  #
-  # production (off by default):
-  #
-  #    to turn on:
-  #     - edit config/environments/production.rb
-  #     - add `config.webpacker.check_yarn_integrity = true`
-  initializer "webpacker.yarn_check" do |app|
-    if File.exist?("yarn.lock") && Webpacker.config.config_path.exist? && Webpacker.config.check_yarn_integrity?
-      output = `yarn check --integrity && yarn check --verify-tree 2>&1`
-
-      unless $?.success?
-        $stderr.puts "\n\n"
-        $stderr.puts "========================================"
-        $stderr.puts "  Your Yarn packages are out of date!"
-        $stderr.puts "  Please run `yarn install --check-files` to update."
-        $stderr.puts "========================================"
-        $stderr.puts "\n\n"
-        $stderr.puts "To disable this check, please change `check_yarn_integrity`"
-        $stderr.puts "to `false` in your webpacker config file (config/webpacker.yml)."
-        $stderr.puts "\n\n"
-        $stderr.puts output
-        $stderr.puts "\n\n"
-
-        exit(1)
-      end
-    end
-  end
-
   initializer "webpacker.proxy" do |app|
     insert_middleware = Webpacker.config.dev_server.present? rescue nil
     if insert_middleware

--- a/test/test_app/config/application.rb
+++ b/test/test_app/config/application.rb
@@ -6,7 +6,6 @@ module TestApp
   class Application < ::Rails::Application
     config.secret_key_base = "abcdef"
     config.eager_load = true
-    config.webpacker.check_yarn_integrity = false
     config.active_support.test_order = :sorted
   end
 end


### PR DESCRIPTION
## Problem

The yarn integrity check is often a cause of confusion and frustration for developers: #2517, #2322, #1568

That it is run in an initializer and potentially interferes with any Rails command that boots the environment is also surprising to many: #1135

Yarn's own maintainer discourages its use: https://github.com/yarnpkg/yarn/issues/6427#issuecomment-434499073

The `yarn check` command has also been removed from Yarn 2.0. 

## Solution

Remove the integrity initializer and the configuration options. Encourage developers to ensure `yarn install` in local environments and `yarn install --frozen-lockfile` as part of deployment.