### PR TITLE
add .js.erb

### DIFF
--- a/lib/install/erb.rb
+++ b/lib/install/erb.rb
@@ -13,7 +13,7 @@ insert_into_file Rails.root.join("config/webpack/environment.js").to_s,
   before: "module.exports"
 
 say "Updating webpack paths to include .erb file extension"
-insert_into_file Webpacker.config.config_path, "- .erb\n".indent(4), after: /\s+extensions:\n/
+insert_into_file Webpacker.config.config_path, "- .erb\n- .js.erb\n".indent(4), after: /\s+extensions:\n/
 
 say "Copying the example entry file to #{Webpacker.config.source_entry_path}"
 copy_file "#{__dir__}/examples/erb/hello_erb.js.erb",


### PR DESCRIPTION
The [documentation](https://github.com/rails/webpacker/blob/master/docs/integrations.md#erb) adds an example with a `.js.erb` extension which is actually not loaded (just .erb).