### PR TITLE
Add support to run webpack-dev-server via webpack-dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,35 @@ const vueConfig = require('./rules/vue')
 module.exports = merge(webpackConfig, vueConfig)
 ```
 
+#### Webpack-Dashboard
+
+When running webpack-dev-server in a separate process, a CLI dashboard could be used - [Webpack-Dashboard](https://github.com/FormidableLabs/webpack-dashboard)
+
+Add it to the gem's package.json:
+
+```bash
+yarn add --dev webpack-dashboard
+```
+
+Configure it as a webpack plugin:
+
+```js
+// config/webpack/development.js
+const webpackConfig = require('./base')
+const { merge } = require('webpack-merge')
+const DashboardPlugin = require("webpack-dashboard/plugin")
+
+module.exports = merge(webpackConfig, {
+  plugins: [new DashboardPlugin()],
+})
+```
+
+Add it as an option when starting the dev server:
+
+```bash
+bin/webpack-dev-server --webpack-dashboard
+```
+
 ### Custom Rails environments
 
 Out of the box Webpacker ships with - development, test and production environments in `config/webpacker.yml` however, in most production apps extra environments are needed as part of deployment workflow. Webpacker supports this out of the box from version 3.4.0+ onwards.

--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -77,6 +77,17 @@ module Webpacker
           @argv.delete "--debug-webpacker"
         end
 
+        if @argv.include?("--webpack-dashboard")
+          cmd = if node_modules_bin_exist?
+            %W[#{@node_modules_bin_path}/webpack-dashboard --] + cmd
+          else
+            idx_after_yarn = cmd.index("yarn") + 1
+            cmd.insert(idx_after_yarn, "webpack-dashboard", "--")
+          end
+
+          @argv.delete "--webpack-dashboard"
+        end
+
         cmd += ["--config", @webpack_config]
         cmd += ["--progress", "--color"] if @pretty
         cmd += @argv

--- a/test/dev_server_runner_test.rb
+++ b/test/dev_server_runner_test.rb
@@ -18,10 +18,22 @@ class DevServerRunnerTest < Webpacker::Test
     verify_command(cmd, use_node_modules: true)
   end
 
+  def test_run_via_dashboard_via_node_modules
+    cmd = %W[#{test_app_path}/node_modules/.bin/webpack-dashboard -- #{test_app_path}/node_modules/.bin/webpack serve --config #{test_app_path}/config/webpack/development.js]
+
+    verify_command(cmd, use_node_modules: true, argv: ["--webpack-dashboard"])
+  end
+
   def test_run_cmd_via_yarn
     cmd = ["yarn", "webpack", "serve", "--config", "#{test_app_path}/config/webpack/development.js"]
 
     verify_command(cmd, use_node_modules: false)
+  end
+
+  def test_run_via_dashboard_via_yarn
+    cmd = %W[yarn webpack-dashboard -- webpack serve --config #{test_app_path}/config/webpack/development.js]
+
+    verify_command(cmd, use_node_modules: false, argv: ["--webpack-dashboard"])
   end
 
   def test_run_cmd_argv


### PR DESCRIPTION
Add support for this convenient [Webpack-Dashboard](https://github.com/FormidableLabs/webpack-dashboard) 

![http://i.imgur.com/qL6dXJd.png](http://i.imgur.com/qL6dXJd.png)
