### PR TITLE
Only set writeToDisk for the webpack-dev-server

### DIFF
--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -44,7 +44,7 @@ const getPluginList = () => {
     'Manifest',
     new WebpackAssetsManifest({
       entrypoints: true,
-      writeToDisk: true,
+      writeToDisk: !!process.env.WEBPACK_DEV_SERVER,
       publicPath: config.publicPathWithoutCDN
     })
   )


### PR DESCRIPTION
Otherwise the manifest.json is written twice for every compilation.

See https://github.com/webdeveric/webpack-assets-manifest/issues/89
for more details.