### PR TITLE
docs: fix case of CoffeeScript, GitHub and TypeScript

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ yarn
 ```
 
 ## Making sure your changes pass all tests
-There are a number of automated checks which run on Github Actions when a pull request is created.
+There are a number of automated checks which run on GitHub Actions when a pull request is created.
 You can run those checks on your own locally to make sure that your changes would not break the CI build.
 
 ### 1. Check the code for JavaScript style violations

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ in which case you may not even need the asset pipeline. This is mostly relevant 
   _requires extra packages to be installed_
 
   - Stylesheets - Sass, Less, Stylus and Css, PostCSS
-  - Coffeescript
-  - Typescript
+  - CoffeeScript
+  - TypeScript
   - React
 
 ## Installation
@@ -261,16 +261,16 @@ console.log(webpackConfig.source_path)
 ### Integrations
 
 Webpacker out of the box supports JS and static assets (fonts, images etc.)
-compilation. To enable support for Coffeescript or Typescript install
+compilation. To enable support for CoffeeScript or TypeScript install
 relevant packages,
 
-**Coffeescript**
+**CoffeeScript**
 
 ```
 yarn add coffeescript coffee-loader
 ```
 
-**Typescript**
+**TypeScript**
 
 ```
 yarn add typescript @babel/preset-typescript


### PR DESCRIPTION
Changes were:
- `Coffeescript` -> `CoffeeScript`
- `Github` -> `GitHub`
- `Typescript` -> `TypeScript`