### PR TITLE
Make versions explicit in 6.0 upgrade doc

### DIFF
--- a/docs/v6_upgrade.md
+++ b/docs/v6_upgrade.md
@@ -35,24 +35,27 @@ Now you have a straight access to the Webpack configuration and you can change i
 3. Rename `config/webpack` to `config/webpack_old`
 4. Rename `config/webpacker.yml` to `config/webpacker_old.yml`
 5. Uninstall the current version of `webpack-dev-server`: `yarn remove webpack-dev-server`
-6. Upgrade Webpacker
+6. Upgrade webpacker to the latest beta
 
-  ```ruby
-  # Gemfile
-  gem 'webpacker', '~> 6.0.0.pre.2'
-  ```
+- [Check the releases page to verify the latest version](https://github.com/rails/webpacker/releases)
+- Make sure to install identical version numbers of webpacker gem and `@rails/webpacker` npm package
 
-  ```bash
-  bundle install
-  ```
+```ruby
+# Gemfile
+gem 'webpacker', '6.0.0.beta.7'
+```
 
-  ```bash
-  yarn add @rails/webpacker@next
-  ```
+```bash
+bundle install
+```
 
-  ```bash
-  bundle exec rails webpacker:install
-  ```
+```bash
+yarn add @rails/webpacker@6.0.0-beta.7
+```
+
+```bash
+bundle exec rails webpacker:install
+```
 
 - Change `javascript_packs_with_chunks_tag` and `stylesheet_packs_with_chunks_tag` to `javascript_pack_tag` and
   `stylesheet_pack_tag`.
@@ -75,12 +78,13 @@ Now you have a straight access to the Webpack configuration and you can change i
 9. Copy over custom browserlist config from `.browserslistrc` if it exists into the `"browserslist"` key in `package.json` and remove `.browserslistrc`.
 
 10. `extensions` was removed from the webpacker.yml file. Move custom extensions to
-  your configuration by merging an object like this. For more details, see docs for
-  [Webpack Configuration](https://github.com/rails/webpacker/blob/master/README.md#webpack-configuration)
+    your configuration by merging an object like this. For more details, see docs for
+    [Webpack Configuration](https://github.com/rails/webpacker/blob/master/README.md#webpack-configuration)
+
 ```js
 {
   resolve: {
-      extensions: ['.ts', '.tsx']
+    extensions: ['.ts', '.tsx']
   }
 }
 ```


### PR DESCRIPTION
## Problem

The 6.0 upgrade instructions as written do not guarantee that developers will end up with identical versions for the webpacker gem and `@rails/webpacker` NPM package. Certain version combinations are incompatible causing developers to run into issues with the upgrade. 

Examples 

- #2955 
- https://discuss.rubyonrails.org/t/upgrading-to-webpacker-6-0-0/77392/4

There is unexpected behavior when following the upgrade instructions:

1. Given the instruction `gem 'webpacker', '~> 6.0.0.pre.2'`, bundler does not install the latest prerelease with the pessimistic version constraint. I would expect bundler to install the latest prerelease version, which, as of this note, is `6.0.0.beta.6`, but instead, `6.0.0.pre.2` is installed.
2. Given the instruction `yarn add @rails/webpacker@next`, yarn does not necessarily install the same version as my webpacker gem nor the latest prerelease. As of this note, it installs `6.0.0.beta.5` when I want `6.0.0.beta.6`.

## Solution

To avoid ambiguity and possibly incompatible installations, I've updated the upgrade instructions to be explicit about version numbers. I've added a note to encourage developers to check the releases page for the latest release, should the version number in the doc get out-of-date. I've also added a note to encourage developers to ensure that the gem and NPM version numbers match to avoid compatibility problems.

Fixes #2955 