### PR TITLE
Update upgrade instructions to use install

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ You can run following commands to upgrade Webpacker to the latest stable version
 
 ```bash
 bundle update webpacker
-rails webpacker:binstubs
+rails webpacker:install
 yarn upgrade @rails/webpacker --latest
 yarn upgrade webpack-dev-server --latest
 


### PR DESCRIPTION
I upgraded webpacker from v3.6.0 to 5.2.1 by following the README.

However, compilation exploded in production 💥 since it was expecting a `public_output_path: packs` line in `webpacker.yml`. I could have caught that (and other changes) earlier if I had called `rails webpacker:install` instead of just `rails webpacker:binstubs`.