### PR TITLE
Fix implicit conversion of Pathname into String on compile

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -106,6 +106,6 @@ class Webpacker::Compiler
 
       env.merge("WEBPACKER_ASSET_HOST"        => ENV.fetch("WEBPACKER_ASSET_HOST", ActionController::Base.helpers.compute_asset_host),
                 "WEBPACKER_RELATIVE_URL_ROOT" => ENV.fetch("WEBPACKER_RELATIVE_URL_ROOT", ActionController::Base.relative_url_root),
-                "WEBPACKER_CONFIG" => webpacker.config_path)
+                "WEBPACKER_CONFIG" => webpacker.config_path.to_s)
     end
 end

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -40,6 +40,10 @@ class CompilerTest < Minitest::Test
     assert !Webpacker.compiler.fresh?
   end
 
+  def test_compile
+    assert !Webpacker.compiler.compile
+  end
+
   def test_freshness_on_compile_success
     status = OpenStruct.new(success?: true)
 


### PR DESCRIPTION
Fixes an issue with the recent master when running integration tests in a rails app.
```
ActionView::Template::Error: no implicit conversion of Pathname into String
    /Users/jan/.rbenv/versions/2.7.1/lib/ruby/2.7.0/open3.rb:213:in `spawn'
    /Users/jan/.rbenv/versions/2.7.1/lib/ruby/2.7.0/open3.rb:213:in `popen_run'
    /Users/jan/.rbenv/versions/2.7.1/lib/ruby/2.7.0/open3.rb:101:in `popen3'
    /Users/jan/.rbenv/versions/2.7.1/lib/ruby/2.7.0/open3.rb:281:in `capture3'
    /Users/jan/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/webpacker-ce0133d1948d/lib/webpacker/compiler.rb:70:in `run_webpack'
    /Users/jan/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/webpacker-ce0133d1948d/lib/webpacker/compiler.rb:23:in `compile'
```