### PR TITLE
Fixed how to specify `tsconfig.json` in TypeScript document.

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -30,7 +30,7 @@ The default installation only transpiles your TypeScript code using Babel. If yo
       "ForkTsCheckerWebpackPlugin",
       new ForkTsCheckerWebpackPlugin({
         typescript: {
-          tsconfig: path.resolve(__dirname, "../../tsconfig.json"),
+          configFile: path.resolve(__dirname, "../../tsconfig.json"),
         },
         async: false,
       })


### PR DESCRIPTION
Since `fork-ts-checker-webpack-plugin` version 5.0, the name has been changed to use the same name as `ts-loader` etc.

> ### TypeScript options
> Options for the TypeScript checker (`typescript` option object).
> | Name                 | Type      | Default value                                                                                                  | Description |
> | -------------------- | --------- | -------------------------------------------------------------------------------------------------------------- | ----------- |
> | `configFile`         | `string`  | `'tsconfig.json'`                                                                                              | Path to the > `tsconfig.json` file (path relative to the `compiler.options.context` or absolute path) |
> 
> https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/blob/v5.0.0/README.md#typescript-options

I fixed documentation to specify `tsconfig.json` by `configFile`. 

ref: https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/pull/436