### PR TITLE
Specify core-js version

### DIFF
--- a/package/babel/preset-react.js
+++ b/package/babel/preset-react.js
@@ -26,7 +26,7 @@ module.exports = function config(api) {
         '@babel/preset-env',
         {
           useBuiltIns: 'entry',
-          corejs: 3,
+          corejs: '3.7',
           modules: false,
           bugfixes: true,
           loose: true,

--- a/package/babel/preset.js
+++ b/package/babel/preset.js
@@ -25,7 +25,7 @@ module.exports = function config(api) {
         '@babel/preset-env',
         {
           useBuiltIns: 'entry',
-          corejs: 3,
+          corejs: '3.7',
           modules: 'auto',
           bugfixes: true,
           loose: true,


### PR DESCRIPTION
I recently used a feature [String.prototype.replaceAll()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll) in this way

```
import 'core-js/stable'
import 'core-js/proposals/string-replace-all'
```

But in `core-js 3.7` it was moved inside `core-js/stable`
https://github.com/zloirock/core-js/blob/master/CHANGELOG.md#370---20201106

Without specifying the exact version of `core-js` version, `string-replace-all` didn't work:
>Warning! Recommended to specify used minor core-js version, like corejs: '3.6', instead of corejs: 3, since with corejs: 3 will not be injected modules which were added in minor core-js releases.

https://github.com/zloirock/core-js#babelpreset-env