### PR TITLE
Resolve multi-word snakecase WEBPACKER_DEV_SERVER env values

### DIFF
--- a/package/__tests__/dev_server.js
+++ b/package/__tests__/dev_server.js
@@ -13,11 +13,13 @@ describe('DevServer', () => {
     process.env.RAILS_ENV = 'development'
     process.env.WEBPACKER_DEV_SERVER_HOST = '0.0.0.0'
     process.env.WEBPACKER_DEV_SERVER_PORT = 5000
+    process.env.WEBPACKER_DEV_SERVER_DISABLE_HOST_CHECK = false
 
     const devServer = require('../dev_server')
     expect(devServer).toBeDefined()
     expect(devServer.host).toEqual('0.0.0.0')
     expect(devServer.port).toEqual('5000')
+    expect(devServer.disable_host_check).toBe(false)
   })
 
   test('with custom env prefix', () => {

--- a/package/dev_server.js
+++ b/package/dev_server.js
@@ -12,7 +12,7 @@ if (devServerConfig) {
   const envPrefix = config.dev_server.env_prefix || 'WEBPACKER_DEV_SERVER'
 
   Object.keys(devServerConfig).forEach((key) => {
-    const envValue = fetch(`${envPrefix}_${key.toUpperCase().replace(/_/g, '')}`)
+    const envValue = fetch(`${envPrefix}_${key.toUpperCase()}`)
     if (envValue !== undefined) devServerConfig[key] = envValue
   })
 }


### PR DESCRIPTION
Env values like WEBPACKER_DEV_SERVER_DISABLE_HOST_CHECK and
WEBPACKER_DEV_SERVER_USE_LOCAL_IP were not being read into the webpack
configuration because of the regex used to resolve the env var name.

This change [matches key resolution on the backend](https://github.com/rails/webpacker/blob/8e8e7454e3022fa01cae051fd537a82a9b4c9ebe/lib/webpacker/dev_server.rb#L60).