### PR TITLE
Support to Yarn v2/berry for webpacker 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 **Please note that Webpacker 4.1.0 has an installer bug. Please use 4.2.0 or above**
 
+## [[5.3.0]](https://github.com/rails/webpacker/compare/v5.3.0...5.2.1) - 2021-01-15
+
+- Adds experimental Yarn 2 support. Note you must manually set `nodeLinker: node-modules` in your `.yarnrc.yml`.
+
 ## [[5.2.1]](https://github.com/rails/webpacker/compare/v5.2.0...5.2.1) - 2020-08-17
 
 - Revert [#1311](https://github.com/rails/webpacker/pull/1311).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Please note that Webpacker 4.1.0 has an installer bug. Please use 4.2.0 or above**
 
-## [[5.3.0]](https://github.com/rails/webpacker/compare/v5.3.0...5.2.1) - 2021-01-15
+## [[5.3.0]](https://github.com/rails/webpacker/compare/v5.3.0...5.2.1) - 2021-TBD
 
 - Adds experimental Yarn 2 support. Note you must manually set `nodeLinker: node-modules` in your `.yarnrc.yml`.
 

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -42,6 +42,14 @@ else
   run "yarn add @rails/webpacker@next"
 end
 
+package_json = File.read("#{__dir__}/../../package.json")
+webpack_version = package_json.match(/"webpack": "(.*)"/)[1]
+webpack_cli_version = package_json.match(/"webpack-cli": "(.*)"/)[1]
+
+# needed for experimental Yarn 2 support and should not harm Yarn 1
+say "Installing webpack and webpack-cli as direct dependencies"
+run "yarn add webpack@#{webpack_version} webpack-cli@#{webpack_cli_version}"
+
 say "Installing dev server for live reloading"
 run "yarn add --dev webpack-dev-server"
 

--- a/lib/tasks/webpacker/check_yarn.rake
+++ b/lib/tasks/webpacker/check_yarn.rake
@@ -9,13 +9,12 @@ namespace :webpacker do
       pkg_path = Pathname.new("#{__dir__}/../../../package.json").realpath
       yarn_range = JSON.parse(pkg_path.read)["engines"]["yarn"]
       is_valid = SemanticRange.satisfies?(yarn_version, yarn_range) rescue false
-      is_unsupported = SemanticRange.satisfies?(yarn_version, ">=2.0.0") rescue false
+      is_unsupported = SemanticRange.satisfies?(yarn_version, ">=3.0.0") rescue false
 
       unless is_valid
         $stderr.puts "Webpacker requires Yarn \"#{yarn_range}\" and you are using #{yarn_version}"
         if is_unsupported
           $stderr.puts "This version of Webpacker does not support Yarn #{yarn_version}. Please downgrade to a supported version of Yarn https://yarnpkg.com/lang/en/docs/install/"
-          $stderr.puts "For information on using Webpacker with Yarn 2.0, see https://github.com/rails/webpacker/issues/2112"
         else
           $stderr.puts "Please upgrade Yarn https://yarnpkg.com/lang/en/docs/install/"
         end

--- a/lib/tasks/webpacker/yarn_install.rake
+++ b/lib/tasks/webpacker/yarn_install.rake
@@ -5,6 +5,12 @@ namespace :webpacker do
     node_env = ENV.fetch("NODE_ENV") do
       valid_node_envs.include?(Rails.env) ? Rails.env : "production"
     end
-    system({ "NODE_ENV" => node_env }, "yarn install --no-progress --frozen-lockfile")
+    yarn_flags =
+      if `yarn --version`.start_with?("1")
+        "--no-progress --frozen-lockfile"
+      else
+        "--immutable"
+      end
+    system({ "NODE_ENV" => node_env }, "yarn install #{yarn_flags}")
   end
 end

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "engines": {
     "node": ">=10.17.0",
-    "yarn": ">=1 <2"
+    "yarn": ">=1 <3"
   },
   "dependencies": {
     "@babel/core": "^7.11.1",


### PR DESCRIPTION
@gauravtiwari 👋 

Closes #2888.

Clone of https://github.com/rails/webpacker/pull/2799 to provide support of Yarn v2 in 5.x versions of webpacker.