### PR TITLE
Only prepend the ruby runner if a ruby script

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -64,12 +64,18 @@ class Webpacker::Compiler
       compilation_digest_path.write(watched_files_digest)
     end
 
+    def optionalRubyRunner
+      bin_webpack_path = config.root_path.join("bin/webpack")
+      first_line = File.readlines(bin_webpack_path).first.chomp
+      /ruby/.match?(first_line) ? RbConfig.ruby : ""
+     end
+
     def run_webpack
       logger.info "Compiling..."
 
       stdout, stderr, status = Open3.capture3(
         webpack_env,
-        "#{RbConfig.ruby} ./bin/webpack",
+        "#{optionalRubyRunner} ./bin/webpack",
         chdir: File.expand_path(config.root_path)
       )
 


### PR DESCRIPTION
Check for the ruby shebang on the first line.

This allows a standard bash script instead.