### PR TITLE
Add `webpack_assets_path_tag` to apply application asset host to dynamic/lazy chunk source path

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -103,6 +103,8 @@ Now, you can set `brotli_static on;` in your nginx site config, as per the confi
 Webpacker out-of-the-box provides CDN support using your Rails app `config.action_controller.asset_host` setting. If you already have [CDN](http://guides.rubyonrails.org/asset_pipeline.html#cdns) added in your Rails app
 you don't need to do anything extra for Webpacker, it just works.
 
+Note: If you rely on dynamic/lazy chunk loading, you should either compile packs with static `WEBPACKER_ASSET_HOST` or use `webpack_assets_path_tag` to override chunk loading source in runtime.
+
 ## Capistrano
 
 ### Assets compiling on every deployment even if JavaScript and CSS files are not changed

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -163,6 +163,23 @@ module Webpacker::Helper
     end
   end
 
+  # Overrides Webpack public path in runtime to apply application asset host.
+  # That forces Webpack to take into account application asset host for dynamic/lazy chunk loading without a necessity
+  # to pre-build bundles with static `WEBPACKER_ASSET_HOST`.
+  #
+  # Examples:
+  #
+  #   # Should be used in `head` before any `*_pack*` helpers
+  #   <%= webpack_assets_path_tag %>
+  #
+  #   <%= javascript_pack_tag 'calendar', 'data-turbolinks-track': 'reload' %>
+  #   <%= stylesheet_pack_tag 'calendar', 'data-turbolinks-track': 'reload' %>
+  def webpack_assets_path_tag(html_options = {})
+    path = "#{compute_asset_host}/#{current_webpacker_instance.config.public_output_path.basename}/"
+
+    javascript_tag("__webpack_public_path__ = '#{path}';", html_options)
+  end
+
   private
     def stylesheet?(name)
       File.extname(name) == ".css"

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -11,6 +11,9 @@ class HelperTest < ActionView::TestCase
       def base_url
         "https://example.com"
       end
+      def protocol
+        "https://"
+      end
     end.new
   end
 
@@ -141,5 +144,37 @@ class HelperTest < ActionView::TestCase
       %(<link rel="stylesheet" media="all" href="/packs/bootstrap-c38deda30895059837cf.css" />\n) +
         %(<link rel="stylesheet" media="all" href="/packs/application-dd6b1cd38bfa093df600.css" />),
       stylesheet_pack_tag("bootstrap.css", "application.css", media: "all")
+  end
+
+  def test_webpack_assets_path_tag
+    assert_equal \
+      %(<script>\n) +
+        %(//<![CDATA[\n) +
+        %(__webpack_public_path__ = '/packs/';\n) +
+        %(//]]>\n) +
+        %(</script>),
+      webpack_assets_path_tag
+  end
+
+  def test_webpack_assets_path_tag_with_asset_host
+    config.stub :asset_host, "cdn.example.com" do
+      assert_equal \
+        %(<script>\n) +
+          %(//<![CDATA[\n) +
+          %(__webpack_public_path__ = 'https://cdn.example.com/packs/';\n) +
+          %(//]]>\n) +
+          %(</script>),
+        webpack_assets_path_tag
+    end
+  end
+
+  def test_webpack_assets_path_tag_with_html_options
+    assert_equal \
+      %(<script defer="defer">\n) +
+        %(//<![CDATA[\n) +
+        %(__webpack_public_path__ = '/packs/';\n) +
+        %(//]]>\n) +
+        %(</script>),
+      webpack_assets_path_tag(defer: "defer")
   end
 end


### PR DESCRIPTION
As pointed out in https://github.com/rails/webpacker/issues/2219#issuecomment-519291725, there was no way to put dynamic/lazy chunks behind the CDN without precompiling `WEBPACKER_ASSET_HOST`. This approach works if you're able to determine CDN host during the assets compilation stage, but in some cases, it's not possible.  For instance, when we run a dockerized application where a single Docker image is intended to be reused in multiple environments and installations.

The proposed changes allow overriding `__webpack_public_path__` in runtime and take into account Rails app `config.action_controller.asset_host` setting. Besides, this is a [convenient Webpack way](https://webpack.js.org/guides/public-path/#on-the-fly) to set Webpack's `publicPath` on the fly.

Sorry, I can't find your release policy. Should I backport this feature to Webpacker 4.x as well?