### PR TITLE
Change splitChunks() default: Use single runtime chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ environment.loaders.append('nodeModules', nodeModules)
 - If you have added `environment.loaders.delete('nodeModules')` to your `environment.js`, this must be removed or you will receive an error (`Item nodeModules not found`).
 - The install task will now set the `extract_css` default to `true` in all environments and generate a separate `application.css` file for the default `application` pack, as supported by multiple files per entry introduced in 5.0.0.  [#2608](https://github.com/rails/webpacker/pull/2608)
 
+- Webpacker's wrapper to the `splitChunks()` API will now default `runtimeChunk: 'single'` which will help prevent potential issues when using multiple entry points per page [#2708](https://github.com/rails/webpacker/pull/2708).
+
 ## [[5.1.1]](https://github.com/rails/webpacker/compare/v5.1.0...v5.1.1) - 2020-04-20
 
 - Update [TypeScript documentation](https://github.com/rails/webpacker/blob/master/docs/typescript.md) and installer to use babel-loader for typescript.[(#2541](https://github.com/rails/webpacker/pull/2541)
@@ -19,7 +21,7 @@ environment.loaders.append('nodeModules', nodeModules)
 ## [[5.1.0]](https://github.com/rails/webpacker/compare/v5.0.1...v5.1.0) - 2020-04-19
 
 - Remove yarn integrity check [#2518](https://github.com/rails/webpacker/pull/2518)
-- Switch from ts-loader to babel-loader [#2449](https://github.com/rails/webpacker/pull/2449)  
+- Switch from ts-loader to babel-loader [#2449](https://github.com/rails/webpacker/pull/2449)
   Please see the [TypeScript documentation](https://github.com/rails/webpacker/blob/master/docs/typescript.md) to upgrade existing projects to use typescript with 5.1
 - Resolve multi-word snakecase WEBPACKER_DEV_SERVER env values [#2528](https://github.com/rails/webpacker/pull/2528)
 

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -140,7 +140,11 @@ module.exports = class Base {
         },
         // Separate runtime chunk to enable long term caching
         // https://twitter.com/wSokra/status/969679223278505985
-        runtimeChunk: true
+        //
+        // optimization.runtimeChunk: 'single' is needed when
+        // multiple entry points are being used on a single HTML page.
+        // https://webpack.js.org/guides/code-splitting/#optimizationruntimechunk
+        runtimeChunk: 'single'
       }
     }
 


### PR DESCRIPTION
## Problem
[Webpacker docs for using the splitChunks() API describe a use case for using multiple entry points on a single page.](https://github.com/rails/webpacker/blob/master/docs/v4-upgrade.md#splitchunks-configuration) 

In these cases, _webpack encourages use of runtimeChunk 'single'_.

> optimization.runtimeChunk: 'single' is needed when multiple entry points are being used on a single HTML page.
>
> source: https://webpack.js.org/guides/code-splitting/#optimizationruntimechunk

In general, webpack discourages the use of multiple entry points per page:

> Using multiple entry points per page should be avoided when possible in favor of an entry point with multiple imports: entry: { page: ['./analytics', './app'] }.

Multiple entry points on a page can lead to surprising behavior, say from duplicated modules.

However, Rails developers seeking to keep their bundles small will be inclined to split their code into multiple packs, especially given prior experience with the Rails asset pipeline.

While documentation can be improved to encourage dynamic imports over multiple entry points as a form of code-splitting, it's reasonable to expect that Rails developers will continue to use multiple entry points per page.

## Solution
This PR sets `runtimeChunk: 'single'` as the default when splitChunks() is enabled to ensure modules across multiple entry points are properly shared.

I propose that this change will improve the "out-of-the-box" developer experience by preventing surprising bugs, i.e., keep Rails devs from shooting themselves in the foot.

The splitChunks optimization is confusing. It would be fair to expect that most developers would not be inclined to learn about its pros, cons, and caveats. Let's improve Webpacker's "conceptual compression" by fixing potential problems with the majority use case. "Pro" users will still be able to override the defaults to meet their needs.