### PR TITLE
Add support for Yarn v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ environment.loaders.append('nodeModules', nodeModules)
 - The install task will now set the `extract_css` default to `true` in all environments and generate a separate `application.css` file for the default `application` pack, as supported by multiple files per entry introduced in 5.0.0.  [#2608](https://github.com/rails/webpacker/pull/2608)
 - Webpacker's wrapper to the `splitChunks()` API will now default `runtimeChunk: 'single'` which will help prevent potential issues when using multiple entry points per page [#2708](https://github.com/rails/webpacker/pull/2708).
 - Changes `@babel/preset-env` modules option to `'auto'` per recommendation in the Babel docs [#2709](https://github.com/rails/webpacker/pull/2709)
+- Adds experimental Yarn 2 support. Note you must manually set `nodeLinker: node-modules` in your `.yarnrc.yml`.
 
 ## [[5.2.1]](https://github.com/rails/webpacker/compare/v5.2.0...5.2.1) - 2020-08-17
 

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -38,6 +38,14 @@ Dir.chdir(Rails.root) do
     run "yarn add @rails/webpacker@next"
   end
 
+  package_json = File.read("#{__dir__}/../../package.json")
+  webpack_version = package_json.match(/"webpack": "(.*)"/)[1]
+  webpack_cli_version = package_json.match(/"webpack-cli": "(.*)"/)[1]
+
+  # needed for experimental Yarn 2 support and should not harm Yarn 1
+  say "Installing webpack and webpack-cli as direct dependencies"
+  run "yarn add webpack@#{webpack_version} webpack-cli@#{webpack_cli_version}"
+
   say "Installing dev server for live reloading"
   run "yarn add --dev webpack-dev-server"
 end

--- a/lib/tasks/webpacker/check_yarn.rake
+++ b/lib/tasks/webpacker/check_yarn.rake
@@ -9,13 +9,12 @@ namespace :webpacker do
       pkg_path = Pathname.new("#{__dir__}/../../../package.json").realpath
       yarn_range = JSON.parse(pkg_path.read)["engines"]["yarn"]
       is_valid = SemanticRange.satisfies?(yarn_version, yarn_range) rescue false
-      is_unsupported = SemanticRange.satisfies?(yarn_version, ">=2.0.0") rescue false
+      is_unsupported = SemanticRange.satisfies?(yarn_version, ">=3.0.0") rescue false
 
       unless is_valid
         $stderr.puts "Webpacker requires Yarn \"#{yarn_range}\" and you are using #{yarn_version}"
         if is_unsupported
           $stderr.puts "This version of Webpacker does not support Yarn #{yarn_version}. Please downgrade to a supported version of Yarn https://yarnpkg.com/lang/en/docs/install/"
-          $stderr.puts "For information on using Webpacker with Yarn 2.0, see https://github.com/rails/webpacker/issues/2112"
         else
           $stderr.puts "Please upgrade Yarn https://yarnpkg.com/lang/en/docs/install/"
         end

--- a/lib/tasks/webpacker/yarn_install.rake
+++ b/lib/tasks/webpacker/yarn_install.rake
@@ -6,7 +6,13 @@ namespace :webpacker do
       valid_node_envs.include?(Rails.env) ? Rails.env : "production"
     end
     Dir.chdir(Rails.root) do
-      system({ "NODE_ENV" => node_env }, "yarn install --no-progress --frozen-lockfile")
+      yarn_flags =
+        if `yarn --version`.start_with?("1")
+          "--no-progress --frozen-lockfile"
+        else
+          "--immutable"
+        end
+      system({ "NODE_ENV" => node_env }, "yarn install #{yarn_flags}")
     end
   end
 end

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "engines": {
     "node": ">=10.17.0 || ^12 || >=14",
-    "yarn": ">=1 <2"
+    "yarn": ">=1 <3"
   },
   "dependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
This should make Webpacker support both Yarn 1 and 2. It comes down to the two changes:

- Use correct `yarn install` flags
- Add `webpack` and `webpack-cli` as direct per project dependencies, otherwise Yarn 2 complains about not finding the binary `webpack`

In addition `nodeLinker: node-modules` must be added to `.yarnrc.yml` for maximum compatibility, but this is left as an exercise for the user who wants to experiment with Yarn 2 for now.

---

I think supporting both Yarn versions – if those are really the only two changes – should be no problem. Later one could force to only supprt Yarn 2, but Rails must gain support for Yarn 2 before. See https://github.com/rails/rails/pull/40722 for Yarn 2 support in Rails.