### PR TITLE
make fetch public

### DIFF
--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -63,11 +63,11 @@ class Webpacker::Configuration
     fetch(:webpack_compile_output)
   end
 
-  private
-    def fetch(key)
-      data.fetch(key, defaults[key])
-    end
+  def fetch(key)
+    data.fetch(key, defaults[key])
+  end
 
+  private
     def data
       @data ||= load
     end


### PR DESCRIPTION
To get the public_output_path without the file system, one must call
Webpacker.config.send(:fetch, :public_output_path)

Instead, this PR allows
Webpacker.config.fetch(:public_output_path)
