### PR TITLE
Allow to set runner config path with an env var

### DIFF
--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -20,7 +20,7 @@ module Webpacker
 
         @config = Configuration.new(
           root_path: app_root,
-          config_path: app_root.join("config/webpacker.yml"),
+          config_path: Pathname.new(@webpacker_config),
           env: ENV["RAILS_ENV"]
         )
 

--- a/lib/webpacker/runner.rb
+++ b/lib/webpacker/runner.rb
@@ -12,7 +12,7 @@ module Webpacker
       @app_path              = File.expand_path(".", Dir.pwd)
       @node_modules_bin_path = ENV["WEBPACKER_NODE_MODULES_BIN_PATH"] || `yarn bin`.chomp
       @webpack_config        = File.join(@app_path, "config/webpack/#{ENV["NODE_ENV"]}.js")
-      @webpacker_config      = File.join(@app_path, "config/webpacker.yml")
+      @webpacker_config      = ENV["WEBPACKER_CONFIG"] || File.join(@app_path, "config/webpacker.yml")
 
       unless File.exist?(@webpack_config)
         $stderr.puts "webpack config #{@webpack_config} not found, please run 'bundle exec rails webpacker:install' to install Webpacker with default configs or add the missing config file for your custom environment."

--- a/test/dev_server_runner_test.rb
+++ b/test/dev_server_runner_test.rb
@@ -5,11 +5,13 @@ class DevServerRunnerTest < Webpacker::Test
   def setup
     @original_node_env, ENV["NODE_ENV"] = ENV["NODE_ENV"], "development"
     @original_rails_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "development"
+    @original_webpacker_config = ENV["WEBPACKER_CONFIG"]
   end
 
   def teardown
     ENV["NODE_ENV"] = @original_node_env
     ENV["RAILS_ENV"] = @original_rails_env
+    ENV["WEBPACKER_CONFIG"] = @original_webpacker_config
   end
 
   def test_run_cmd_via_node_modules
@@ -46,7 +48,7 @@ class DevServerRunnerTest < Webpacker::Test
   def test_environment_variables
     cmd = ["#{test_app_path}/node_modules/.bin/webpack", "serve", "--config", "#{test_app_path}/config/webpack/development.js"]
     env = Webpacker::Compiler.env.dup
-    env["WEBPACKER_CONFIG"] = "#{test_app_path}/config/webpacker.yml"
+    ENV["WEBPACKER_CONFIG"] = env["WEBPACKER_CONFIG"] = "#{test_app_path}/config/webpacker_other_location.yml"
     env["WEBPACK_DEV_SERVER"] = "true"
     verify_command(cmd, env: env)
   end

--- a/test/test_app/config/webpacker_other_location.yml
+++ b/test/test_app/config/webpacker_other_location.yml
@@ -1,0 +1,79 @@
+# Note: You must restart bin/webpack-dev-server for changes to take effect
+
+default: &default
+  source_path: app/packs
+  source_entry_path: entrypoints
+  public_root_path: public
+  public_output_path: packs
+  cache_path: tmp/cache/webpacker
+  webpack_compile_output: false
+
+  # Additional paths webpack should look up modules
+  # ['app/assets', 'engine/foo/app/assets']
+  additional_paths:
+    - app/assets
+    - /etc/yarn
+    - some.config.js
+    - app/elm
+
+  # Reload manifest.json on all requests so we reload latest compiled packs
+  cache_manifest: false
+
+  static_assets_extensions:
+    - .jpg
+    - .jpeg
+    - .png
+    - .gif
+    - .tiff
+    - .ico
+    - .svg
+
+  extensions:
+    - .mjs
+    - .js
+
+development:
+  <<: *default
+  compile: true
+
+  # Reference: https://webpack.js.org/configuration/dev-server/
+  dev_server:
+    https: false
+    host: localhost
+    port: 3035
+    public: localhost:3035
+    hmr: false
+    # Inline should be set to true if using HMR
+    inline: true
+    overlay: true
+    disable_host_check: true
+    use_local_ip: false
+    pretty: false
+
+test:
+  <<: *default
+  compile: true
+
+  # Compile test packs to a separate directory
+  public_output_path: packs-test
+
+production:
+  <<: *default
+
+  # Production depends on precompilation of packs prior to booting for performance.
+  compile: false
+
+  # Cache manifest.json for performance
+  cache_manifest: true
+
+staging:
+  <<: *default
+
+  # Production depends on precompilation of packs prior to booting for performance.
+  compile: false
+
+  # Cache manifest.json for performance
+  cache_manifest: true
+
+  # Compile staging packs to a separate directory
+  public_output_path: packs-staging


### PR DESCRIPTION
Dev Server `config_path` is hardcoded to `app_root/config/webpacker.yml`, while in other parts you can re-define the location of the configuration, here you can't. 

This change let's you to customize the config_path for the dev server, in case you are using a custom path for configuration in your Webpacker instance.

Just to give some context, I'm working in a Rails engine that I want the instance app to have the webpacker configuration, so I'm declaring the config_path relative to the `Rails.root`:

```
module Decidim
  # Declare a Webpacker instance for Decidim
  ROOT_PATH = Pathname.new(File.join(__dir__, ".."))

  class << self
    def webpacker
      @webpacker ||= ::Webpacker::Instance.new(
        root_path: ROOT_PATH,
        config_path: Rails.root.join("config/decidim_webpacker.yml")
      )
    end
```

With this patch I can run `WEBPACKER_CONFIG=/path/to/app/config/decidim_webpacker.ytml bin/webpack-dev-server`