### PR TITLE
Allow configuration of the WEBPACKER_CONFIG via env

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -105,6 +105,7 @@ class Webpacker::Compiler
       return env unless defined?(ActionController::Base)
 
       env.merge("WEBPACKER_ASSET_HOST"        => ENV.fetch("WEBPACKER_ASSET_HOST", ActionController::Base.helpers.compute_asset_host),
-                "WEBPACKER_RELATIVE_URL_ROOT" => ENV.fetch("WEBPACKER_RELATIVE_URL_ROOT", ActionController::Base.relative_url_root))
+                "WEBPACKER_RELATIVE_URL_ROOT" => ENV.fetch("WEBPACKER_RELATIVE_URL_ROOT", ActionController::Base.relative_url_root),
+                "WEBPACKER_CONFIG" => webpacker.config_path)
     end
 end

--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -45,6 +45,7 @@ module Webpacker
 
       def execute_cmd
         env = Webpacker::Compiler.env
+        env.merge("WEBPACKER_CONFIG" => @webpacker_config)
 
         cmd = if node_modules_bin_exist?
           ["#{@node_modules_bin_path}/webpack-dev-server"]

--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -45,7 +45,7 @@ module Webpacker
 
       def execute_cmd
         env = Webpacker::Compiler.env
-        env["WEBPACKER_CONFIG"] = @webpacker_config
+        env.merge("WEBPACKER_CONFIG" => @webpacker_config)
 
         cmd = if node_modules_bin_exist?
           ["#{@node_modules_bin_path}/webpack-dev-server"]

--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -45,7 +45,7 @@ module Webpacker
 
       def execute_cmd
         env = Webpacker::Compiler.env
-        env.merge("WEBPACKER_CONFIG" => @webpacker_config)
+        env["WEBPACKER_CONFIG"] = @webpacker_config
 
         cmd = if node_modules_bin_exist?
           ["#{@node_modules_bin_path}/webpack-dev-server"]

--- a/lib/webpacker/runner.rb
+++ b/lib/webpacker/runner.rb
@@ -12,6 +12,7 @@ module Webpacker
       @app_path              = File.expand_path(".", Dir.pwd)
       @node_modules_bin_path = ENV["WEBPACKER_NODE_MODULES_BIN_PATH"] || `yarn bin`.chomp
       @webpack_config        = File.join(@app_path, "config/webpack/#{ENV["NODE_ENV"]}.js")
+      @webpacker_config      = File.join(@app_path, "config/webpacker.yml")
 
       unless File.exist?(@webpack_config)
         $stderr.puts "webpack config #{@webpack_config} not found, please run 'bundle exec rails webpacker:install' to install Webpacker with default configs or add the missing config file for your custom environment."

--- a/lib/webpacker/webpack_runner.rb
+++ b/lib/webpacker/webpack_runner.rb
@@ -5,7 +5,7 @@ module Webpacker
   class WebpackRunner < Webpacker::Runner
     def run
       env = Webpacker::Compiler.env
-
+      env.merge("WEBPACKER_CONFIG" => @webpacker_config)
       cmd = if node_modules_bin_exist?
         ["#{@node_modules_bin_path}/webpack"]
       else

--- a/lib/webpacker/webpack_runner.rb
+++ b/lib/webpacker/webpack_runner.rb
@@ -5,7 +5,7 @@ module Webpacker
   class WebpackRunner < Webpacker::Runner
     def run
       env = Webpacker::Compiler.env
-      env["WEBPACKER_CONFIG"] = @webpacker_config
+      env.merge("WEBPACKER_CONFIG" => @webpacker_config)
       cmd = if node_modules_bin_exist?
         ["#{@node_modules_bin_path}/webpack"]
       else

--- a/lib/webpacker/webpack_runner.rb
+++ b/lib/webpacker/webpack_runner.rb
@@ -5,7 +5,7 @@ module Webpacker
   class WebpackRunner < Webpacker::Runner
     def run
       env = Webpacker::Compiler.env
-      env.merge("WEBPACKER_CONFIG" => @webpacker_config)
+      env["WEBPACKER_CONFIG"] = @webpacker_config
       cmd = if node_modules_bin_exist?
         ["#{@node_modules_bin_path}/webpack"]
       else

--- a/lib/webpacker/webpack_runner.rb
+++ b/lib/webpacker/webpack_runner.rb
@@ -5,7 +5,8 @@ module Webpacker
   class WebpackRunner < Webpacker::Runner
     def run
       env = Webpacker::Compiler.env
-      env.merge("WEBPACKER_CONFIG" => @webpacker_config)
+      env["WEBPACKER_CONFIG"] = @webpacker_config
+
       cmd = if node_modules_bin_exist?
         ["#{@node_modules_bin_path}/webpack"]
       else

--- a/package/config.js
+++ b/package/config.js
@@ -4,9 +4,9 @@ const { readFileSync } = require('fs')
 const deepMerge = require('./utils/deep_merge')
 const { isArray, ensureTrailingSlash } = require('./utils/helpers')
 const { railsEnv } = require('./env')
+const configPath = require('./configPath')
 
 const defaultConfigPath = require.resolve('../lib/install/config/webpacker.yml')
-const configPath = resolve('config', 'webpacker.yml')
 
 const getDefaultConfig = () => {
   const defaultConfig = safeLoad(readFileSync(defaultConfigPath), 'utf8')

--- a/package/configPath.js
+++ b/package/configPath.js
@@ -1,0 +1,3 @@
+const { resolve } = require('path')
+
+export default process.env.WEBPACKER_CONFIG || resolve('config', 'webpacker.yml')

--- a/package/configPath.js
+++ b/package/configPath.js
@@ -1,3 +1,3 @@
 const { resolve } = require('path')
 
-export default process.env.WEBPACKER_CONFIG || resolve('config', 'webpacker.yml')
+module.exports = process.env.WEBPACKER_CONFIG || resolve('config', 'webpacker.yml')

--- a/package/env.js
+++ b/package/env.js
@@ -1,10 +1,9 @@
-const { resolve } = require('path')
 const { safeLoad } = require('js-yaml')
 const { readFileSync } = require('fs')
 
 const NODE_ENVIRONMENTS = ['development', 'production', 'test']
 const DEFAULT = 'production'
-const configPath = resolve('config', 'webpacker.yml')
+const configPath = require('./configPath')
 
 const railsEnv = process.env.RAILS_ENV
 const nodeEnv = process.env.NODE_ENV

--- a/test/dev_server_runner_test.rb
+++ b/test/dev_server_runner_test.rb
@@ -36,7 +36,7 @@ class DevServerRunnerTest < Webpacker::Test
       klass = Webpacker::DevServerRunner
       instance = klass.new([])
       mock = Minitest::Mock.new
-      mock.expect(:call, nil, [{}, *cmd])
+      mock.expect(:call, nil, [Webpacker::Compiler.env, *cmd])
 
       klass.stub(:new, instance) do
         instance.stub(:node_modules_bin_exist?, use_node_modules) do

--- a/test/webpack_runner_test.rb
+++ b/test/webpack_runner_test.rb
@@ -36,7 +36,7 @@ class WebpackRunnerTest < Webpacker::Test
       klass = Webpacker::WebpackRunner
       instance = klass.new([])
       mock = Minitest::Mock.new
-      mock.expect(:call, nil, [{}, *cmd])
+      mock.expect(:call, nil, [Webpacker::Compiler.env, *cmd])
 
       klass.stub(:new, instance) do
         instance.stub(:node_modules_bin_exist?, use_node_modules) do


### PR DESCRIPTION
If you're using the rails/webpacker node package from an installation
where the node_modules is a subdirectory of the main rails directory,
then the package has an error reading the main config/webpacker.yml.

This is because config.js and env.js assume (maybe incorrectly) that the
node_modules directory is at the top level of the rails project.

Instead, an installation may like the node_modules for the frontend or
client to be in a directory named as such.

This change sets the ENV value in the 3 places that webpack is called:

1. bin/webpack
2. bin/webpack-dev-server
3. compiler called from within the Rails code when the bundles are
   stale.