### PR TITLE
Improve error messaging when running webpacker:install

### DIFF
--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -72,4 +72,5 @@ if results.all?
   say "Webpacker successfully installed 🎉 🍰", :green
 else
   say "Webpacker installation failed 😭 See above for details.", :red
+  exit 1
 end

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -26,13 +26,15 @@ if File.exists?(git_ignore_path)
   end
 end
 
+results = []
+
 Dir.chdir(Rails.root) do
   if Webpacker::VERSION =~ /^[0-9]+\.[0-9]+\.[0-9]+$/
     say "Installing all JavaScript dependencies [#{Webpacker::VERSION}]"
-    run "yarn add @rails/webpacker@#{Webpacker::VERSION}"
+    results << run("yarn add @rails/webpacker@#{Webpacker::VERSION}")
   else
     say "Installing all JavaScript dependencies [from prerelease rails/webpacker]"
-    run "yarn add @rails/webpacker@next"
+    results << run("yarn add @rails/webpacker@next")
   end
 
   package_json = File.read("#{__dir__}/../../package.json")
@@ -41,10 +43,10 @@ Dir.chdir(Rails.root) do
 
   # needed for experimental Yarn 2 support and should not harm Yarn 1
   say "Installing webpack and webpack-cli as direct dependencies"
-  run "yarn add webpack@#{webpack_version} webpack-cli@#{webpack_cli_version}"
+  results << run("yarn add webpack@#{webpack_version} webpack-cli@#{webpack_cli_version}")
 
   say "Installing dev server for live reloading"
-  run "yarn add --dev webpack-dev-server @webpack-cli/serve"
+  results << run("yarn add --dev webpack-dev-server @webpack-cli/serve")
 end
 
 insert_into_file Rails.root.join("package.json").to_s, before: /\n}\n*$/ do
@@ -66,4 +68,8 @@ if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR > 1
   say "policy.connect_src :self, :https, \"http://localhost:3035\", \"ws://localhost:3035\" if Rails.env.development?", :yellow
 end
 
-say "Webpacker successfully installed 🎉 🍰", :green
+if results.all?
+  say "Webpacker successfully installed 🎉 🍰", :green
+else
+  say "Webpacker installation failed 😭 See above for details.", :red
+end


### PR DESCRIPTION
Hello! I noticed that running `rails webpacker:install` will always report success, even if an underlying yarn command fails:

<img width="636" alt="Screen Shot 2021-02-18 at 08 58 03" src="https://user-images.githubusercontent.com/7259082/108392401-8ba1cf00-71c7-11eb-9403-8aae4113609d.png">

This can happen for many reasons, including network timeouts, or using a private registry and encountering authentication failure, etc.

We already output enough info from the yarn command itself to debug, but the "success" message is a bit misleading. I thought it would be nicer to tell the user that something went wrong instead:

<img width="634" alt="Screen Shot 2021-02-18 at 08 57 02" src="https://user-images.githubusercontent.com/7259082/108392674-ca378980-71c7-11eb-8aaf-47f271cfb887.png">

