### PR TITLE
handle nils in additional_paths method (#2699)

### DIFF
--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -28,7 +28,7 @@ class Webpacker::Configuration
   end
 
   def additional_paths
-    fetch(:additional_paths) + resolved_paths
+    (fetch(:additional_paths) || []) + (resolved_paths || [])
   end
 
   def additional_paths_globbed

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -57,6 +57,25 @@ class ConfigurationTest < Webpacker::Test
     assert_equal @config.additional_paths, ["app/assets", "/etc/yarn", "app/elm"]
   end
 
+  def test_additional_paths_with_nil_additional_paths
+    @config = Webpacker::Configuration.new(
+      root_path: Pathname.new(File.expand_path("test_app", __dir__)),
+      config_path: Pathname.new(File.expand_path("./test_app/config/webpacker_with_nil_additional_paths.yml", __dir__)),
+      env: "production"
+    )
+    assert_equal @config.additional_paths, ["app/elm"]
+  end
+
+  def test_additional_paths_with_nil_resolved_paths
+    @config = Webpacker::Configuration.new(
+      root_path: Pathname.new(File.expand_path("test_app", __dir__)),
+      config_path: Pathname.new(File.expand_path("./test_app/config/webpacker_with_nil_resolved_paths.yml", __dir__)),
+      env: "production"
+    )
+
+    assert_equal @config.additional_paths, ["app/assets", "/etc/yarn"]
+  end
+
   def test_additional_paths_globbed
     assert_equal @config.additional_paths_globbed, [
       "app/assets/**/*{.mjs,.js,.sass,.scss,.css,.module.sass,.module.scss,.module.css,.png,.svg,.gif,.jpeg,.jpg,.elm}",

--- a/test/test_app/config/webpacker_with_nil_additional_paths.yml
+++ b/test/test_app/config/webpacker_with_nil_additional_paths.yml
@@ -1,0 +1,97 @@
+# Note: You must restart bin/webpack-dev-server for changes to take effect
+
+default: &default
+  source_path: app/javascript
+  source_entry_path: packs
+  public_root_path: public
+  public_output_path: packs
+  cache_path: tmp/cache/webpacker
+  webpack_compile_output: false
+
+  # This configuration option is deprecated and is only here for testing, to
+  # ensure backwards-compatibility. Please use `additional_paths`.
+  resolved_paths:
+    - app/elm
+
+  # Reload manifest.json on all requests so we reload latest compiled packs
+  cache_manifest: false
+
+  # Extract and emit a css file
+  extract_css: false
+
+  static_assets_extensions:
+    - .jpg
+    - .jpeg
+    - .png
+    - .gif
+    - .tiff
+    - .ico
+    - .svg
+
+  extensions:
+    - .mjs
+    - .js
+    - .sass
+    - .scss
+    - .css
+    - .module.sass
+    - .module.scss
+    - .module.css
+    - .png
+    - .svg
+    - .gif
+    - .jpeg
+    - .jpg
+    - .elm
+
+development:
+  <<: *default
+  compile: true
+
+  # Reference: https://webpack.js.org/configuration/dev-server/
+  dev_server:
+    https: false
+    host: localhost
+    port: 3035
+    public: localhost:3035
+    hmr: false
+    # Inline should be set to true if using HMR
+    inline: true
+    overlay: true
+    disable_host_check: true
+    use_local_ip: false
+    pretty: false
+
+test:
+  <<: *default
+  compile: true
+
+  # Compile test packs to a separate directory
+  public_output_path: packs-test
+
+production:
+  <<: *default
+
+  # Production depends on precompilation of packs prior to booting for performance.
+  compile: false
+
+  # Extract and emit a css file
+  extract_css: true
+
+  # Cache manifest.json for performance
+  cache_manifest: true
+
+staging:
+  <<: *default
+
+  # Production depends on precompilation of packs prior to booting for performance.
+  compile: false
+
+  # Extract and emit a css file
+  extract_css: true
+
+  # Cache manifest.json for performance
+  cache_manifest: true
+
+  # Compile staging packs to a separate directory
+  public_output_path: packs-staging

--- a/test/test_app/config/webpacker_with_nil_resolved_paths.yml
+++ b/test/test_app/config/webpacker_with_nil_resolved_paths.yml
@@ -1,0 +1,98 @@
+# Note: You must restart bin/webpack-dev-server for changes to take effect
+
+default: &default
+  source_path: app/javascript
+  source_entry_path: packs
+  public_root_path: public
+  public_output_path: packs
+  cache_path: tmp/cache/webpacker
+  webpack_compile_output: false
+
+  # Additional paths webpack should lookup modules
+  # ['app/assets', 'engine/foo/app/assets']
+  additional_paths:
+    - app/assets
+    - /etc/yarn
+
+  # Reload manifest.json on all requests so we reload latest compiled packs
+  cache_manifest: false
+
+  # Extract and emit a css file
+  extract_css: false
+
+  static_assets_extensions:
+    - .jpg
+    - .jpeg
+    - .png
+    - .gif
+    - .tiff
+    - .ico
+    - .svg
+
+  extensions:
+    - .mjs
+    - .js
+    - .sass
+    - .scss
+    - .css
+    - .module.sass
+    - .module.scss
+    - .module.css
+    - .png
+    - .svg
+    - .gif
+    - .jpeg
+    - .jpg
+    - .elm
+
+development:
+  <<: *default
+  compile: true
+
+  # Reference: https://webpack.js.org/configuration/dev-server/
+  dev_server:
+    https: false
+    host: localhost
+    port: 3035
+    public: localhost:3035
+    hmr: false
+    # Inline should be set to true if using HMR
+    inline: true
+    overlay: true
+    disable_host_check: true
+    use_local_ip: false
+    pretty: false
+
+test:
+  <<: *default
+  compile: true
+
+  # Compile test packs to a separate directory
+  public_output_path: packs-test
+
+production:
+  <<: *default
+
+  # Production depends on precompilation of packs prior to booting for performance.
+  compile: false
+
+  # Extract and emit a css file
+  extract_css: true
+
+  # Cache manifest.json for performance
+  cache_manifest: true
+
+staging:
+  <<: *default
+
+  # Production depends on precompilation of packs prior to booting for performance.
+  compile: false
+
+  # Extract and emit a css file
+  extract_css: true
+
+  # Cache manifest.json for performance
+  cache_manifest: true
+
+  # Compile staging packs to a separate directory
+  public_output_path: packs-staging


### PR DESCRIPTION
There is a failing test in master—it's not failing based on anything I did in this branch:

```
F

Failure:
RakeTasksTest#test_rake_tasks [/Users/brandon/Code/Ruby/webpacker/test/rake_tasks_test.rb:6]:
Expected "" to include "webpacker".
```

This is meant to resolve the problem described in https://github.com/rails/webpacker/issues/2706.

This is the first time I've used Minitest, so if there is anything you'd like me to do differently, please let me know.  I'm happy to adapt style or techniques.  