### PR TITLE
Update doc for TS to support fork-ts-checker-webpack-plugin 5.0

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -16,26 +16,37 @@ The default installation only transpiles your TypeScript code using Babel. If yo
 
 1. Install the Fork TS Checker Webpack Plugin
 
-```sh
-yarn add --dev fork-ts-checker-webpack-plugin
-```
+    ```sh
+    yarn add --dev fork-ts-checker-webpack-plugin
+    ```
 
 2. Then add it to your development environment config in `config/webpack/development.js`
 
-```js
-const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
-const path = require("path");
+    ```js
+    const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 
-environment.plugins.append(
-  "ForkTsCheckerWebpackPlugin",
-  new ForkTsCheckerWebpackPlugin({
-    // this is a relative path to your project's TypeScript config
-    tsconfig: path.resolve(__dirname, "../../tsconfig.json"),
-    // non-async so type checking will block compilation
-    async: false,
-  })
-);
-```
+    environment.plugins.append(
+      "ForkTsCheckerWebpackPlugin",
+      new ForkTsCheckerWebpackPlugin({ async: false }) // non-async so type checking will block compilation
+    );
+    ```
+
+    If you are `fork-ts-checker-webpack-plugin` older than 5.0, the `tsconfig` option also needs to be specified:
+
+    ```js
+    const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
+    const path = require("path");
+
+    environment.plugins.append(
+      "ForkTsCheckerWebpackPlugin",
+      new ForkTsCheckerWebpackPlugin({
+        // this is a relative path to your project's TypeScript config
+        tsconfig: path.resolve(__dirname, "../../tsconfig.json"),
+        // non-async so type checking will block compilation
+        async: false,
+      })
+    );
+    ```
 
 ## Upgrading to 5.1
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -24,6 +24,7 @@ The default installation only transpiles your TypeScript code using Babel. If yo
 
     ```js
     const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
+    const path = require("path");
 
     environment.plugins.append(
       "ForkTsCheckerWebpackPlugin",

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -27,7 +27,12 @@ The default installation only transpiles your TypeScript code using Babel. If yo
 
     environment.plugins.append(
       "ForkTsCheckerWebpackPlugin",
-      new ForkTsCheckerWebpackPlugin({ async: false }) // non-async so type checking will block compilation
+      new ForkTsCheckerWebpackPlugin({
+        typescript: {
+          tsconfig: path.resolve(__dirname, "../../tsconfig.json"),
+        },
+        async: false,
+      })
     );
     ```
 


### PR DESCRIPTION
[`fork-ts-checker-webpack-plugin` 5.0.0](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/releases/tag/v5.0.0) has been released 3 days ago and it has a few breaking changes. Basically I had to remove the `tsconfig` option from the existing setup:

```js
const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");

environment.plugins.append(
  "ForkTsCheckerWebpackPlugin",
  new ForkTsCheckerWebpackPlugin({ async: false }) // non-async so type checking will block compilation
);
```

cc @hueter 