### PR TITLE
Faster compilation when there is no cache

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -35,7 +35,7 @@ class Webpacker::Compiler
 
   # Returns true if all the compiled packs are up to date with the underlying asset files.
   def fresh?
-    watched_files_digest == last_compilation_digest
+    last_compilation_digest&.== watched_files_digest
   end
 
   # Returns true if the compiled packs are out of date with the underlying asset files.


### PR DESCRIPTION
When `last_compilation_digest` returns `nil`, we don't need to calculate the digest for watched files.
This commit first checks the return value of `last_compilation_digest` to skip the calculation of unnecessary digests.

## Benchmark

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "benchmark-ips"
  gem "webpacker", github: "rails/webpacker", ref: "461a61f2038b58bef99eaec64846e564e712dc9e"
end

require "benchmark/ips"
require "webpacker"

def build_compiler(tmpdir)
  root_path = Pathname.new(tmpdir)

  # Put webpacker.yml
  config_path = root_path.join("webpacker.yml")
  config_path.write <<~YAML
    development:
      source_path: javascript
      public_root_path: public
      public_output_path: packs
      cache_path: cache
      extensions:
        - .js
  YAML

  # Put dummy files to calculate SHA1 digest
  source_path = root_path.join("javascript")
  FileUtils.mkdir(source_path)
  100.times { |n| source_path.join("#{n}.js").write("// #{n}") }

  # Build a compiler
  instance = Webpacker::Instance.new(root_path: root_path, config_path: config_path)
  instance.instance_variable_set(:@env, "development")
  Webpacker::Compiler.new(instance)
end

Dir.mktmpdir do |dir|
  compiler = build_compiler(dir)

  Benchmark.ips do |x|
    x.report("before") do
      compiler.instance_eval do
        watched_files_digest == last_compilation_digest
      end
    end
    x.report("after") do
      compiler.instance_eval do
        last_compilation_digest&.== watched_files_digest
      end
    end
    x.compare!
  end
end
```

The results are:

```
Warming up --------------------------------------
              before    17.000  i/100ms
               after     4.059k i/100ms
Calculating -------------------------------------
              before    252.545  (±15.4%) i/s -      1.224k in   5.046493s
               after     41.469k (± 3.8%) i/s -    211.068k in   5.096865s

Comparison:
               after:    41469.3 i/s
              before:      252.5 i/s - 164.21x  (± 0.00) slower
```
