### PR TITLE
Fix compare links in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,11 +43,11 @@ environment.loaders.append('nodeModules', nodeModules)
 
 - Bump deps and remove node-sass [#2997](https://github.com/rails/webpacker/pull/2997).
 
-## [[5.2.1]](https://github.com/rails/webpacker/compare/v5.2.0...5.2.1) - 2020-08-17
+## [[5.2.1]](https://github.com/rails/webpacker/compare/v5.2.0...v5.2.1) - 2020-08-17
 
 - Revert [#1311](https://github.com/rails/webpacker/pull/1311).
 
-## [[5.2.0]](https://github.com/rails/webpacker/compare/v5.1.1...5.2.0) - 2020-08-16
+## [[5.2.0]](https://github.com/rails/webpacker/compare/v5.1.1...v5.2.0) - 2020-08-16
 
 - Bump dependencies and fixes. See [diff](https://github.com/rails/webpacker/compare/v5.1.1...5-x-stable) for changes.
 


### PR DESCRIPTION
The strict tag names are required in compare links.