### PR TITLE
gives more description if compilation failed

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -81,6 +81,7 @@ class Webpacker::Compiler
           logger.info stdout
         end
       else
+        logger.error "Compilation process status: #{status}"
         non_empty_streams = [stdout, stderr].delete_if(&:empty?)
         logger.error "Compilation failed:\n#{non_empty_streams.join("\n\n")}"
       end


### PR DESCRIPTION
With the current messaging my compilation failed with no error. Everything what I saw was `Compilation failed:`. No error message.
The new line output said me `pid 13283 SIGKILL (signal 9)`. This helped to understand what was the reason to fail.