### PR TITLE
Update dotenv example in env.md

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -49,8 +49,6 @@ dotenvFiles.forEach((dotenvFile) => {
   dotenv.config({ path: dotenvFile, silent: true })
 })
 
-environment.plugins.prepend('Environment', new webpack.EnvironmentPlugin(JSON.parse(JSON.stringify(process.env))))
-
 module.exports = environment
 ```
 


### PR DESCRIPTION
Removes use of `EnvironmentPlugin` from the dotenv example in the docs.

The base webpack config already adds the `EnvironmentPlugin` with JSON-ified `process.env`: https://github.com/rails/webpacker/blob/a84a4bb6b385ae17dd775a6034a0b159b88c6ea9/package/environments/base.js#L31-L34