### PR TITLE
[Backport for 5.x] Fix cross-platform issue when loading nested files

### DIFF
--- a/package/rules/file.js
+++ b/package/rules/file.js
@@ -1,4 +1,4 @@
-const { join } = require('path')
+const { join, normalize } = require('path')
 const { source_path: sourcePath, static_assets_extensions: fileExtensions } = require('../config')
 
 module.exports = {
@@ -8,7 +8,7 @@ module.exports = {
       loader: 'file-loader',
       options: {
         name(file) {
-          if (file.includes(sourcePath)) {
+          if (file.includes(normalize(sourcePath))) {
             return 'media/[path][name]-[hash].[ext]'
           }
           return 'media/[folder]/[name]-[hash:8].[ext]'


### PR DESCRIPTION
That is a backport, for 5.x versions, of this PR: https://github.com/rails/webpacker/pull/2730

It fixed issues when loading nested files in platforms that are not linux (Windows, for example), normalizing it and providing the same behavior in any platform.

It also closes #2899.