### PR TITLE
Allow passing files to additional_files

### DIFF
--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -116,6 +116,8 @@ class Webpacker::Configuration
     end
 
     def globbed_path_with_extensions(path)
+      return path if root_path.join(path).file?
+
       "#{path}/**/*{#{extensions.join(',')}}"
     end
 end

--- a/package/__tests__/config.js
+++ b/package/__tests__/config.js
@@ -28,6 +28,7 @@ describe('Config', () => {
       [
         'app/assets',
         '/etc/yarn',
+        'some.config.js',
         'app/elm'
       ]
     )

--- a/package/environments/__tests__/base.js
+++ b/package/environments/__tests__/base.js
@@ -83,6 +83,7 @@ describe('Environment', () => {
         resolve('app', 'javascript'),
         resolve('app/assets'),
         resolve('/etc/yarn'),
+        resolve('some.config.js'),
         resolve('app/elm'),
         'node_modules'
       ])

--- a/test/compiler_test.rb
+++ b/test/compiler_test.rb
@@ -27,6 +27,7 @@ class CompilerTest < Minitest::Test
     assert_equal Webpacker.compiler.send(:default_watched_paths), [
       "app/assets/**/*{.mjs,.js,.sass,.scss,.css,.module.sass,.module.scss,.module.css,.png,.svg,.gif,.jpeg,.jpg,.elm}",
       "/etc/yarn/**/*{.mjs,.js,.sass,.scss,.css,.module.sass,.module.scss,.module.css,.png,.svg,.gif,.jpeg,.jpg,.elm}",
+      "some.config.js",
       "app/elm/**/*{.mjs,.js,.sass,.scss,.css,.module.sass,.module.scss,.module.css,.png,.svg,.gif,.jpeg,.jpg,.elm}",
       "app/javascript/**/*{.mjs,.js,.sass,.scss,.css,.module.sass,.module.scss,.module.css,.png,.svg,.gif,.jpeg,.jpg,.elm}",
       "yarn.lock",

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -54,14 +54,15 @@ class ConfigurationTest < Webpacker::Test
   end
 
   def test_additional_paths
-    assert_equal @config.additional_paths, ["app/assets", "/etc/yarn", "app/elm"]
+    assert_equal @config.additional_paths, ["app/assets", "/etc/yarn", "some.config.js", "app/elm"]
   end
 
   def test_additional_paths_globbed
     assert_equal @config.additional_paths_globbed, [
       "app/assets/**/*{.mjs,.js,.sass,.scss,.css,.module.sass,.module.scss,.module.css,.png,.svg,.gif,.jpeg,.jpg,.elm}",
       "/etc/yarn/**/*{.mjs,.js,.sass,.scss,.css,.module.sass,.module.scss,.module.css,.png,.svg,.gif,.jpeg,.jpg,.elm}",
-      "app/elm/**/*{.mjs,.js,.sass,.scss,.css,.module.sass,.module.scss,.module.css,.png,.svg,.gif,.jpeg,.jpg,.elm}"
+      "some.config.js",
+      "app/elm/**/*{.mjs,.js,.sass,.scss,.css,.module.sass,.module.scss,.module.css,.png,.svg,.gif,.jpeg,.jpg,.elm}",
     ]
   end
 

--- a/test/test_app/config/webpacker.yml
+++ b/test/test_app/config/webpacker.yml
@@ -13,6 +13,7 @@ default: &default
   additional_paths:
     - app/assets
     - /etc/yarn
+    - some.config.js
 
   # This configuration option is deprecated and is only here for testing, to
   # ensure backwards-compatibility. Please use `additional_paths`.


### PR DESCRIPTION
Currently, everything passed to `additional_files` array is converted into a directory glob pattern, so, it's not possible to add a single file from the project's root to the list of watched files.

For example, if you're using Tailwind, you're likely to have `<root>/tailwind.config.js` which contains important configuration. Currently, changes to this file are ignored when calculated the digest which could result in "Everything up-to-date..." while we must recompile the assets.
