### PR TITLE
Keep backups, even when they're old.

### DIFF
--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -23,7 +23,7 @@ class Webpacker::Commands
         .each_with_index
         .drop_while do |(mtime, _), index|
           max_age = [0, Time.now - Time.at(mtime)].max
-          max_age < age && index < count
+          max_age < age || index < count
         end
         .each do |(_, files), index|
           files.each do |file|


### PR DESCRIPTION
Recently, we encountered an issue with webpacker removing our previous assets during the webpacker:clean task, and not keeping the specified number of backups. We expected the [behavior from sprockets][sprockets], in which assets are kept if under age or within the count limit. However, webpacker only keeps assets if under age *AND* within the count limit.

I think this should work like sprockets and has perhaps been overlooked.

[sprockets]: https://github.com/rails/sprockets/blob/358f83ff09a77f69ac17543a9b1d127737060f00/lib/sprockets/manifest.rb#L258-L259
