### PR TITLE
Use webpack serve for dev server

### DIFF
--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -66,9 +66,9 @@ module Webpacker
         env["WEBPACKER_CONFIG"] = @webpacker_config
 
         cmd = if node_modules_bin_exist?
-          ["#{@node_modules_bin_path}/webpack-dev-server"]
+          ["#{@node_modules_bin_path}/webpack", "serve"]
         else
-          ["yarn", "webpack-dev-server"]
+          ["yarn", "webpack", "serve"]
         end
 
         if @argv.include?("--debug-webpacker")

--- a/test/dev_server_runner_test.rb
+++ b/test/dev_server_runner_test.rb
@@ -13,25 +13,25 @@ class DevServerRunnerTest < Webpacker::Test
   end
 
   def test_run_cmd_via_node_modules
-    cmd = ["#{test_app_path}/node_modules/.bin/webpack-dev-server", "--config", "#{test_app_path}/config/webpack/development.js"]
+    cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/development.js"]
 
     verify_command(cmd, use_node_modules: true)
   end
 
   def test_run_cmd_via_yarn
-    cmd = ["yarn", "webpack-dev-server", "--config", "#{test_app_path}/config/webpack/development.js"]
+    cmd = ["yarn", "webpack", "serve", "--config", "#{test_app_path}/config/webpack/development.js"]
 
     verify_command(cmd, use_node_modules: false)
   end
 
   def test_run_cmd_argv
-    cmd = ["#{test_app_path}/node_modules/.bin/webpack-dev-server", "--config", "#{test_app_path}/config/webpack/development.js", "--quiet"]
+    cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/development.js", "--quiet"]
 
     verify_command(cmd, argv: ["--quiet"])
   end
 
   def test_run_cmd_argv_with_https
-    cmd = ["#{test_app_path}/node_modules/.bin/webpack-dev-server", "--config", "#{test_app_path}/config/webpack/development.js", "--https"]
+    cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/development.js", "--https"]
 
     dev_server = Webpacker::DevServer.new({})
     def dev_server.host; "localhost"; end


### PR DESCRIPTION
webpack-dev-server has been deprecated in favor of `webpack serve` according to this issue: https://github.com/webpack/webpack-dev-server/issues/2759 

This PR updates the `DevServerRunner` to be compatible with webpack-cli v4. Fixes #2776 