### PR TITLE
Export all webpack-merge v5 functions

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,3 @@
+# Note
+
+This directory exists for Jest specs that execute code expecting the Rails config directory at this path.

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -1,0 +1,1 @@
+lib/install/config/webpacker.yml

--- a/package/__tests__/index.js
+++ b/package/__tests__/index.js
@@ -1,0 +1,9 @@
+const index = require('../index')
+
+describe('index', () => {
+  test('exports webpack-merge v5 functions', () => {
+    expect(index.merge).toBeInstanceOf(Function)
+    expect(index.mergeWithRules).toBeInstanceOf(Function)
+    expect(index.mergeWithCustomize).toBeInstanceOf(Function)
+  })
+})

--- a/package/index.js
+++ b/package/index.js
@@ -1,7 +1,7 @@
 /* eslint global-require: 0 */
 /* eslint import/no-dynamic-require: 0 */
 
-const { merge } = require('webpack-merge')
+const webpackMerge = require('webpack-merge')
 const { resolve } = require('path')
 const { existsSync } = require('fs')
 const baseConfig = require('./environments/base')
@@ -23,7 +23,7 @@ module.exports = {
   webpackConfig: webpackConfig(),
   baseConfig,
   rules,
-  merge,
   moduleExists,
-  canProcess
+  canProcess,
+  ...webpackMerge
 }


### PR DESCRIPTION
This PR adds all the [webpack-merge](https://github.com/survivejs/webpack-merge) [v5 functions](https://github.com/survivejs/webpack-merge/blob/28cfdbda7bfa54717c13d1f28d715d33fdc7b339/src/index.ts#L294-L304) to the `@rails/webpacker` module.exports. 

The webpack-merge provides a number of helpful utility functions for extending and customizing webpack config. 

For example, the `mergeWithRules` function could be a useful for way to support Vue in Webpacker 6 (https://github.com/rails/webpacker/issues/2835):

```javascript
const { webpackConfig, mergeWithRules } = require('@rails/webpacker')
const VueLoaderPlugin = require('vue-loader/lib/plugin')

// Add `vue-loader` to support "Single File Component"-style components
const vueConfig = {
  module: {
    rules: [
      {
        test: [/\.html$/],
        exclude: [/\.(js|mjs|jsx|ts|tsx|vue\.html)$/],
        type: 'asset/source',
      },
      {
        test: /\.vue$/,
        use: { loader: 'vue-loader' },
      },
    ],
  },
  plugins: [new VueLoaderPlugin()],
  resolve: {
    alias: {
      vue: 'vue/dist/vue.js',
    },
  },
}

const exportConfig = mergeWithRules({
  module: {
    rules: {
      test: 'match',
      exclude: 'replace',
      type: 'match',
    },
  },
})(webpackConfig, vueConfig)
```
_The `mergeWithRules` logic above replaces the `exclude` option in module rules that match the default asset/source rule for html files while also performing the traditional merge of the VueLoaderPlugin and resolve options._

Since webpack-cli currently depends on webpack-merge v4, I believe requiring webpack-merge directly within Rails app webpack configs will resolve the older version. This is why it's advantageous to export the webpack-merge v5 from `@rails/webpacker`.

Thoughts?