### PR TITLE
bump gem to 5.2.1

### DIFF
--- a/lib/webpacker/version.rb
+++ b/lib/webpacker/version.rb
@@ -1,4 +1,4 @@
 module Webpacker
   # Change the version in package.json too, please!
-  VERSION = "5.1.1".freeze
+  VERSION = "5.2.1".freeze
 end


### PR DESCRIPTION
switched from gem to github source and was surprised about the version number

also: should this be 6.0.0 instead of 5.2.1?

![Screenshot 2020-11-21 at 08 00 59](https://user-images.githubusercontent.com/12844/99869980-b8961400-2bcf-11eb-9a3b-6bebd3ac17e1.png)
