### PR TITLE
New line character in check node and yarn

### DIFF
--- a/lib/tasks/webpacker/check_node.rake
+++ b/lib/tasks/webpacker/check_node.rake
@@ -3,7 +3,7 @@ namespace :webpacker do
   desc "Verifies if Node.js is installed"
   task :check_node do
     begin
-      node_version = `node -v || nodejs -v`
+      node_version = `node -v || nodejs -v`.strip
       raise Errno::ENOENT if node_version.blank?
 
       pkg_path = Pathname.new("#{__dir__}/../../../package.json").realpath

--- a/lib/tasks/webpacker/check_yarn.rake
+++ b/lib/tasks/webpacker/check_yarn.rake
@@ -3,7 +3,7 @@ namespace :webpacker do
   desc "Verifies if Yarn is installed"
   task :check_yarn do
     begin
-      yarn_version = `yarn --version`
+      yarn_version = `yarn --version`.strip
       raise Errno::ENOENT if yarn_version.blank?
 
       pkg_path = Pathname.new("#{__dir__}/../../../package.json").realpath


### PR DESCRIPTION
The `node -v`and `yarn --version`system calls in [check_node.rake](https://github.com/rails/webpacker/blob/master/lib/tasks/webpacker/check_node.rake#L6) and [check_yarn.rake](https://github.com/rails/webpacker/blob/master/lib/tasks/webpacker/check_yarn.rake#L6) might include a new line character, resulting in messages like
```
Warning: you are using an unstable release of Node.js (v13.12.0
). If you encounter issues with Node.js, consider switching to an Active LTS release. More info: https://docs.npmjs.com/try-the-latest-stable-version-of-node
```
and
```
This version of Webpacker does not support Yarn 1.22.4
. Please downgrade to a supported version of Yarn
```

This pull requests fixes that by stripping any extra characters in the returned value of the system call, so the message are printed in a single line.