### PR TITLE
Change WEBPACKER_DEV_SERVER_HOST to 0.0.0.0

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -58,7 +58,7 @@ then add the webpacker host name environment variable to the web/app service:
     ports:
       - "3000:3000"
     environment:
-      - WEBPACKER_DEV_SERVER_HOST=webpacker
+      - WEBPACKER_DEV_SERVER_HOST=0.0.0.0
 ```
 
 Lastly, rebuild your container:


### PR DESCRIPTION
Setting `WEBPACKER_DEV_SERVER_HOST=webpacker` does not allow Docker to see changes from Webpacker.

When changing `WEBPACKER_DEV_SERVER_HOST=0.0.0.0` everything runs as intended.