### PR TITLE
Update 6_0_upgrade.md: webpack-dev-server

### DIFF
--- a/6_0_upgrade.md
+++ b/6_0_upgrade.md
@@ -8,6 +8,7 @@ straightforward.
 
 - Rename `config/webpack` to `config/webpack_old`
 - Rename `config/webpacker.yml` to `config/webpacker_old.yml`
+- Uninstall the current version of `webpack-dev-server`: `yarn remove webpack-dev-server`
 - Upgrade webpacker
 
   ```ruby


### PR DESCRIPTION
Depending on local installations, outdated versions of webpack-dev-server might not work with webpack 5. 

Uninstalling the current version is one way to help developers avoid running into issues when trying to run the dev server after upgrading since the install task will upgrade in this case.