### PR TITLE
Constrain supported node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib/install/config/webpacker.yml"
   ],
   "engines": {
-    "node": ">=10.22.1 || ^12 || >=14",
+    "node": ">=10.22.1 || ^12 || >=14 || <15",
     "yarn": ">=1 <3"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #2874

Until Webpacker uses node-sass 5.0+, node version 15 isn't supported.