### PR TITLE
feat: Add --trace-deprecation flag

### DIFF
--- a/lib/webpacker/webpack_runner.rb
+++ b/lib/webpacker/webpack_runner.rb
@@ -17,6 +17,11 @@ module Webpacker
         cmd = [ "node", "--inspect-brk"] + cmd
       end
 
+      if @argv.include?("--trace-deprecation")
+        cmd = [ "node", "--trace-deprecation"] + cmd
+        @argv.delete "--trace-deprecation"
+      end
+
       cmd += ["--config", @webpack_config] + @argv
 
       Dir.chdir(@app_path) do


### PR DESCRIPTION
This simply parses through the webpack binary args to execute `node
--trace-deprecation` when called with `./bin/webpack
--trace-deprecation` so that deprecation warnings in various packages
can be discovered more easily.

The method grabs that flag out of the args and deletes it if it's there and
prepends the cmd with `node --trace-deprecation`.

Hopefully this will make it easier to track down deprecation issues.

There's probably a better way to handle these types of arguments passed in cause this just feels like it's handling 2 "one-offs" and not really handling things exceptionally well. It's possible developing a different interface for this would improve it I just don't know what it would look like.