### PR TITLE
Fix file-loader compat issue in webpacker 5

### DIFF
--- a/package/rules/file.js
+++ b/package/rules/file.js
@@ -13,6 +13,7 @@ module.exports = {
           }
           return 'media/[folder]/[name]-[hash:8].[ext]'
         },
+        esModule: false,
         context: join(sourcePath)
       }
     }


### PR DESCRIPTION
Change file-loader `esModule` option to `false`

Resolve https://github.com/rails/webpacker/issues/2613

