### PR TITLE
Use css-modules suggested localIdentName default

### DIFF
--- a/package/__tests__/env.js
+++ b/package/__tests__/env.js
@@ -13,7 +13,8 @@ describe('Env', () => {
     process.env.NODE_ENV = 'development'
     expect(require('../env')).toEqual({
       railsEnv: 'development',
-      nodeEnv: 'development'
+      nodeEnv: 'development',
+      isProduction: false
     })
   })
 
@@ -22,7 +23,8 @@ describe('Env', () => {
     delete process.env.NODE_ENV
     expect(require('../env')).toEqual({
       railsEnv: 'development',
-      nodeEnv: 'production'
+      nodeEnv: 'production',
+      isProduction: true
     })
   })
 
@@ -31,7 +33,8 @@ describe('Env', () => {
     delete process.env.RAILS_ENV
     expect(require('../env')).toEqual({
       railsEnv: 'production',
-      nodeEnv: 'production'
+      nodeEnv: 'production',
+      isProduction: true
     })
   })
 
@@ -40,7 +43,8 @@ describe('Env', () => {
     process.env.NODE_ENV = 'staging'
     expect(require('../env')).toEqual({
       railsEnv: 'staging',
-      nodeEnv: 'production'
+      nodeEnv: 'production',
+      isProduction: true
     })
   })
 })

--- a/package/env.js
+++ b/package/env.js
@@ -6,7 +6,9 @@ const DEFAULT = 'production'
 const configPath = require('./configPath')
 
 const railsEnv = process.env.RAILS_ENV
-const nodeEnv = process.env.NODE_ENV
+const rawNodeEnv = process.env.NODE_ENV
+const nodeEnv = rawNodeEnv && NODE_ENVIRONMENTS.includes(rawNodeEnv) ? rawNodeEnv : DEFAULT
+const isProduction = nodeEnv === 'production'
 
 const config = safeLoad(readFileSync(configPath), 'utf8')
 const availableEnvironments = Object.keys(config).join('|')
@@ -14,5 +16,6 @@ const regex = new RegExp(`^(${availableEnvironments})$`, 'g')
 
 module.exports = {
   railsEnv: railsEnv && railsEnv.match(regex) ? railsEnv : DEFAULT,
-  nodeEnv: nodeEnv && NODE_ENVIRONMENTS.includes(nodeEnv) ? nodeEnv : DEFAULT
+  nodeEnv,
+  isProduction
 }

--- a/package/rules/babel.js
+++ b/package/rules/babel.js
@@ -1,7 +1,7 @@
 const { resolve } = require('path')
 const { realpathSync } = require('fs')
 const { source_path: sourcePath, additional_paths: additionalPaths } = require('../config')
-const { nodeEnv } = require('../env')
+const { isProduction } = require('../env')
 
 // Process application Javascript code with Babel.
 // Uses application .babelrc to apply any transformations
@@ -20,8 +20,8 @@ module.exports = {
       loader: 'babel-loader',
       options: {
         cacheDirectory: true,
-        cacheCompression: nodeEnv === 'production',
-        compact: nodeEnv === 'production'
+        cacheCompression: isProduction,
+        compact: isProduction
       }
     }
   ]

--- a/package/rules/node_modules.js
+++ b/package/rules/node_modules.js
@@ -1,4 +1,4 @@
-const { nodeEnv } = require('../env')
+const { isProduction } = require('../env')
 
 // Compile standard ES features for JS in node_modules with Babel.
 //   Regex details for exclude: https://regex101.com/r/SKPnnv/1
@@ -13,7 +13,7 @@ module.exports = {
         babelrc: false,
         presets: [['@babel/preset-env', { modules: false }]],
         cacheDirectory: true,
-        cacheCompression: nodeEnv === 'production',
+        cacheCompression: isProduction,
         compact: false,
         sourceMaps: false
       }

--- a/package/utils/get_style_rule.js
+++ b/package/utils/get_style_rule.js
@@ -1,6 +1,7 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const { resolve } = require('path')
 const config = require('../config')
+const { isProduction } = require('../env')
 
 const styleLoader = {
   loader: 'style-loader'
@@ -14,7 +15,7 @@ const getStyleRule = (test, modules = false, preprocessors = []) => {
         sourceMap: true,
         importLoaders: 2,
         modules: modules ? {
-          localIdentName: '[name]__[local]___[hash:base64:5]'
+          localIdentName: isProduction ? '[hash:base64]' : '[path][name]__[local]'
         } : false
       }
     },
@@ -28,7 +29,7 @@ const getStyleRule = (test, modules = false, preprocessors = []) => {
     ...preprocessors
   ]
 
-  const options = modules ? { include: /\.module\.[a-z]+$/ } : { exclude: /\.module\.[a-z]+$/ }
+  const options = modules ? { include: /\.module\.[a-z]+$/i } : { exclude: /\.module\.[a-z]+$/i }
 
   if (config.extract_css) {
     use.unshift(MiniCssExtractPlugin.loader)


### PR DESCRIPTION
From docs: https://github.com/webpack-contrib/css-loader#localidentname

localIdentName
Type: String Default: '[hash:base64]'

Recommendations:

use '[path][name]__[local]' for development
use '[hash:base64]' for production

Also, refactored check for productionEnv.