### PR TITLE
Update README to fix links to typescript info

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ in which case you may not even need the asset pipeline. This is mostly relevant 
   - [Elm](./docs/integrations.md#elm)
   - [Stimulus](./docs/integrations.md#stimulus)
   - [Svelte](./docs/integrations.md#svelte)
+  - [Typescript](./docs/typescript.md)
   - [CoffeeScript](./docs/integrations.md#coffeescript)
   - [Erb](./docs/integrations.md#erb)
 - [Paths](#paths)
@@ -318,7 +319,7 @@ Included install integrations:
 - [Svelte](./docs/integrations.md#Svelte)
 - [Stimulus](./docs/integrations.md#Stimulus)
 - [CoffeeScript](./docs/integrations.md#CoffeeScript)
-- [Typescript](./docs/integrations.md)
+- [Typescript](./docs/typescript.md)
 - [Erb](./docs/integrations.md#Erb)
 
 See [Integrations](./docs/integrations.md) for further details.


### PR DESCRIPTION
1. The Typescript link under integrations linked to `docs/integrations.md` which doesn't contain any info on typescript. I linked it to `docs/typescript.md` instead - but I could add a typescript section to `integrations.md` if preferred.

2. The TOC > Integrations section did not include typescript under Integrations, added