### PR TITLE
Update 6_0_upgrade.md: .browserslistrc

### DIFF
--- a/6_0_upgrade.md
+++ b/6_0_upgrade.md
@@ -41,3 +41,4 @@ straightforward.
 
   module.exports = merge(webpackConfig, customConfig)
   ```
+- Copy over custom browserlist config from `.browserlistrc` if it exists into the `"browserlist"` key in `package.json` and remove `.browserslistrc`.


### PR DESCRIPTION
Now that the Webpacker install task inserts browserslist config into `package.json`, webpack compilation will fail if the `.browserlistrc` file from prior Webpacker versions still exists.