### PR TITLE
Dev server detection workaround

### DIFF
--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -25,6 +25,8 @@ development:
     host: localhost
     port: 3035
     public: localhost:3035
+    # Inject browserside javascript that required by both HMR and Live(full) reload
+    inject_client: true
     # Hot Module Replacement updates modules while the application is running without a full reload
     hmr: false
     # Inline should be set to true if using HMR; it inserts a script to take care of live reloading

--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -64,6 +64,7 @@ module Webpacker
       def execute_cmd
         env = Webpacker::Compiler.env
         env["WEBPACKER_CONFIG"] = @webpacker_config
+        env["WEBPACK_DEV_SERVER"] = 'true'
 
         cmd = if node_modules_bin_exist?
           ["#{@node_modules_bin_path}/webpack", "serve"]

--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -64,7 +64,7 @@ module Webpacker
       def execute_cmd
         env = Webpacker::Compiler.env
         env["WEBPACKER_CONFIG"] = @webpacker_config
-        env["WEBPACK_DEV_SERVER"] = 'true'
+        env["WEBPACK_DEV_SERVER"] = "true"
 
         cmd = if node_modules_bin_exist?
           ["#{@node_modules_bin_path}/webpack", "serve"]

--- a/package/__tests__/development.js
+++ b/package/__tests__/development.js
@@ -22,7 +22,8 @@ describe('Development environment', () => {
       expect(webpackConfig).toMatchObject({
         devServer: {
           host: 'localhost',
-          port: 3035
+          port: 3035,
+          injectClient: true
         }
       })
     })

--- a/package/environments/development.js
+++ b/package/environments/development.js
@@ -34,6 +34,7 @@ if (
       hot: devServer.hmr,
       contentBase,
       inline: devServer.inline,
+      injectClient: devServer.inject_client,
       useLocalIp: devServer.use_local_ip,
       public: devServer.public,
       publicPath,

--- a/test/dev_server_runner_test.rb
+++ b/test/dev_server_runner_test.rb
@@ -43,19 +43,27 @@ class DevServerRunnerTest < Webpacker::Test
     end
   end
 
+  def test_environment_variables
+    cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/development.js"]
+    env = Webpacker::Compiler.env.dup
+    env["WEBPACKER_CONFIG"] = "#{test_app_path}/config/webpacker.yml"
+    env["WEBPACK_DEV_SERVER"] = 'true'
+    verify_command(cmd, env: env)
+  end
+
   private
     def test_app_path
       File.expand_path("test_app", __dir__)
     end
 
-    def verify_command(cmd, use_node_modules: true, argv: [])
+    def verify_command(cmd, use_node_modules: true, argv: [], env: Webpacker::Compiler.env)
       cwd = Dir.pwd
       Dir.chdir(test_app_path)
 
       klass = Webpacker::DevServerRunner
       instance = klass.new(argv)
       mock = Minitest::Mock.new
-      mock.expect(:call, nil, [Webpacker::Compiler.env, *cmd])
+      mock.expect(:call, nil, [env, *cmd])
 
       klass.stub(:new, instance) do
         instance.stub(:node_modules_bin_exist?, use_node_modules) do

--- a/test/dev_server_runner_test.rb
+++ b/test/dev_server_runner_test.rb
@@ -47,7 +47,7 @@ class DevServerRunnerTest < Webpacker::Test
     cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/development.js"]
     env = Webpacker::Compiler.env.dup
     env["WEBPACKER_CONFIG"] = "#{test_app_path}/config/webpacker.yml"
-    env["WEBPACK_DEV_SERVER"] = 'true'
+    env["WEBPACK_DEV_SERVER"] = "true"
     verify_command(cmd, env: env)
   end
 


### PR DESCRIPTION
Not sure how it works for everyone else. But as I can see, the webpack-cli@4.2.0 requires the webpack-dev-server package after our development.js file is loaded, so process.env.WEBPACK_DEV_SERVER variable is not yet available. This resulting devServer config section skipped when bin/webpack-dev-server is executed without manually setting env variables.

Looks like this problem is solved in webpack-cli@4.3.0 with a WEBPACK_SERVE environment variable (webpack/webpack-cli/pull/2027). But because the master branch is linked to 4.2.0 I came up with this solution. And I think that this is maybe a good idea to not rely on the environment variable that is set somewhere in the internals of the other project when it can be coupled within one repo.

