### PR TITLE
Forward ARGV to webpack-dev-server command

### DIFF
--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -59,6 +59,7 @@ module Webpacker
 
         cmd += ["--config", @webpack_config]
         cmd += ["--progress", "--color"] if @pretty
+        cmd += @argv
 
         Dir.chdir(@app_path) do
           Kernel.exec env, *cmd

--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -7,12 +7,24 @@ require "webpacker/runner"
 module Webpacker
   class DevServerRunner < Webpacker::Runner
     def run
+      detect_unsupported_switches!
       load_config
       detect_port!
       execute_cmd
     end
 
     private
+
+      UNSUPPORTED_SWITCHES = %w[--host --port --https]
+      private_constant :UNSUPPORTED_SWITCHES
+      def detect_unsupported_switches!
+        unsupported_switches = UNSUPPORTED_SWITCHES & @argv
+        if unsupported_switches.any?
+          $stdout.puts "The following CLI switches are not supported by Webpacker: #{unsupported_switches.join(' ')}. Please edit your command and try again."
+          exit!
+        end
+      end
+
       def load_config
         app_root = Pathname.new(@app_path)
 

--- a/test/dev_server_runner_test.rb
+++ b/test/dev_server_runner_test.rb
@@ -24,23 +24,29 @@ class DevServerRunnerTest < Webpacker::Test
     verify_command(cmd, use_node_modules: false)
   end
 
+  def test_run_cmd_argv
+    cmd = ["#{test_app_path}/node_modules/.bin/webpack-dev-server", "--config", "#{test_app_path}/config/webpack/development.js", "--quiet"]
+
+    verify_command(cmd, argv: ["--quiet"])
+  end
+
   private
     def test_app_path
       File.expand_path("test_app", __dir__)
     end
 
-    def verify_command(cmd, use_node_modules: true)
+    def verify_command(cmd, use_node_modules: true, argv: [])
       cwd = Dir.pwd
       Dir.chdir(test_app_path)
 
       klass = Webpacker::DevServerRunner
-      instance = klass.new([])
+      instance = klass.new(argv)
       mock = Minitest::Mock.new
       mock.expect(:call, nil, [Webpacker::Compiler.env, *cmd])
 
       klass.stub(:new, instance) do
         instance.stub(:node_modules_bin_exist?, use_node_modules) do
-          Kernel.stub(:exec, mock) { klass.run([]) }
+          Kernel.stub(:exec, mock) { klass.run(argv) }
         end
       end
 

--- a/test/webpack_runner_test.rb
+++ b/test/webpack_runner_test.rb
@@ -24,23 +24,29 @@ class WebpackRunnerTest < Webpacker::Test
     verify_command(cmd, use_node_modules: false)
   end
 
+  def test_run_cmd_argv
+    cmd = ["#{test_app_path}/node_modules/.bin/webpack", "--config", "#{test_app_path}/config/webpack/development.js", "--watch"]
+
+    verify_command(cmd, argv: ["--watch"])
+  end
+
   private
     def test_app_path
       File.expand_path("test_app", __dir__)
     end
 
-    def verify_command(cmd, use_node_modules: true)
+    def verify_command(cmd, use_node_modules: true, argv: [])
       cwd = Dir.pwd
       Dir.chdir(test_app_path)
 
       klass = Webpacker::WebpackRunner
-      instance = klass.new([])
+      instance = klass.new(argv)
       mock = Minitest::Mock.new
       mock.expect(:call, nil, [Webpacker::Compiler.env, *cmd])
 
       klass.stub(:new, instance) do
         instance.stub(:node_modules_bin_exist?, use_node_modules) do
-          Kernel.stub(:exec, mock) { klass.run([]) }
+          Kernel.stub(:exec, mock) { klass.run(argv) }
         end
       end
 


### PR DESCRIPTION
The `webpack` command runner [forwards additional ARGV options to the underlying executable](https://github.com/rails/webpacker/blob/22ab02b7c84e917f985ecc76f5916d144f43bfbf/lib/webpacker/webpack_runner.rb#L21).

This PR brings parity to usage of the `webpack-dev-server` command runner. Example:

Before, options like the `--quiet` flag would be dropped; now they will be respected. 

`./bin/webpacker-dev-server --quiet`

Fixes #2000