### PR TITLE
Correct docs re: assets:precompile task

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,7 +2,17 @@
 
 
 Webpacker hooks up a new `webpacker:compile` task to `assets:precompile`, which gets run whenever you run `assets:precompile`.
-If you are not using Sprockets `webpacker:compile` is automatically aliased to `assets:precompile`. Remember to set NODE_ENV environment variable to production during deployment or when running the rake task.
+If you are not using Sprockets you must define `assets:precompile` yourself. 
+
+```ruby
+# When not using Sprockets, must define assets:precompile manually
+# https://github.com/heroku/heroku-buildpack-ruby/issues/576#issuecomment-305847577
+task "assets:precompile" do
+  Rake::Task["webpacker:compile"].invoke
+end
+```
+
+Remember to set NODE_ENV environment variable to production during deployment or when running the rake task.
 
 The `javascript_pack_tag` and `stylesheet_pack_tag` helper method will automatically insert the correct HTML tag for compiled pack. Just like the asset pipeline does it.
 


### PR DESCRIPTION
Based on my experience only, it seems *to me* that the documentation is incorrect or misleading here.

After uninstalling sprockets, I no longer see the `assets:precompile` task in my `rake -T` list. According to the docs, I should, but I don't.

```plain
bundle info sprockets
Could not find gem 'sprockets'.
bundle info webpacker
  * webpacker (5.2.1)
NODE_ENV=production bin/rake -T | egrep -i compile
rake webpacker:clean[keep,age]                                      # Remove old compiled webpacks
rake webpacker:clobber                                              # Remove the webpack compiled output directory
rake webpacker:compile                                              # Compile JavaScript packs using webpack for production with digests
```