### PR TITLE
Remove integrity default setting from WebpackAssetsManifest

### DIFF
--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -43,7 +43,6 @@ const getPluginList = () => {
   result.append(
     'Manifest',
     new WebpackAssetsManifest({
-      integrity: false,
       entrypoints: true,
       writeToDisk: true,
       publicPath: config.publicPathWithoutCDN


### PR DESCRIPTION
WebpackAssetsManifest plugin have default setting for integrity is false. So If we don't pass this value while creating WebpackAssetsManifest plugin object then it will take default value.

So  for code cleanup I had removed this default setting already there in the WebpackAssetsManifest. 
https://github.com/rails/webpacker/blob/master/package/environments/base.js#L46

Here is the document
https://github.com/webdeveric/webpack-assets-manifest#integrity
https://github.com/webdeveric/webpack-assets-manifest/blob/master/src/WebpackAssetsManifest.js#L175
 