### PR TITLE
Only include dev-server parts if for dev server

### DIFF
--- a/package/__tests__/development.js
+++ b/package/__tests__/development.js
@@ -11,9 +11,10 @@ describe('Development environment', () => {
   describe('toWebpackConfig', () => {
     beforeEach(() => jest.resetModules())
 
-    test('should use development config and environment', () => {
+    test('should use development config and environment including devServer if WEBPACK_DEV_SERVER', () => {
       process.env.RAILS_ENV = 'development'
       process.env.NODE_ENV = 'development'
+      process.env.WEBPACK_DEV_SERVER = 'YES'
       const { environment } = require('../index')
 
       const config = environment.toWebpackConfig()
@@ -25,6 +26,18 @@ describe('Development environment', () => {
           port: 3035
         }
       })
+    })
+
+    test('should use development config and environment if WEBPACK_DEV_SERVER', () => {
+      process.env.RAILS_ENV = 'development'
+      process.env.NODE_ENV = 'development'
+      process.env.WEBPACK_DEV_SERVER = undefined
+      const { environment } = require('../index')
+
+      const config = environment.toWebpackConfig()
+      expect(config.output.path).toEqual(resolve('public', 'packs'))
+      expect(config.output.publicPath).toEqual('/packs/')
+      expect(config.devServer).toEqual(undefined)
     })
   })
 })

--- a/package/environments/development.js
+++ b/package/environments/development.js
@@ -12,7 +12,8 @@ module.exports = class extends Base {
       devtool: 'cheap-module-source-map'
     })
 
-    if (process.env.WEBPACK_DEV_SERVER) {
+    if (process.env.WEBPACK_DEV_SERVER
+        && process.env.WEBPACK_DEV_SERVER !== 'undefined') {
       if (devServer.hmr) {
         this.plugins.append('HotModuleReplacement', new webpack.HotModuleReplacementPlugin())
         this.config.output.filename = '[name]-[hash].js'

--- a/package/environments/development.js
+++ b/package/environments/development.js
@@ -7,41 +7,46 @@ module.exports = class extends Base {
   constructor() {
     super()
 
-    if (devServer.hmr) {
-      this.plugins.append('HotModuleReplacement', new webpack.HotModuleReplacementPlugin())
-      this.config.output.filename = '[name]-[hash].js'
-    }
-
     this.config.merge({
       mode: 'development',
-      devtool: 'cheap-module-source-map',
-      devServer: {
-        clientLogLevel: 'none',
-        compress: devServer.compress,
-        quiet: devServer.quiet,
-        disableHostCheck: devServer.disable_host_check,
-        host: devServer.host,
-        port: devServer.port,
-        https: devServer.https,
-        hot: devServer.hmr,
-        contentBase,
-        inline: devServer.inline,
-        useLocalIp: devServer.use_local_ip,
-        public: devServer.public,
-        publicPath,
-        historyApiFallback: {
-          disableDotRule: true
-        },
-        headers: devServer.headers,
-        overlay: devServer.overlay,
-        stats: {
-          entrypoints: false,
-          errorDetails: true,
-          modules: false,
-          moduleTrace: false
-        },
-        watchOptions: devServer.watch_options
-      }
+      devtool: 'cheap-module-source-map'
     })
+
+    if (process.env.WEBPACK_DEV_SERVER) {
+      if (devServer.hmr) {
+          this.plugins.append('HotModuleReplacement', new webpack.HotModuleReplacementPlugin())
+          this.config.output.filename = '[name]-[hash].js'
+      }
+
+      this.config.merge({
+        devServer: {
+          clientLogLevel: 'none',
+          compress: devServer.compress,
+          quiet: devServer.quiet,
+          disableHostCheck: devServer.disable_host_check,
+          host: devServer.host,
+          port: devServer.port,
+          https: devServer.https,
+          hot: devServer.hmr,
+          contentBase,
+          inline: devServer.inline,
+          useLocalIp: devServer.use_local_ip,
+          public: devServer.public,
+          publicPath,
+          historyApiFallback: {
+            disableDotRule: true
+          },
+          headers: devServer.headers,
+          overlay: devServer.overlay,
+          stats: {
+            entrypoints: false,
+            errorDetails: true,
+            modules: false,
+            moduleTrace: false
+          },
+          watchOptions: devServer.watch_options
+        }
+      })
+    }
   }
 }

--- a/package/environments/development.js
+++ b/package/environments/development.js
@@ -14,8 +14,8 @@ module.exports = class extends Base {
 
     if (process.env.WEBPACK_DEV_SERVER) {
       if (devServer.hmr) {
-          this.plugins.append('HotModuleReplacement', new webpack.HotModuleReplacementPlugin())
-          this.config.output.filename = '[name]-[hash].js'
+        this.plugins.append('HotModuleReplacement', new webpack.HotModuleReplacementPlugin())
+        this.config.output.filename = '[name]-[hash].js'
       }
 
       this.config.merge({


### PR DESCRIPTION
Without this change, webpack still includes things like window
in the build even if not using the webpack-dev-server.

When that happens, the bundle cannot be used for server-side rendering.