### PR TITLE
Change @babel/preset-env modules to 'auto'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ environment.loaders.append('nodeModules', nodeModules)
 - If you have added `environment.loaders.delete('nodeModules')` to your `environment.js`, this must be removed or you will receive an error (`Item nodeModules not found`).
 - The install task will now set the `extract_css` default to `true` in all environments and generate a separate `application.css` file for the default `application` pack, as supported by multiple files per entry introduced in 5.0.0.  [#2608](https://github.com/rails/webpacker/pull/2608)
 
+- Changes `@babel/preset-env` modules option to `'auto'` per recommendation in the Babel docs [#2709](https://github.com/rails/webpacker/pull/2709)
+
 ## [[5.1.1]](https://github.com/rails/webpacker/compare/v5.1.0...v5.1.1) - 2020-04-20
 
 - Update [TypeScript documentation](https://github.com/rails/webpacker/blob/master/docs/typescript.md) and installer to use babel-loader for typescript.[(#2541](https://github.com/rails/webpacker/pull/2541)
@@ -19,7 +21,7 @@ environment.loaders.append('nodeModules', nodeModules)
 ## [[5.1.0]](https://github.com/rails/webpacker/compare/v5.0.1...v5.1.0) - 2020-04-19
 
 - Remove yarn integrity check [#2518](https://github.com/rails/webpacker/pull/2518)
-- Switch from ts-loader to babel-loader [#2449](https://github.com/rails/webpacker/pull/2449)  
+- Switch from ts-loader to babel-loader [#2449](https://github.com/rails/webpacker/pull/2449)
   Please see the [TypeScript documentation](https://github.com/rails/webpacker/blob/master/docs/typescript.md) to upgrade existing projects to use typescript with 5.1
 - Resolve multi-word snakecase WEBPACKER_DEV_SERVER env values [#2528](https://github.com/rails/webpacker/pull/2528)
 

--- a/package/babel/preset.js
+++ b/package/babel/preset.js
@@ -26,7 +26,7 @@ module.exports = function config(api) {
         {
           useBuiltIns: 'entry',
           corejs: 3,
-          modules: false,
+          modules: 'auto',
           bugfixes: true,
           loose: true,
           exclude: ['transform-typeof-symbol']


### PR DESCRIPTION
@babel/preset-env already defaults to `'auto'` and encourages its use when using babel with a bundler such as webpack.

According to babel docs (source: https://babeljs.io/docs/en/babel-preset-env#modules)

> Setting this to false will preserve ES modules. Use this only if you intend to ship native ES Modules to browsers. If you are using a bundler with Babel, the default modules: "auto" is always preferred.

I believe this would also be [consistent with create-react-app](https://github.com/facebook/create-react-app/blob/edfc30abf91c1081bee3e50358f981cf3c6e1b05/packages/babel-preset-react-app/create.js#L78-L89) which appears to use the default.

Given this info, I believe Webpacker should follow suit.