### PR TITLE
Move cache_path (and compilation_digest_path) out of default Rails.cache.cache_path

### DIFF
--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -5,7 +5,7 @@ default: &default
   source_entry_path: entrypoints
   public_root_path: public
   public_output_path: packs
-  cache_path: tmp/cache/webpacker
+  cache_path: tmp/webpacker
   webpack_compile_output: true
 
   # Additional paths webpack should look up modules

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -44,7 +44,7 @@ class ConfigurationTest < Webpacker::Test
   end
 
   def test_cache_path
-    cache_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/tmp/cache/webpacker").to_s
+    cache_path = File.expand_path File.join(File.dirname(__FILE__), "test_app/tmp/webpacker").to_s
     assert_equal @config.cache_path.to_s, cache_path
   end
 

--- a/test/mounted_app/test/dummy/config/webpacker.yml
+++ b/test/mounted_app/test/dummy/config/webpacker.yml
@@ -4,7 +4,7 @@ default: &default
   source_path: app/packs
   source_entry_path: entrypoints
   public_output_path: packs
-  cache_path: tmp/cache/webpacker
+  cache_path: tmp/webpacker
 
   # Additional paths webpack should look up modules
   # ['app/assets', 'engine/foo/app/assets']

--- a/test/test_app/config/webpacker.yml
+++ b/test/test_app/config/webpacker.yml
@@ -5,7 +5,7 @@ default: &default
   source_entry_path: entrypoints
   public_root_path: public
   public_output_path: packs
-  cache_path: tmp/cache/webpacker
+  cache_path: tmp/webpacker
   webpack_compile_output: false
 
   # Additional paths webpack should look up modules


### PR DESCRIPTION
This effectively partially reverts this commit https://github.com/rails/webpacker/commit/064148e9aed1fd0d2076edcd628fc5ec4f4f3b73

Highlights from it:

was: `mattr_accessor(:cache_dir) { "tmp/webpacker" }`
now:  `cache_path: tmp/cache/webpacker`

When using `ActiveSupport::Cache::FileStore` for cache, `Rails.cache.clear` and `rake rails:tmp:clear` clear all contents inside `tmp/cache` including `compilation_digest_path` which is `config.cache_path.join("last-compilation-digest-#{webpacker.env}")`

This forces packs rebuild while the next deployment, even if no assets changed

Of course, this can be configured in the application, but I think this default saves some time to find out why sometimes compilation continues to happen even if no assets changed