### PR TITLE
Remove default from rules

### DIFF
--- a/package/environments/__tests__/base.js
+++ b/package/environments/__tests__/base.js
@@ -51,7 +51,7 @@ describe('Environment', () => {
       const configRules = config.module.rules
 
       expect(defaultRules.length).toEqual(6)
-      expect(configRules.length).toEqual(7)
+      expect(configRules.length).toEqual(6)
     })
 
     test('should return cache path for nodeModules rule', () => {

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -163,7 +163,7 @@ module.exports = class Base {
 
       module: {
         strictExportPresence: true,
-        rules: [{ parser: { requireEnsure: false } }, ...this.loaders.values()]
+        rules: this.loaders.values()
       },
 
       plugins: this.plugins.values(),


### PR DESCRIPTION
No need to add something that is already a default.

https://webpack.js.org/configuration/module/#ruleparser

Default is
requireEnsure: false, // disable require.ensure