### PR TITLE
Preserve paths in entrypoint lookup

### DIFF
--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -91,8 +91,7 @@ class Webpacker::Manifest
     # manifest hash the entrypoints are defined by their pack name without the extension.
     # When the user provides a name with a file extension, we want to try to strip it off.
     def manifest_name(name, pack_type)
-      return name if File.extname(name.to_s).empty?
-      File.basename(name, ".#{pack_type}")
+      name.chomp(".#{pack_type}")
     end
 
     def manifest_type(pack_type)

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -33,6 +33,14 @@ class ManifestTest < Minitest::Test
     assert_equal ["/packs/bootstrap-300631c4f0e0f9c865bc.js"], Webpacker.manifest.lookup_pack_with_chunks!("bootstrap.js", type: :javascript)
   end
 
+  def test_lookup_with_chunks_without_extension_subdir_success!
+    assert_equal ["/packs/print/application-983b6c164a47f7ed49cd.css"], Webpacker.manifest.lookup_pack_with_chunks!("print/application", type: :css)
+  end
+
+  def test_lookup_with_chunks_with_extension_subdir_success!
+    assert_equal ["/packs/print/application-983b6c164a47f7ed49cd.css"], Webpacker.manifest.lookup_pack_with_chunks!("print/application.css", type: :css)
+  end
+
   def test_lookup_nil
     assert_nil Webpacker.manifest.lookup("foo.js")
   end

--- a/test/manifest_test.rb
+++ b/test/manifest_test.rb
@@ -26,11 +26,11 @@ class ManifestTest < Minitest::Test
   end
 
   def test_lookup_with_chunks_without_extension_success!
-    assert_equal Webpacker.manifest.lookup_pack_with_chunks!("bootstrap", type: :javascript), ["/packs/bootstrap-300631c4f0e0f9c865bc.js"]
+    assert_equal ["/packs/bootstrap-300631c4f0e0f9c865bc.js"], Webpacker.manifest.lookup_pack_with_chunks!("bootstrap", type: :javascript)
   end
 
   def test_lookup_with_chunks_with_extension_success!
-    assert_equal Webpacker.manifest.lookup_pack_with_chunks!("bootstrap.js", type: :javascript), ["/packs/bootstrap-300631c4f0e0f9c865bc.js"]
+    assert_equal ["/packs/bootstrap-300631c4f0e0f9c865bc.js"], Webpacker.manifest.lookup_pack_with_chunks!("bootstrap.js", type: :javascript)
   end
 
   def test_lookup_nil

--- a/test/test_app/public/packs/manifest.json
+++ b/test/test_app/public/packs/manifest.json
@@ -38,6 +38,13 @@
           "/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css"
         ]
       }
+    },
+    "print/application": {
+      "assets": {
+        "css": [
+          "/packs/print/application-983b6c164a47f7ed49cd.css"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
Looking up `print/application.css` in the manifest should yield the same entry as a lookup for `print/application`. Previously it would strip parent paths and yield the entry for `application`.

Related to #2919, which fixed entrypoints with extensions that lack paths.

I'm new to this codebase, all feedback very welcome!