### PR TITLE
Always use content hash for MiniCssExtractPlugin

### DIFF
--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -67,12 +67,8 @@ const getPlugins = () => {
     const MiniCssExtractPlugin = require('mini-css-extract-plugin')
     plugins.push(
       new MiniCssExtractPlugin({
-        filename: isDevelopment
-          ? 'css/[name].css'
-          : 'css/[name]-[contenthash:8].css',
-        chunkFilename: isDevelopment
-          ? 'css/[id].css'
-          : 'css/[id]-[contenthash:8].css'
+        filename: 'css/[name]-[contenthash:8].css',
+        chunkFilename: 'css/[id]-[contenthash:8].css'
       })
     )
   }

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -10,7 +10,6 @@ const WebpackAssetsManifest = require('webpack-assets-manifest')
 const webpack = require('webpack')
 const rules = require('../rules')
 const config = require('../config')
-const { isDevelopment } = require('../env')
 const { moduleExists } = require('../utils/helpers')
 
 const getEntryObject = () => {


### PR DESCRIPTION
Closes #2928 

With Javascript packs in development mode, files are outputted with
hashes in the file names so browser cache is automatically busted when
code is changed and new files are made.

However, the mini-css-extract-plugin plugin is only configured to output
files with hashes in production mode. This means that any changes to CSS
files locally will appear to not have any effect on the page you are
working on because the browser is assuming the resulting CSS file with
the same name has not changed and reloads the cached version, forcing us
to manually bust browser cache to see our changes.

This code change enables the hash-based file names for the plugin
regardless of environment.