### PR TITLE
`node_modules` should no longer be compiled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 **Please note that Webpacker 4.1.0 has an installer bug. Please use 4.2.0 or above**
 
+## [[6.0.0]](https://github.com/rails/webpacker/compare/v5.1.1...v6.0.0) - 2020-TBD
+
+- `node_modules` will no longer be compiled by default. This primarily fixes [rails issue #35501](https://github.com/rails/rails/issues/35501) as well as [numerous other webpacker issues](https://github.com/rails/webpacker/issues/2131#issuecomment-581618497). The disabled loader can still be required explicitly via:
+```js
+const nodeModules = require('@rails/webpacker/rules/node_modules.js')
+environment.loaders.append('nodeModules', nodeModules)
+```
+- If you have added `environment.loaders.delete('nodeModules')` to your `environment.js`, this must be removed or you will receive an error (`Item nodeModules not found`).
+
 ## [[5.1.1]](https://github.com/rails/webpacker/compare/v5.1.0...v5.1.1) - 2020-04-20
 
 - Update [TypeScript documentation](https://github.com/rails/webpacker/blob/master/docs/typescript.md) and installer to use babel-loader for typescript.[(#2541](https://github.com/rails/webpacker/pull/2541)

--- a/package/environments/__tests__/base.js
+++ b/package/environments/__tests__/base.js
@@ -50,12 +50,13 @@ describe('Environment', () => {
       const defaultRules = Object.keys(rules)
       const configRules = config.module.rules
 
-      expect(defaultRules.length).toEqual(7)
-      expect(configRules.length).toEqual(8)
+      expect(defaultRules.length).toEqual(6)
+      expect(configRules.length).toEqual(7)
     })
 
     test('should return cache path for nodeModules rule', () => {
-      const nodeModulesLoader = rules.nodeModules.use.find(rule => rule.loader === 'babel-loader')
+      const nodeModulesRule = require('../../rules/node_modules')
+      const nodeModulesLoader = nodeModulesRule.use.find(rule => rule.loader === 'babel-loader')
 
       expect(nodeModulesLoader.options.cacheDirectory).toBeTruthy()
     })

--- a/package/rules/index.js
+++ b/package/rules/index.js
@@ -4,7 +4,6 @@ const css = require('./css')
 const sass = require('./sass')
 const moduleCss = require('./module.css')
 const moduleSass = require('./module.sass')
-const nodeModules = require('./node_modules')
 
 // Webpack loaders are processed in reverse order
 // https://webpack.js.org/concepts/loaders/#loader-features
@@ -15,6 +14,5 @@ module.exports = {
   sass,
   moduleCss,
   moduleSass,
-  nodeModules,
   babel
 }


### PR DESCRIPTION
`node_modules` will no longer be compiled by default. This primarily fixes [rails issue #35501](https://github.com/rails/rails/issues/35501) as well as [numerous other webpacker issues](https://github.com/rails/webpacker/issues/2131#issuecomment-581618497). The disabled loader can still be required explicitly via:
```js
const nodeModules = require('@rails/webpacker/rules/node_modules.js')
environment.loaders.append('nodeModules', nodeModules)
```
If you have added `environment.loaders.delete('nodeModules')` to your `environment.js`, this must be removed or you will receive an error (`Item nodeModules not found`).


fixes https://github.com/rails/rails/issues/35501
fixes https://github.com/rails/webpacker/issues/2131
fixes https://github.com/rails/rails/issues/36278
fixes https://github.com/rails/webpacker/issues/2407
fixes https://github.com/rails/webpacker/issues/2114
fixes https://github.com/rails/webpacker/issues/1949
fixes https://github.com/rails/webpacker/issues/1865
fixes https://github.com/rails/webpacker/issues/1857