### PR TITLE
Fix chunks cleanup

### DIFF
--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -136,7 +136,7 @@ module.exports = class Base {
         // https://twitter.com/wSokra/status/969633336732905474
         splitChunks: {
           chunks: 'all',
-          name: false
+          name: true
         },
         // Separate runtime chunk to enable long term caching
         // https://twitter.com/wSokra/status/969679223278505985


### PR DESCRIPTION
Hello!
I've been using splitChunks feature:
```
// config/webpack/environment.js

// Enable the default config
environment.splitChunks()
```
but I've noticed that sometimes my builds weren't passing on CI. The reason of that was missing chunk file with node_modules. After quick investigation I noticed that `webpacker:clean` task removed my chunk even if it was still in use (but it was compiled more than 1 hour ago).  It's happening because `webpack-assets-manifest` plugin doesn't put unnamed chunks into the manifest and `webpacker:clean` task implementation is using manifest to determine which files are used or not. To fix that I changed the config to:

```
environment.splitChunks((config) => Object.assign({}, config, { optimization: { splitChunks: { chunks: 'all', name: true } }}))
```

Now my chunks are present in manifest and they are not being removed. I think it would be good to enable this by default to avoid such problems for future users. 