### PR TITLE
Feature: Change extract_css default to true in all environments

### DIFF
--- a/docs/webpack-dev-server.md
+++ b/docs/webpack-dev-server.md
@@ -17,7 +17,20 @@ Now if you refresh your Rails view everything should work as expected.
 ## HOT module replacement
 
 Webpacker out-of-the-box supports HMR with `webpack-dev-server` and
-you can toggle it by setting `dev_server/hmr` option inside `webpacker.yml`.
+you can toggle it by setting options in `config/webpacker.yml`:
+
+```yaml
+development:
+  # ...
+  extract_css: false
+  # ...
+  dev_server:
+    # ...
+    hmr: true
+    inline: true
+    # ...
+```
+`dev_server/hmr` option inside `webpacker.yml`.
 
 Checkout this guide for more information:
 

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -16,7 +16,7 @@ default: &default
   cache_manifest: false
 
   # Extract and emit a css file
-  extract_css: false
+  extract_css: true
 
   static_assets_extensions:
     - .jpg
@@ -51,6 +51,9 @@ development:
   <<: *default
   compile: true
 
+  # Set to false if using HMR for CSS
+  extract_css: true
+
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:
     https: false
@@ -84,9 +87,6 @@ production:
 
   # Production depends on precompilation of packs prior to booting for performance.
   compile: false
-
-  # Extract and emit a css file
-  extract_css: true
 
   # Cache manifest.json for performance
   cache_manifest: true

--- a/lib/install/javascript/packs/application.css
+++ b/lib/install/javascript/packs/application.css
@@ -1,0 +1,6 @@
+/* 
+Any CSS added to this file or imported from this file, e.g. `@import '../stylesheets/my-css.css'`,
+will be included in the "application" pack. Any CSS imported from application.js or as part of the 
+application.js dependency graph, e.g. `import '../stylesheets/my-css.css'` will also be included 
+in the "application" pack. 
+*/


### PR DESCRIPTION
## Problem

Dealing with CSS with Webpacker is a common issue. See the lengthy background in https://github.com/rails/webpacker/issues/2605 as one example for getting a local development running from rails new with webpacker. Another common issue is deployment; developers don't catch missing stylesheets locally as a result of `extract_css: false` until first deployment where `extract_css: true`, e.g., #2071.

## Solution

This changeset adds two key changes:

* Set `extract_css: true` by default for all environments
* Add an empty `app/javascript/packs/application.css` file on install. This ensures that adding `stylesheet_pack_tag "application"` to the layout does not raise an error if no styles have been otherwise imported from js.

I expect there to be some discussion around these changes as they are fairly impactful. The most important argument I can make is that these changes together **improve the out-of-the-box experience with Webpacker**. I believe this would prevent issues like #2605 and #2071. This sets up an experience that is more Sprockets-friendly to start. Developers can remove this file if not needed.

Fixes #2592
Fixes #2605

### Potential concerns

1. Does adding a separate file, `application.css`, add to the confusion? My change takes advantage of a new feature, https://github.com/rails/webpacker/pull/2476: as of Webpacker 5, files of the same canonical name and different extensions act as a single multi-file entrypoint. I think, is more "Sprockets-like". I'm not sure that this convention is well-known yet however and could be surprising to folks with more experience.
1. One change I did not make is inserting the corresponding `stylesheet_pack_tag "application"` tag in the application layout. I expected that would be a more drastic change, also deferring to the Rails default preference for Sprockets to compile CSS. Generally, developers are confused about how the Rails default straddles the fence between Sprockets and Webpacker, especially around CSS. My intent with this change is to ease the transition for developers who are new to webpack. I could see that it may add to confusion as well. I'm open to feedback on this.
1. I believe that the main reason for `extract_css: false` is to enable HMR for CSS in development. My expectation is that developers would prefer a setup that is less surprising out-of-the-box than one that is optimized for HMR. This PR means one extra file change to get HMR working. I believe this is an acceptable tradeoff. To make _that_ easier, I added an explicit entry for `extract_css` in the `development` section of `config/webpacker.yml`. 