### PR TITLE
Remove application.css from installer

### DIFF
--- a/lib/install/javascript/packs/application.css
+++ b/lib/install/javascript/packs/application.css
@@ -1,9 +1,0 @@
-/* 
-Any CSS added to this file or imported from this file, e.g. `@import '../stylesheets/my-css.css'`,
-will be included in the "application" pack. Any CSS imported from application.js or as part of the 
-application.js dependency graph, e.g. `import '../stylesheets/my-css.css'` will also be included 
-in the "application" pack. 
-
-To reference this file, add <%= stylesheet_pack_tag 'application' %> to the appropriate
-layout file, like app/views/layouts/application.html.erb
-*/


### PR DESCRIPTION
Since CSS support is now opt-in and no longer included by default, it would be potentially confusing to generate a stylesheet as part of the install task.

Note: although framework installers were removed, it may be helpful to support CSS/PostCSS/SCSS/etc installers to make it easier to add the right loaders—an application.css stylesheet could be generated in this "CSS" installer(s). I'll look into a separate PR.