### PR TITLE
[5.x] Properly look up entry in manifest when name is given with extension

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,11 +29,7 @@ jobs:
             gemfile: gemfiles/Gemfile-rails.6.0.x
         experimental: [false]
         include:
-          - ruby: head
-            os: ubuntu-latest
-            gemfile: gemfiles/Gemfile-rails.6.0.x
-            experimental: true
-          - ruby: head
+          - ruby: 2.5
             os: ubuntu-latest
             gemfile: gemfiles/Gemfile-rails-edge
             experimental: true

--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -92,7 +92,7 @@ class Webpacker::Manifest
     # When the user provides a name with a file extension, we want to try to strip it off.
     def manifest_name(name, pack_type)
       return name if File.extname(name.to_s).empty?
-      File.basename(name, pack_type)
+      File.basename(name, ".#{pack_type}")
     end
 
     def manifest_type(pack_type)

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -24,6 +24,14 @@ class ManifestTest < Minitest::Test
   def test_lookup_success!
     assert_equal Webpacker.manifest.lookup!("bootstrap.js"), "/packs/bootstrap-300631c4f0e0f9c865bc.js"
   end
+  
+  def test_lookup_with_chunks_without_extension_success!
+    assert_equal Webpacker.manifest.lookup_pack_with_chunks!("bootstrap", type: :javascript), ["/packs/bootstrap-300631c4f0e0f9c865bc.js"]
+  end
+
+  def test_lookup_with_chunks_with_extension_success!
+    assert_equal Webpacker.manifest.lookup_pack_with_chunks!("bootstrap.js", type: :javascript), ["/packs/bootstrap-300631c4f0e0f9c865bc.js"]
+  end
 
   def test_lookup_nil
     assert_nil Webpacker.manifest.lookup("foo.js")


### PR DESCRIPTION
Clone of https://github.com/rails/webpacker/pull/2919, to provide the bugfix also in stable 5.x versions.

Thanks @leonid-shevtsov 🤝 🍻 