### PR TITLE
Remove default value from transform-runtime

### DIFF
--- a/lib/install/config/babel.config.js
+++ b/lib/install/config/babel.config.js
@@ -48,9 +48,7 @@ module.exports = function(api) {
       [
         '@babel/plugin-transform-runtime',
         {
-          helpers: false,
-          regenerator: true,
-          corejs: false
+          helpers: false
         }
       ]
     ].filter(Boolean)


### PR DESCRIPTION
@babel/plugin-transform-runtime plugin following are the default value, If we don't need to pass these default value, it will take the default value. 
For code clean up I am removing this default settings.
regenerator -> true
corejs -> false

Here is the more information.
https://babeljs.io/docs/en/babel-plugin-transform-runtime#corejs
https://babeljs.io/docs/en/babel-plugin-transform-runtime#regenerator
https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-runtime/src/index.js#L20
