### PR TITLE
Add `.coffee` extension to the babel.

### DIFF
--- a/package/rules/babel.js
+++ b/package/rules/babel.js
@@ -8,7 +8,7 @@ const {
 const { isProduction } = require('../env')
 
 module.exports = {
-  test: /\.(js|jsx|mjs|ts|tsx)?(\.erb)?$/,
+  test: /\.(js|jsx|mjs|ts|tsx|coffee)?(\.erb)?$/,
   include: [sourcePath, ...additionalPaths].map((p) => {
     try {
       return realpathSync(p)


### PR DESCRIPTION
CoffeeScript both included as a rule in `rules/` and also in `resolves` but its not processed with babel. This also fixes #2845. See the comments of that issue for more details.

See coffee: https://github.com/rails/webpacker/blob/master/package/rules/coffee.js

Also resolve:

https://github.com/rails/webpacker/blob/6efb3ee5367dbced7b76b7daec35684db4d9570a/package/environments/base.js#L94