### PR TITLE
Update bin/webpack-dev-server with ENV value

### DIFF
--- a/lib/install/bin/webpack-dev-server
+++ b/lib/install/bin/webpack-dev-server
@@ -2,6 +2,7 @@
 
 ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
 ENV["NODE_ENV"]  ||= "development"
+ENV["WEBPACK_DEV_SERVER"] ||= "TRUE"
 
 require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",


### PR DESCRIPTION
Setting an ENV value allows one to easily setup up config/webpack/development.js so that it can build a separate client bundle separately from a server bundle. Only the client bundle should get sent to the webpack-dev-server.

Here is an example configuration that would use this env value.

## `config/webpack/development.js`
```js
process.env.NODE_ENV = process.env.NODE_ENV || "development";

const environment = require("./environment");
const merge = require("webpack-merge");

// Replace
// module.exports = environment.toWebpackConfig()

const clientConfig = environment.toWebpackConfig();

const serverConfig = merge(environment.toWebpackConfig(), {
  mode: "development",
  target: "web",
  entry: "./app/javascript/bundles/hello-world-bundle-server.js",
  output: {
    filename: "hello-world-bundle-server.js",
    path: environment.config.output.path,
    globalObject: "this",
  },
  optimization: {
    minimize: false,
  },
});

serverConfig.plugins = serverConfig.plugins.filter(
  (plugin) => plugin.constructor.name !== "WebpackAssetsManifest"
);

// For HMR, we need to separate the the client and server webpack configurations
if (process.env.WEBPACK_DEV_SERVER) {
  module.exports = clientConfig;
} else if (process.env.SERVER_BUNDLE_ONLY) {
  module.exports = serverConfig;
} else {
  module.exports = [clientConfig, serverConfig];
}
```