### PR TITLE
webpack-dev-server live reload issue fix

### DIFF
--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -25,6 +25,8 @@ development:
     host: localhost
     port: 3035
     public: localhost:3035
+    # Inject browserside javascript that required by both HMR and Live(full) reload
+    inject_client: true
     # Hot Module Replacement updates modules while the application is running without a full reload
     hmr: false
     # Inline should be set to true if using HMR; it inserts a script to take care of live reloading

--- a/package/__tests__/development.js
+++ b/package/__tests__/development.js
@@ -22,7 +22,8 @@ describe('Development environment', () => {
       expect(webpackConfig).toMatchObject({
         devServer: {
           host: 'localhost',
-          port: 3035
+          port: 3035,
+          injectClient: true
         }
       })
     })

--- a/package/environments/development.js
+++ b/package/environments/development.js
@@ -34,6 +34,7 @@ if (
       hot: devServer.hmr,
       contentBase,
       inline: devServer.inline,
+      injectClient: devServer.inject_client,
       useLocalIp: devServer.use_local_ip,
       public: devServer.public,
       publicPath,


### PR DESCRIPTION
In combination with #2890 fixes #2832.
Since webpack 5, the default compiler target is browserslist (when available), and it is not being recognized by the webpack-dev-server as a target for client injection by default. Because it searches through:

`
[
          'web',
          'webworker',
          'electron-renderer',
          'node-webkit',
          undefined,
          null
        ]
`

So, even this can be a webpack-dev-server issue, we need to set this setting explicitly to have Live Reload or HMR working. 