### PR TITLE
Add missing_entry_behavior configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ in which case you may not even need the asset pipeline. This is mostly relevant 
 - [Paths](#paths)
   - [Resolved](#resolved)
   - [Watched](#watched)
+- [Missing entry behavior](#missing-entry-behavior)
 - [Deployment](#deployment)
 - [Docs](#docs)
 - [Contributing](#contributing)
@@ -389,6 +390,17 @@ import 'images/rails.png'
 **Note:** Please be careful when adding paths here otherwise it
 will make the compilation slow, consider adding specific paths instead of
 whole parent directory if you just need to reference one or two modules
+
+## Missing entry behavior
+
+By default, Webpacker will raise `Webpacker::Manifest::MissingEntryError` on a try to render the missing module.
+You can change this if you like:
+
+```yml
+# config/webpacker.yml
+production:
+  missing_entry_behavior: log # Can be set to 'raise' (default), 'log' or 'silence'
+```
 
 ## Deployment
 

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -18,6 +18,9 @@ default: &default
   # Extract and emit a css file
   extract_css: true
 
+  # Raise error on missing module. Optionally it can be set to 'log' or 'silence'
+  missing_entry_behavior: raise
+
   static_assets_extensions:
     - .jpg
     - .jpeg

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -75,6 +75,10 @@ class Webpacker::Configuration
     fetch(:extract_css)
   end
 
+  def missing_entry_behavior
+    fetch(:missing_entry_behavior)
+  end
+
   private
     def resolved_paths
       paths = data.fetch(:resolved_paths, [])

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class ManifestTest < Minitest::Test
-  def test_lookup_exception!
+  def test_lookup_raised_error!
     asset_file = "calendar.js"
 
     error = assert_raises_manifest_missing_entry_error do
@@ -11,7 +11,7 @@ class ManifestTest < Minitest::Test
     assert_match "Webpacker can't find #{asset_file} in #{manifest_path}", error.message
   end
 
-  def test_lookup_with_type_exception!
+  def test_lookup_with_type_raised_error!
     asset_file = "calendar"
 
     error = assert_raises_manifest_missing_entry_error do
@@ -19,6 +19,26 @@ class ManifestTest < Minitest::Test
     end
 
     assert_match "Webpacker can't find #{asset_file}.js in #{manifest_path}", error.message
+  end
+
+  def test_lookup_logged_error!
+    asset_file = "calendar.js"
+
+    Webpacker.config.stub :compile?, false do
+      Webpacker.config.stub :missing_entry_behavior, "silence" do
+        assert_equal Webpacker.manifest.lookup!(asset_file), asset_file
+      end
+    end
+  end
+
+  def test_lookup_with_type_logged_error!
+    asset_file = "calendar"
+
+    Webpacker.config.stub :compile?, false do
+      Webpacker.config.stub :missing_entry_behavior, "silence" do
+        assert_equal Webpacker.manifest.lookup!(asset_file, type: :javascript), "#{asset_file}.js"
+      end
+    end
   end
 
   def test_lookup_success!


### PR DESCRIPTION
Introduces `missing_entry_behavior` setting to be set within `webpacker.yml`.
It behaves like [ActiveSupport::Deprecation.behavior](https://api.rubyonrails.org/classes/ActiveSupport/Deprecation/Behavior.html) and provides the options:

* 'raise' - default value keeping the existing behavior, raises the exception on a try to render the missing bundle;
* 'log' - warns the logger instead of raising the exception, `lookup!` method will return the name of bundle;
* 'silence' - does nothing more than returning the name of bundle as a result of `lookup!`.

Why do we need this:

1) `log` option can be useful for production environment;
2) `silence` option looks suitable for some test environments.

For instance, `silence` option  in combination with `compile: false` saves for us up to 2 minutes per every single CI build. We still keep the compilation tested by dedicated CI step for sure )