### PR TITLE
Clear error message when yarn or node not installed

### DIFF
--- a/lib/tasks/webpacker/check_node.rake
+++ b/lib/tasks/webpacker/check_node.rake
@@ -3,6 +3,7 @@ namespace :webpacker do
   desc "Verifies if Node.js is installed"
   task :check_node do
     begin
+      raise Errno::ENOENT if `which node || which nodejs`.strip.empty?
       node_version = `node -v || nodejs -v`.strip
       raise Errno::ENOENT if node_version.blank?
 

--- a/lib/tasks/webpacker/check_yarn.rake
+++ b/lib/tasks/webpacker/check_yarn.rake
@@ -3,6 +3,7 @@ namespace :webpacker do
   desc "Verifies if Yarn is installed"
   task :check_yarn do
     begin
+      raise Errno::ENOENT if `which yarn`.strip.empty?
       yarn_version = `yarn --version`.strip
       raise Errno::ENOENT if yarn_version.blank?
 


### PR DESCRIPTION
This fix addresses rails/webpacker#954

When yarn is NOT installed I run into the following issue:

```
   $ rake webpacker:check_yarn
   bin/rails: No such file or directory - yarn
   rails aborted!
   NoMethodError: undefined method `strip' for nil:NilClass
   Tasks: TOP => webpacker:check_yarn
   (See full trace by running task with --trace)
```

It looks like lib/tasks/webpacker/check_yarn.rake behaves as expected when line 6 calls ``yarn_version = `yarn --version`.strip``.  When yarn is not installed the shell raises an exception and is rescued on line 25.

HOWEVER! When running this in the application, Rails will rescue this exception and `yarn --version` will return nil.  The tests do not test this adequately in a Rails environment.

This fix will more elegantly call `which yarn` first and follow the expected error handling.