### PR TITLE
Wrap the path in quotes

### DIFF
--- a/lib/tasks/webpacker/binstubs.rake
+++ b/lib/tasks/webpacker/binstubs.rake
@@ -7,9 +7,9 @@ namespace :webpacker do
     prefix = task.name.split(/#|webpacker:binstubs/).first
 
     if Rails::VERSION::MAJOR >= 5
-      exec "#{RbConfig.ruby} #{bin_path}/rails #{prefix}app:template LOCATION=#{binstubs_template_path}"
+      exec "#{RbConfig.ruby} #{bin_path}/rails #{prefix}app:template LOCATION='#{binstubs_template_path}'"
     else
-      exec "#{RbConfig.ruby} #{bin_path}/rake #{prefix}rails:template LOCATION=#{binstubs_template_path}"
+      exec "#{RbConfig.ruby} #{bin_path}/rake #{prefix}rails:template LOCATION='#{binstubs_template_path}'"
     end
   end
 end

--- a/lib/tasks/webpacker/install.rake
+++ b/lib/tasks/webpacker/install.rake
@@ -7,9 +7,9 @@ namespace :webpacker do
     prefix = task.name.split(/#|webpacker:install/).first
 
     if Rails::VERSION::MAJOR >= 5
-      exec "#{RbConfig.ruby} #{bin_path}/rails #{prefix}app:template LOCATION=#{install_template_path}"
+      exec "#{RbConfig.ruby} #{bin_path}/rails #{prefix}app:template LOCATION='#{install_template_path}'"
     else
-      exec "#{RbConfig.ruby} #{bin_path}/rake #{prefix}rails:template LOCATION=#{install_template_path}"
+      exec "#{RbConfig.ruby} #{bin_path}/rake #{prefix}rails:template LOCATION='#{install_template_path}'"
     end
   end
 end


### PR DESCRIPTION
## Description

While trying to upgrade to Rails 6 one of my projects, I noticed that `bin/rails webpacker:install` was failing with

```shell
Thor::Error: Could not find "/Users/raulriera/Library/Mobile" in any of your source paths. Your current source paths are: 
/Users/raulriera/Library/Mobile Documents/com~apple~CloudDocs/Documents/Work/odonto.me/odontome/vendor/cache/ruby/2.7.0/gems/railties-6.1.3/lib/rails/generators/rails/app/templates
/Users/raulriera/Library/Mobile Documents/com~apple~CloudDocs/Documents/Work/odonto.me/odontome/vendor/cache/ruby/2.7.0/gems/thor-1.1.0/lib/thor/actions.rb:156:in `find_in_source_paths'
/Users/raulriera/Library/Mobile Documents/com~apple~CloudDocs/Documents/Work/odonto.me/odontome/vendor/cache/ruby/2.7.0/gems/thor-1.1.0/lib/thor/actions.rb:215:in `apply'
/Users/raulriera/Library/Mobile Documents/com~apple~CloudDocs/Documents/Work/odonto.me/odontome/vendor/cache/ruby/2.7.0/gems/railties-6.1.3/lib/rails/tasks/framework.rake:15:in `block (2 levels) in <top (required)>'
```

Turns out the `LOCATION` environment variable when set without quotes will get trimmed.  I was unable to find a test for the install action 🤔 

This should probably be merged into the 5.x branch as well (if accepted)