### PR TITLE
[5.x] Turn Github Actions green again

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,11 +29,7 @@ jobs:
             gemfile: gemfiles/Gemfile-rails.6.0.x
         experimental: [false]
         include:
-          - ruby: head
-            os: ubuntu-latest
-            gemfile: gemfiles/Gemfile-rails.6.0.x
-            experimental: true
-          - ruby: head
+          - ruby: 2.5
             os: ubuntu-latest
             gemfile: gemfiles/Gemfile-rails-edge
             experimental: true


### PR DESCRIPTION
Fixes, in 5.x stable branch, the failed builds 👍 

The errors that was appearing was these 2 below:

![Capturar](https://user-images.githubusercontent.com/10530520/105611149-62417f00-5d92-11eb-8692-18cf01608eff.PNG)
![Capturar2](https://user-images.githubusercontent.com/10530520/105611151-6372ac00-5d92-11eb-8d51-b3609ed951bf.PNG)
