### PR TITLE
Fix typo in 5.0 to 6.0 upgrade documentation

### DIFF
--- a/6_0_upgrade.md
+++ b/6_0_upgrade.md
@@ -7,7 +7,7 @@ straightforward.
 ## Preparation
 
 1. If your `source_path` is `app/javascript`, rename it to `app/packs`
-2. If your `source_entry_path` is `app/javascript/packs`, rename it to `app/packs/entrypoints`
+2. If your `source_entry_path` is `packs`, rename it to `entrypoints`
 3. Rename `config/webpack` to `config/webpack_old`
 4. Rename `config/webpacker.yml` to `config/webpacker_old.yml`
 5. Uninstall the current version of `webpack-dev-server`: `yarn remove webpack-dev-server`


### PR DESCRIPTION
The existing documentation incorrectly listed the `source_entry_path` as a non-relative path.