### PR TITLE
Fix cross-platform issue when loading nested files

### DIFF
--- a/package/rules/file.js
+++ b/package/rules/file.js
@@ -1,4 +1,4 @@
-const { join } = require('path')
+const { join, normalize } = require('path')
 const { source_path: sourcePath, static_assets_extensions: fileExtensions } = require('../config')
 
 module.exports = {
@@ -8,7 +8,7 @@ module.exports = {
       loader: 'file-loader',
       options: {
         name(file) {
-          if (file.includes(sourcePath)) {
+          if (file.includes(normalize(sourcePath))) {
             return 'media/[path][name]-[hash].[ext]'
           }
           return 'media/[folder]/[name]-[hash:8].[ext]'


### PR DESCRIPTION
- nested files would be given incorrect names in the webpack manifest
- for instance, a file like `images/icons/a.svg` would end up at
  `icons/a.svg` instead of `images/icons/a.svg`, but a file like `images/b.svg` would end up at
  `images/b.svg` (correctly)
- webpacker.yml config files generally follow a POSIX path naming
  convention (so source_path might be something like 'app/javascript')
- the webpacker file loader config checks to see if a given file is in
  the source path by calling `includes` and passing the source path
- on Windows, the file names resolve to strings with backslashes as
  separators, but the source path has a forward slash
- the issue *could* be fixed by just changing the .yml file to have a
  backslash for the source path, but it would then break on POSIX
  systems
- instead, we check that the *normalized* source path is contained
  within the file, which fixes the issue