### PR TITLE
Properly look up entry in manifest when name is given with extension

### DIFF
--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -92,7 +92,7 @@ class Webpacker::Manifest
     # When the user provides a name with a file extension, we want to try to strip it off.
     def manifest_name(name, pack_type)
       return name if File.extname(name.to_s).empty?
-      File.basename(name, pack_type)
+      File.basename(name, ".#{pack_type}")
     end
 
     def manifest_type(pack_type)

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -25,6 +25,14 @@ class ManifestTest < Minitest::Test
     assert_equal Webpacker.manifest.lookup!("bootstrap.js"), "/packs/bootstrap-300631c4f0e0f9c865bc.js"
   end
 
+  def test_lookup_with_chunks_without_extension_success!
+    assert_equal Webpacker.manifest.lookup_pack_with_chunks!("bootstrap", type: :javascript), ["/packs/bootstrap-300631c4f0e0f9c865bc.js"]
+  end
+
+  def test_lookup_with_chunks_with_extension_success!
+    assert_equal Webpacker.manifest.lookup_pack_with_chunks!("bootstrap.js", type: :javascript), ["/packs/bootstrap-300631c4f0e0f9c865bc.js"]
+  end
+
   def test_lookup_nil
     assert_nil Webpacker.manifest.lookup("foo.js")
   end


### PR DESCRIPTION
There was a fairly obvious (once you encounter it) bug with separating extension from entry name: `File.basename` requires not just the extension, but the full suffix, dot included:

```
> File.basename('file.rb', 'rb')
=> "file."
> File.basename('file.rb', '.rb')
=> "file"
```

(I've encountered the entry name with extension [in ActiveAdmin](https://github.com/activeadmin/activeadmin/blob/a8e9d2f78960968c2c9409b2b7e3c5cf1b5c38ba/lib/active_admin/application.rb#L167))