### PR TITLE
docs: fix stylesheet_packs_with_chunks_tag in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ You can then link the JavaScript pack in Rails views using the `javascript_pack_
 
 ```erb
 <%= javascript_pack_tag 'application' %>
-<%= stylesheet_packs_with_chunks_tag 'application' %>
+<%= stylesheet_pack_tag 'application' %>
 ```
 
 If you want to link a static asset for `<img />` tag, you can use the `asset_pack_path` helper:


### PR DESCRIPTION
Based on this commit:

https://github.com/rails/webpacker/commit/4565b843f649842b03c99fd877e6f3681dd92027

I believe the `stylesheet_packs_with_chunks_tag` should also be changed to `stylesheet_pack_tag` in the README.md !