### PR TITLE
Update env.md documentation

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -49,6 +49,11 @@ dotenvFiles.forEach((dotenvFile) => {
   dotenv.config({ path: dotenvFile, silent: true })
 })
 
+environment.plugins.insert(
+  "Environment",
+  new webpack.EnvironmentPlugin(process.env)
+)
+
 module.exports = environment
 ```
 


### PR DESCRIPTION
While trying to get a clean Rails + Webpacker project going with `dotenv` I noticed that my environment variables weren't being picked up by webpack, even after following this doc. Adding these lines to my `environment.js` file fixes the issue.

While I think there's a plugin like this in the default plugins, I have the feeling that changes to `process.env` made by `dotenv` are not being picked up in that plugin, which is why I think we need to redefine the plugin after we call `dotenv.config`.