### PR TITLE
Use single runtimeChunk as optimization default

### DIFF
--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -106,7 +106,7 @@ module.exports = {
   optimization: {
     splitChunks: { chunks: 'all' },
 
-    runtimeChunk: { name: (entrypoint) => `runtime-${entrypoint.name}` }
+    runtimeChunk: 'single'
   },
 
   module: {


### PR DESCRIPTION
This change brings back the runtimeChunk default setting introduced in #2708.

This change sets `runtimeChunk: 'single'` as the default when splitChunks() is enabled to ensure modules across multiple entry points are properly shared. I believe this default better serves the "out-of-the-box" behavior for Rails developers.

In general, webpack discourages the use of multiple entry points per page:

> Using multiple entry points per page should be avoided when possible in favor of an entry point with multiple imports: entry: { page: ['./analytics', './app'] }.

However, Rails developers seeking to keep their bundles small will be inclined to split their code into multiple packs, especially given prior experience with the Rails asset pipeline and the way Rails views enable a mode of targeting pages with specific packs.

For this use case, _webpack encourages use of runtimeChunk 'single'_.

> optimization.runtimeChunk: 'single' is needed when multiple entry points are being used on a single HTML page.
>
> source: https://webpack.js.org/guides/code-splitting/#optimizationruntimechunk

While documentation can be improved to encourage dynamic imports over multiple entry points as a form of code-splitting, it's reasonable to expect that Rails developers will continue to use multiple entry points per page in which case, I believe, 'single' is the better default.

