### PR TITLE
Allow "stylus" as additional file ending

### DIFF
--- a/package/rules/stylus.js
+++ b/package/rules/stylus.js
@@ -8,7 +8,7 @@ const {
 } = require('../config')
 
 module.exports = canProcess('stylus-loader', (resolvedPath) =>
-  getStyleRule(/\.(styl)(\.erb)?$/i, [
+  getStyleRule(/\.(styl(us)?)(\.erb)?$/i, [
     {
       loader: resolvedPath,
       options: {


### PR DESCRIPTION
I found that the file extension and the language code (in Vue files) "stylus" (instead of "styl") becomes more common (e.g. RubyMine suggests it in autocompletion), so this PR simply adds support for using "stylus" in addition to "styl".

![Bildschirmfoto 2021-02-11 um 13 47 13](https://user-images.githubusercontent.com/341793/107639169-d0ca7c00-6c70-11eb-9ecb-ea2be938ef5b.png)
(Screenshot of RubyMine's autocompletion suggestions)