### PR TITLE
[Backport for 5.x] Keep backups, even when they're old

### DIFF
--- a/lib/webpacker/commands.rb
+++ b/lib/webpacker/commands.rb
@@ -23,7 +23,7 @@ class Webpacker::Commands
         .each_with_index
         .drop_while do |(mtime, _), index|
           max_age = [0, Time.now - Time.at(mtime)].max
-          max_age < age && index < count
+          max_age < age || index < count
         end
         .each do |(_, files), index|
           files.each do |file|


### PR DESCRIPTION
That is a backport for 5.x versions of #2734

It fixed an issue where webpacker would remove previous assets during clean, rather than keeping the specified number of backups and is currently only available in the 6.x beta.

Our rails projects are still currently using a custom fork of webpacker with this fix applied, but it seems many others have unearthed the same problem (https://github.com/rails/webpacker/pull/2443#issuecomment-772811599, https://github.com/Quimbee/webpacker/commit/624f687cbdd8cb47531f7bfe1e77006a293ae64e) backporting will fix up the issue for those yet to, or unable to, upgrade to 6.x.

/cc: @dkniffin @viniciusgama @braddunbar @oboxodo