### PR TITLE
Fix duplicated test names for image pack helpers

### DIFF
--- a/docs/assets.md
+++ b/docs/assets.md
@@ -132,4 +132,4 @@ require.context('../images', true)
 <% # => <img src="/packs/media/images/calendar-k344a6d59eef8632c9d1.png" /> %>
 ```
 
-Note you need to add a `media/` prefix (not `/media/`) to any subfolder structure you might have in `app/javascript`. See more examples in the [tests](https://github.com/rails/webpacker/blob/0b86cadb5ed921e2c1538382e72a236ec30a5d97/test/helper_test.rb#L37).
+Note you need to add a `media/` prefix (not `/media/`) to any subfolder structure you might have in `app/javascript`. See more examples in the [tests](/test/helper_test.rb#L37).

--- a/docs/es6.md
+++ b/docs/es6.md
@@ -42,7 +42,7 @@ The comment you see above (`/* webpackChunkName */`) is not arbitrary, it is one
 **Warning**: You should not attempt to dynamically load anything from your `packs/` folder. Instead, try to make your `pack` scripts a hub from which you dynamically load `non-pack` scripts.
 
 - [Docs for using magic comments](https://webpack.js.org/api/module-methods/#magic-comments)
-- [Docs for configuring `splitChunks` in webpacker](https://github.com/rails/webpacker/blob/master/docs/webpack.md#add-splitchunks-webpack-v4).
+- [Docs for configuring `splitChunks` in webpacker](/docs/webpack.md#add-splitchunks-webpack-v4).
 - [Docs for using dynamic `import()`](https://webpack.js.org/guides/code-splitting#dynamic-imports).
 
 ## Module import vs require()

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -140,7 +140,7 @@ config.public_file_server.enabled = true
 Webpacker ships with three javascript configuration files: `test.js`,
 `development.js`, and `production.js`. The `NODE_ENV` environment
 variable determines which config will be used. `NODE_ENV` is
-independent of `RAILS_ENV` and is set to `development` by [default](https://github.com/rails/webpacker/blob/bf278f9787704ed0f78038ad7d36c008abc2edfd/lib/install/bin/webpack#L4).
+independent of `RAILS_ENV` and is set to `development` by [default](/lib/install/bin/webpack#L4).
 This means that `rails test` or `rspec` will use `development.js`
 by default, _not_ `test.js`.
 

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -34,7 +34,7 @@ class HelperTest < ActionView::TestCase
     end
   end
 
-  def test_asset_pack_path
+  def test_image_pack_path
     assert_equal "/packs/application-k344a6d59eef8632c9d1.png", image_pack_path("application.png")
     assert_equal "/packs/media/images/image-c38deda30895059837cf.jpg", image_pack_path("image.jpg")
     assert_equal "/packs/media/images/image-c38deda30895059837cf.jpg", image_pack_path("media/images/image.jpg")
@@ -42,7 +42,7 @@ class HelperTest < ActionView::TestCase
     assert_equal "/packs/media/images/nested/image-c38deda30895059837cf.jpg", image_pack_path("media/images/nested/image.jpg")
   end
 
-  def test_asset_pack_url
+  def test_image_pack_url
     assert_equal "https://example.com/packs/application-k344a6d59eef8632c9d1.png", image_pack_url("application.png")
     assert_equal "https://example.com/packs/media/images/image-c38deda30895059837cf.jpg", image_pack_url("image.jpg")
     assert_equal "https://example.com/packs/media/images/image-c38deda30895059837cf.jpg", image_pack_url("media/images/image.jpg")


### PR DESCRIPTION
@gauravtiwari **emergency commit**

in my last pull request to add missing helper functions I completely missed that I accidentally left duplicated test names in the `helper_test.rb` when I copied the structure of the other asset path tests for the image pack versions

Also added the use of github relative links in docs so that instructions aren't pointing at incorrect assets because the link in the `assets` docs to an old version of the helper test file is how I came across the duplication when switching to the master version

If the docs updates needs to be a separate PR I can split them out, but the test file needs to be updated ASAP