### PR TITLE
Rename local variable in helper.rb

### DIFF
--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -51,8 +51,8 @@ module Webpacker::Helper
   #  <img srcset= "/packs/picture-2x-7cca48e6cae66ec07b8e.png 2x" src="/packs/picture-c38deda30895059837cf.png" >
   def image_pack_tag(name, **options)
     if options[:srcset] && !options[:srcset].is_a?(String)
-      options[:srcset] = options[:srcset].map do |name, size|
-        "#{resolve_path_to_image(name)} #{size}"
+      options[:srcset] = options[:srcset].map do |src_name, size|
+        "#{resolve_path_to_image(src_name)} #{size}"
       end.join(", ")
     end
 


### PR DESCRIPTION
When running the test suite, the following warning is printed:
```
/webpacker/lib/webpacker/helper.rb:54: warning: shadowing outer local variable - name
```

This PR address the warning by renaming the variable.