### PR TITLE
Node 15

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [10.x, 12.x, 14.x]
+        node: [10.x, 12.x, 14.x, 15.x]
 
     runs-on: ${{ matrix.os }}
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib/install/config/webpacker.yml"
   ],
   "engines": {
-    "node": ">=10.22.1 || ^12 || >=14 || <15",
+    "node": ">=10.22.1 || ^12 || >=14",
     "yarn": ">=1 <3"
   },
   "dependencies": {


### PR DESCRIPTION
Adds CI checks for Node 15, and reverts the version constraint in `package.json` introduced in https://github.com/rails/webpacker/pull/2877 (see https://github.com/rails/webpacker/pull/2877#issuecomment-759594340). The CI check passes and I am able to use Node 15 locally with a Rails 6.1 and both Webpacker 5.2.1 and 6.0.0.beta.2.