### PR TITLE
Enable devServer.stats.colors by default

### DIFF
--- a/package/environments/development.js
+++ b/package/environments/development.js
@@ -42,6 +42,7 @@ if (
       headers: devServer.headers,
       overlay: devServer.overlay,
       stats: {
+        colors: true,
         entrypoints: false,
         errorDetails: true,
         modules: false,


### PR DESCRIPTION
## Problem

The webpack-dev-server changed the default option for devServer.stats.colors from true to false in [a recent changeset](https://github.com/webpack/webpack-dev-server/pull/2660/files#r447299960).

Hence, in previous versions of Webpacker, the webpack-dev-server output was colorized, but is no longer in Webpacker 6.

## Solution

This PR sets the default Webpacker 6 devServer.stats.colors to true to preserve colorized behavior across the upgrade. This is consistent with the behavior of `bin/webpack`, which _is_ colorized by default and, generally, with Rails.logger behavior in development.

### Before

Webpacker 6 `$ bin/webpack-dev-server`
<img width="1089" alt="Screen Shot 2021-02-24 at 3 47 03 PM" src="https://user-images.githubusercontent.com/11673/109064802-d71d1700-76b8-11eb-8842-753601425cb5.png">


### After

Webpacker 6 `$ bin/webpack-dev-server`
<img width="1098" alt="Screen Shot 2021-02-24 at 3 49 16 PM" src="https://user-images.githubusercontent.com/11673/109064836-e0a67f00-76b8-11eb-8059-20a18662d81d.png">

See also current behavior of Webpacker 6 `$ bin/webpack`
<img width="1091" alt="Screen Shot 2021-02-24 at 3 47 12 PM" src="https://user-images.githubusercontent.com/11673/109064994-15b2d180-76b9-11eb-866c-b8c3ecdb0df7.png">

Fixes #2936