### PR TITLE
Fix wrong path to docs/es6

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -91,7 +91,7 @@ You can read more about this in the [Vue docs](https://vuejs.org/v2/guide/instal
 
 ### Lazy loading integration
 
-See [docs/es6](docs/es6.md) to know more about Webpack and Webpacker configuration.
+See [docs/es6](es6.md) to know more about Webpack and Webpacker configuration.
 
 For instance, you can lazy load Vue JS components:
 


### PR DESCRIPTION
Hi. This is a very small fix.
I found a wrong path in [docs/integrations.md](https://github.com/rails/webpacker/blob/master/docs/integrations.md), so I fixed it.

```markdown
# Before
[docs/es6](docs/es6.md) to know more about Webpack ...
           ^^^^^
# After
[docs/es6](es6.md) to know more about Webpack ...
```
thanks :)