### PR TITLE
semantic_range dep: Update; use twiddle-wakka

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
-      semantic_range (>= 2.3.0)
+      semantic_range (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -145,7 +145,7 @@ GEM
       rubocop (>= 0.87.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.10.1)
-    semantic_range (2.3.0)
+    semantic_range (3.0.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/webpacker.gemspec
+++ b/webpacker.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", ">= 5.2"
   s.add_dependency "railties",      ">= 5.2"
   s.add_dependency "rack-proxy",    ">= 0.6.1"
-  s.add_dependency "semantic_range", ">= 2.3.0"
+  s.add_dependency "semantic_range", "~> 3.0"
 
   s.add_development_dependency "bundler", ">= 1.3.0"
   s.add_development_dependency "rubocop", "0.93.1"


### PR DESCRIPTION
3.0 was recently released, and it was a bit scary to find the version constraint in Webpacker was optimistic – it could have been incompatible.

Turned out it only changed APIs that Webpacker doesn't use. But I think we can trust "semantic_range" to use semantic versioning itself, so let's be careful in future :)

Did not change any other version constraints to keep this focused, but that may be a good idea too.