### PR TITLE
Install postcss with css to avoid warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ module.exports = merge(webpackConfig, {
 To enable CSS support in your application, add following packages:
 
 ```bash
-yarn add css-loader mini-css-extract-plugin css-minimizer-webpack-plugin
+yarn add css-loader mini-css-extract-plugin css-minimizer-webpack-plugin postcss
 ```
 
 optionally, add the css extension to webpack config for easy resolution.


### PR DESCRIPTION
### ⚠️ opinionated change

`css-loader` depends on `postcss`. `postcss-loader` instead has a peer
dependency on `postcss`.

This means that when following webpacker instructions to install
`postcss-loader` is installed, the console shows this warning:

```
warning " > postcss-loader@4.1.0" has unmet peer dependency "postcss@^7.0.0 || ^8.0.1".
```

On the other hand, installing `postcss` and `postcss-loader` together,
will result in another warning:

```
warning Pattern ["postcss@^8.2.1"] is trying to unpack in the same destination "node_modules/postcss" as pattern ["postcss@^8.1.4"]. This could result in non-deterministic behavior, skipping.
```

This change explicitly installs `postcss` with css packages to avoid
both warnings
How to replicate

```bash
$ rails new test-webpacker6-postcss --skip-active-record --skip-javascript
$ cd test-webpacker6-postcss/
$ echo "{ \"private\": true }" > package.json
$ echo "gem 'webpacker', git: 'https://github.com/rails/webpacker.git'" >> Gemfile
$ bundle
$ rails webpacker:install
$ yarn add css-loader mini-css-extract-plugin css-minimizer-webpack-plugin
$ yarn add postcss-loader
```

Output contains:
```
warning " > postcss-loader@4.1.0" has unmet peer dependency "postcss@^7.0.0 || ^8.0.1".
```

Ref:
- #2816 
- https://www.npmjs.com/package/css-loader?activeTab=dependencies
- https://www.npmjs.com/package/postcss-loader?activeTab=dependencies