### PR TITLE
Update babel.config.js

### DIFF
--- a/lib/install/config/babel.config.js
+++ b/lib/install/config/babel.config.js
@@ -1,4 +1,4 @@
-module.exports = function(api) {
+module.exports = function (api) {
   var validEnv = ['development', 'test', 'production']
   var currentEnv = api.env()
   var isDevelopmentEnv = api.env('development')


### PR DESCRIPTION
Prettier would add a space after function with no function name before the parens.