### PR TITLE
Directly we used process.env instead of JSON.parse(JSON.stringify(process.env))

### DIFF
--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -30,7 +30,7 @@ const getPluginList = () => {
   const result = new ConfigList()
   result.append(
     'Environment',
-    new webpack.EnvironmentPlugin(JSON.parse(JSON.stringify(process.env)))
+    new webpack.EnvironmentPlugin(process.env)
   )
   result.append('CaseSensitivePaths', new CaseSensitivePathsPlugin())
   result.append(


### PR DESCRIPTION
"process.env" is returning the same value as "JSON.parse(JSON.stringify(process.env))"
So we dont need to stringify and parsing of process.env' in below line.
https://github.com/rails/webpacker/blob/master/package/environments/base.js#L33

new webpack.EnvironmentPlugin accepts either an array of keys or an object mapping its keys to their default values.
https://webpack.js.org/plugins/environment-plugin/

In Node JS 
process.env is returning an object
https://nodejs.org/dist/latest-v8.x/docs/api/process.html#process_process_env


```
C02XJPQGJG5H:webpacker smondal$ node
> process.env
{ MANPATH:
   '/Users/smondal/.nvm/versions/node/v11.8.0/share/man:/usr/local/share/man:/usr/share/man:/Library/Frameworks/Mono.framework/Versions/Current/share/man:/Library/Developer/CommandLineTools/usr/share/man',
  TERM_PROGRAM: 'Apple_Terminal',
 .....
  __CF_USER_TEXT_ENCODING: '0x1F6:0x0:0x0' }
```

```
> JSON.parse(JSON.stringify(process.env))
{ MANPATH:
   '/Users/smondal/.nvm/versions/node/v11.8.0/share/man:/usr/local/share/man:/usr/share/man:/Library/Frameworks/Mono.framework/Versions/Current/share/man:/Library/Developer/CommandLineTools/usr/share/man',
  TERM_PROGRAM: 'Apple_Terminal',
   .....
  __CF_USER_TEXT_ENCODING: '0x1F6:0x0:0x0' }

```



