### PR TITLE
Removing javascript_packs_with_chunks_tag

### DIFF
--- a/6_0_upgrade.md
+++ b/6_0_upgrade.md
@@ -30,8 +30,8 @@ straightforward.
   bundle exec rails webpacker:install
   ```
 
-- Change `javascript_pack_tag` and `stylesheet_pack_tag` to `javascript_packs_with_chunks_tag` and
-  `stylesheet_packs_with_chunks_tag`
+- Change `javascript_packs_with_chunks_tag` and `stylesheet_packs_with_chunks_tag` to `javascript_pack_tag` and
+  `stylesheet_pack_tag`.
 
 7. If you are using any integrations like `css`, `React` or `TypeScript`. Please see https://github.com/rails/webpacker#integrations section on how they work in v6.0.
 

--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ app/packs:
       └── logo.svg
 ```
 
-You can then link the JavaScript pack in Rails views using the `javascript_packs_with_chunks_tag` helper. If you have styles imported in your pack file, you can link them by using `stylesheet_packs_with_chunks_tag`:
+You can then link the JavaScript pack in Rails views using the `javascript_pack_tag` helper. If you have styles imported in your pack file, you can link them by using `stylesheet_packs_with_chunks_tag`:
 
 ```erb
-<%= javascript_packs_with_chunks_tag 'application' %>
+<%= javascript_pack_tag 'application' %>
 <%= stylesheet_packs_with_chunks_tag 'application' %>
 ```
 

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -72,18 +72,6 @@ module Webpacker::Helper
     favicon_link_tag(resolve_path_to_image(name), options)
   end
 
-  # Creates a script tag that references the named pack file, as compiled by webpack per the entries list
-  # in package/environments/base.js. By default, this list is auto-generated to match everything in
-  # app/packs/entrypoints/*.js. In production mode, the digested reference is automatically looked up.
-  #
-  # Example:
-  #
-  #   <%= javascript_pack_tag 'calendar', 'data-turbolinks-track': 'reload' %> # =>
-  #   <script src="/packs/calendar-1016838bab065ae1e314.js" data-turbolinks-track="reload"></script>
-  def javascript_pack_tag(*names, **options)
-    javascript_include_tag(*sources_from_manifest_entries(names, type: :javascript), **options)
-  end
-
   # Creates script tags that reference the js chunks from entrypoints when using split chunks API,
   # as compiled by webpack per the entries list in package/environments/base.js.
   # By default, this list is auto-generated to match everything in
@@ -92,7 +80,7 @@ module Webpacker::Helper
   #
   # Example:
   #
-  #   <%= javascript_packs_with_chunks_tag 'calendar', 'map', 'data-turbolinks-track': 'reload' %> # =>
+  #   <%= javascript_pack_tag 'calendar', 'map', 'data-turbolinks-track': 'reload' %> # =>
   #   <script src="/packs/vendor-16838bab065ae1e314.chunk.js" data-turbolinks-track="reload"></script>
   #   <script src="/packs/calendar~runtime-16838bab065ae1e314.chunk.js" data-turbolinks-track="reload"></script>
   #   <script src="/packs/calendar-1016838bab065ae1e314.chunk.js" data-turbolinks-track="reload"></script>
@@ -101,13 +89,13 @@ module Webpacker::Helper
   #
   # DO:
   #
-  #   <%= javascript_packs_with_chunks_tag 'calendar', 'map' %>
+  #   <%= javascript_pack_tag 'calendar', 'map' %>
   #
   # DON'T:
   #
-  #   <%= javascript_packs_with_chunks_tag 'calendar' %>
-  #   <%= javascript_packs_with_chunks_tag 'map' %>
-  def javascript_packs_with_chunks_tag(*names, **options)
+  #   <%= javascript_pack_tag 'calendar' %>
+  #   <%= javascript_pack_tag 'map' %>
+  def javascript_pack_tag(*names, **options)
     javascript_include_tag(*sources_from_manifest_entrypoints(names, type: :javascript), **options)
   end
 
@@ -127,21 +115,6 @@ module Webpacker::Helper
     end
   end
 
-  # Creates a link tag that references the named pack file, as compiled by webpack per the entries list
-  # in package/environments/base.js. By default, this list is auto-generated to match everything in
-  # app/packs/entrypoints/*.js. In production mode, the digested reference is automatically looked up.
-  #
-  # Note: If the development server is running and hot module replacement is active, this will return nothing.
-  # In that setup you need to configure your styles to be inlined in your JavaScript for hot reloading.
-  #
-  # Examples:
-  #
-  #   <%= stylesheet_pack_tag 'calendar', 'data-turbolinks-track': 'reload' %> # =>
-  #   <link rel="stylesheet" media="screen" href="/packs/calendar-1016838bab065ae1e122.css" data-turbolinks-track="reload" />
-  def stylesheet_pack_tag(*names, **options)
-    stylesheet_link_tag(*sources_from_manifest_entries(names, type: :stylesheet), **options)
-  end
-
   # Creates link tags that reference the css chunks from entrypoints when using split chunks API,
   # as compiled by webpack per the entries list in package/environments/base.js.
   # By default, this list is auto-generated to match everything in
@@ -150,30 +123,27 @@ module Webpacker::Helper
   #
   # Examples:
   #
-  #   <%= stylesheet_packs_with_chunks_tag 'calendar', 'map' %> # =>
+  #   <%= stylesheet_pack_tag 'calendar', 'map' %> # =>
   #   <link rel="stylesheet" media="screen" href="/packs/3-8c7ce31a.chunk.css" />
   #   <link rel="stylesheet" media="screen" href="/packs/calendar-8c7ce31a.chunk.css" />
   #   <link rel="stylesheet" media="screen" href="/packs/map-8c7ce31a.chunk.css" />
   #
   # DO:
   #
-  #   <%= stylesheet_packs_with_chunks_tag 'calendar', 'map' %>
+  #   <%= stylesheet_pack_tag 'calendar', 'map' %>
   #
   # DON'T:
   #
-  #   <%= stylesheet_packs_with_chunks_tag 'calendar' %>
-  #   <%= stylesheet_packs_with_chunks_tag 'map' %>
-  def stylesheet_packs_with_chunks_tag(*names, **options)
+  #   <%= stylesheet_pack_tag 'calendar' %>
+  #   <%= stylesheet_pack_tag 'map' %>
+  def stylesheet_pack_tag(*names, **options)
     stylesheet_link_tag(*sources_from_manifest_entrypoints(names, type: :stylesheet), **options)
   end
 
   private
-    def sources_from_manifest_entries(names, type:)
-      names.map { |name| current_webpacker_instance.manifest.lookup!(name, type: type) }.flatten
-    end
 
     def sources_from_manifest_entrypoints(names, type:)
-      names.map { |name| current_webpacker_instance.manifest.lookup_pack_with_chunks!(name, type: type) }.flatten.uniq
+      names.map { |name| current_webpacker_instance.manifest.lookup_pack_with_chunks!(name.to_s, type: type) }.flatten.uniq
     end
 
     def resolve_path_to_image(name, **options)

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -79,33 +79,6 @@ class HelperTest < ActionView::TestCase
       favicon_pack_tag("media/images/nested/mb-icon.png", rel: "apple-touch-icon", type: "image/png")
   end
 
-  def test_javascript_pack_tag
-    assert_equal \
-      %(<script src="/packs/bootstrap-300631c4f0e0f9c865bc.js"></script>),
-      javascript_pack_tag("bootstrap.js")
-  end
-
-  def test_javascript_pack_tag_symbol
-    assert_equal \
-      %(<script src="/packs/bootstrap-300631c4f0e0f9c865bc.js"></script>),
-      javascript_pack_tag(:bootstrap)
-  end
-
-  def test_javascript_pack_tag_splat
-    assert_equal \
-      %(<script src="/packs/bootstrap-300631c4f0e0f9c865bc.js" defer="defer"></script>\n) +
-        %(<script src="/packs/application-k344a6d59eef8632c9d1.js" defer="defer"></script>),
-      javascript_pack_tag("bootstrap.js", "application.js", defer: true)
-  end
-
-  def test_javascript_pack_tag_split_chunks
-    assert_equal \
-      %(<script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js"></script>\n) +
-        %(<script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js"></script>\n) +
-        %(<script src="/packs/application-k344a6d59eef8632c9d1.js"></script>),
-      javascript_packs_with_chunks_tag("application")
-  end
-
   def test_preload_pack_asset
     if self.class.method_defined?(:preload_link_tag)
       assert_equal \
@@ -122,30 +95,51 @@ class HelperTest < ActionView::TestCase
     end
   end
 
-  def test_stylesheet_pack_tag_split_chunks
+  def test_javascript_pack_tag
     assert_equal \
-      %(<link rel="stylesheet" media="screen" href="/packs/1-c20632e7baf2c81200d3.chunk.css" />\n) +
-        %(<link rel="stylesheet" media="screen" href="/packs/application-k344a6d59eef8632c9d1.chunk.css" />\n) +
-        %(<link rel="stylesheet" media="screen" href="/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css" />),
-      stylesheet_packs_with_chunks_tag("application", "hello_stimulus")
+      %(<script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js"></script>\n) +
+        %(<script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js"></script>\n) +
+        %(<script src="/packs/application-k344a6d59eef8632c9d1.js"></script>\n) +
+        %(<script src="/packs/bootstrap-300631c4f0e0f9c865bc.js"></script>),
+      javascript_pack_tag("application", "bootstrap")
+  end
+
+  def test_javascript_pack_tag_splat
+    assert_equal \
+      %(<script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js" defer="defer"></script>\n) +
+        %(<script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js" defer="defer"></script>\n) +
+        %(<script src="/packs/application-k344a6d59eef8632c9d1.js" defer="defer"></script>),
+      javascript_pack_tag("application", defer: true)
+  end
+
+  def test_javascript_pack_tag_symbol
+    assert_equal \
+      %(<script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js"></script>\n) +
+        %(<script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js"></script>\n) +
+        %(<script src="/packs/application-k344a6d59eef8632c9d1.js"></script>),
+      javascript_pack_tag(:application)
   end
 
   def test_stylesheet_pack_tag
     assert_equal \
-      %(<link rel="stylesheet" media="screen" href="/packs/bootstrap-c38deda30895059837cf.css" />),
-      stylesheet_pack_tag("bootstrap.css")
+      %(<link rel="stylesheet" media="screen" href="/packs/1-c20632e7baf2c81200d3.chunk.css" />\n) +
+        %(<link rel="stylesheet" media="screen" href="/packs/application-k344a6d59eef8632c9d1.chunk.css" />\n) +
+        %(<link rel="stylesheet" media="screen" href="/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css" />),
+      stylesheet_pack_tag("application", "hello_stimulus")
   end
 
   def test_stylesheet_pack_tag_symbol
     assert_equal \
-      %(<link rel="stylesheet" media="screen" href="/packs/bootstrap-c38deda30895059837cf.css" />),
-      stylesheet_pack_tag(:bootstrap)
+      %(<link rel="stylesheet" media="screen" href="/packs/1-c20632e7baf2c81200d3.chunk.css" />\n) +
+        %(<link rel="stylesheet" media="screen" href="/packs/application-k344a6d59eef8632c9d1.chunk.css" />\n) +
+        %(<link rel="stylesheet" media="screen" href="/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css" />),
+      stylesheet_pack_tag(:application, :hello_stimulus)
   end
 
   def test_stylesheet_pack_tag_splat
     assert_equal \
-      %(<link rel="stylesheet" media="all" href="/packs/bootstrap-c38deda30895059837cf.css" />\n) +
-        %(<link rel="stylesheet" media="all" href="/packs/application-dd6b1cd38bfa093df600.css" />),
-      stylesheet_pack_tag("bootstrap.css", "application.css", media: "all")
+      %(<link rel="stylesheet" media="all" href="/packs/1-c20632e7baf2c81200d3.chunk.css" />\n) +
+        %(<link rel="stylesheet" media="all" href="/packs/application-k344a6d59eef8632c9d1.chunk.css" />),
+      stylesheet_pack_tag("application", media: "all")
   end
 end

--- a/test/test_app/public/packs/manifest.json
+++ b/test/test_app/public/packs/manifest.json
@@ -24,6 +24,13 @@
         ]
       }
     },
+    "bootstrap": {
+      "assets": {
+        "js": [
+          "/packs/bootstrap-300631c4f0e0f9c865bc.js"
+        ]
+      }
+    },
     "hello_stimulus": {
       "assets": {
         "css": [


### PR DESCRIPTION
Since chunks are enabled by default, I think we should have only one helper to manage tags