### PR TITLE
Fix babel warning about private-methods

### DIFF
--- a/lib/install/config/babel.config.js
+++ b/lib/install/config/babel.config.js
@@ -54,6 +54,12 @@ module.exports = function(api) {
         }
       ],
       [
+        '@babel/plugin-proposal-private-methods',
+        {
+          loose: true
+        }
+      ],
+      [
         '@babel/plugin-transform-runtime',
         {
           helpers: false

--- a/lib/install/examples/react/babel.config.js
+++ b/lib/install/examples/react/babel.config.js
@@ -63,6 +63,12 @@ module.exports = function(api) {
         }
       ],
       [
+        '@babel/plugin-proposal-private-methods',
+        {
+          loose: true
+        }
+      ],
+      [
         '@babel/plugin-transform-runtime',
         {
           helpers: false,


### PR DESCRIPTION
#### ⚠️ I'm not a JavaScript developer ⚠️ 

How to replicate:

```
$ rails _6.1.3.2_ new test-babel-warning --skip-active-record --skip-javascript
$ cd test-babel-warning
$ echo "{ \"private\": true }" > package.json
$ echo "gem 'webpacker', '5.4.0'" >> Gemfile
$ bundle
$ bundle exec rails webpacker:install
$ echo "class Counter extends HTMLElement { #xValue = 0; }" >> app/javascript/packs/application.js
$ bin/webpack
```

```
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
	["@babel/plugin-proposal-private-methods", { "loose": true }]
to the "plugins" section of your Babel config.
```

---

The "loose" option must be the same for:

- @babel/plugin-proposal-class-properties,
- @babel/plugin-proposal-private-methods
- @babel/plugin-proposal-private-property-in-object

class-properties and private-methods are dependencies of
@babel/preset-env, which is required by webpacker.

This commit sets the same loose value for both class-properties and
private-methods to silence the warning 

Fix #3008