### PR TITLE
Add .jsx and .tsx to resolve.extensions

### DIFF
--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -91,7 +91,7 @@ module.exports = {
   },
   entry: getEntryObject(),
   resolve: {
-    extensions: ['.js', '.mjs', '.ts', '.coffee'],
+    extensions: ['.js', '.jsx', '.mjs', '.ts', '.tsx', '.coffee'],
     modules: getModulePaths(),
     plugins: [PnpWebpackPlugin]
   },


### PR DESCRIPTION
The following extensions are currently matched by the default rules for babel-loader.

https://github.com/rails/webpacker/blob/1aca8aaebd21a075d42e718d2b60dfba8e8d1b70/package/rules/babel.js#L11

This PR adds `.jsx` and `.tsx` to the default `resolve.extensions` to bring parity. 

Fixes #2853 #2861