### PR TITLE
Use Rails.application.config_for to load the webpacker.yml

### DIFF
--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -97,7 +97,7 @@ class Webpacker::Configuration
     end
 
     def load
-      YAML.load(config_path.read)[env].deep_symbolize_keys
+      Rails.application.config_for(config_path, env: env)
 
     rescue Errno::ENOENT => e
       raise "Webpacker configuration file not found #{config_path}. " \

--- a/test/test_app/config/webpacker.yml
+++ b/test/test_app/config/webpacker.yml
@@ -57,8 +57,8 @@ development:
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:
-    https: false
-    host: localhost
+    https: <%= ENV.fetch('WEBPACKER_DEV_USE_HTTP') { false } %>
+    host: <%= ENV.fetch('WEBPACKER_DEV_HOST') { 'localhost' } %>
     port: 3035
     public: localhost:3035
     hmr: false

--- a/test/webpacker_test.rb
+++ b/test/webpacker_test.rb
@@ -10,4 +10,22 @@ class WebpackerTest < Webpacker::Test
       assert_equal "test", Webpacker.config.env
     end
   end
+
+  def test_erb_config_compilation
+    with_rails_env("development") do
+      assert_equal false, Webpacker.config.dev_server[:https]
+      assert_equal 'localhost', Webpacker.config.dev_server[:host]
+    end
+
+    ENV['WEBPACKER_DEV_USE_HTTP'] = 'true'
+    ENV['WEBPACKER_DEV_HOST'] = 'host.local'
+
+    with_rails_env("development") do
+      assert_equal true, Webpacker.config.dev_server[:https]
+      assert_equal 'host.local', Webpacker.config.dev_server[:host]
+    end
+
+    ENV.delete('WEBPACKER_DEV_USE_HTTP')
+    ENV.delete('WEBPACKER_DEV_HOST')
+  end
 end


### PR DESCRIPTION
This PR adds support for 'erb' compilation of webpacker.yml config files.

Without this change, webpacker.yml will forever live on it's own and be responsible for loading a config file manually and work in unexpected ways, like ERB compilation not working inside of webpacker.yml loading similar to how all other config files work.

After this change, webpacker.yml will now act like every other "rails" yml file that people are used to and things like the below will evaluate properly when the environment is set properly

```
development: 
  host: <%= ENV.fetch('SOMETHING') { true } %>
```

Internally, this is a small change, we use the [Rails.application.config_for](https://github.com/rails/rails/blob/26fd55e02a19111d9b7785ca262e95dde6645f1a/railties/lib/rails/application.rb#L241) method that is used for all other configuration loads and handles erb compilation.  


I looked through the [github history](https://github.com/rails/webpacker/pull/636) and this did not seem like a design decision to intentionally not include compilation.

Closes: https://github.com/rails/webpacker/issues/1615