### PR TITLE
Fix compatibility with Psych 4

### DIFF
--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -73,8 +73,12 @@ class Webpacker::Configuration
     end
 
     def load
-      YAML.load(config_path.read)[env].deep_symbolize_keys
-
+      config = begin
+        YAML.load_file(config_path.to_s, aliases: true)
+      rescue ArgumentError
+        YAML.load_file(config_path.to_s)
+      end
+      config[env].deep_symbolize_keys
     rescue Errno::ENOENT => e
       raise "Webpacker configuration file not found #{config_path}. " \
             "Please run rails webpacker:install " \
@@ -87,7 +91,14 @@ class Webpacker::Configuration
     end
 
     def defaults
-      @defaults ||= \
-        HashWithIndifferentAccess.new(YAML.load_file(File.expand_path("../../install/config/webpacker.yml", __FILE__))[env])
+      @defaults ||= begin
+        path = File.expand_path("../../install/config/webpacker.yml", __FILE__)
+        config = begin
+          YAML.load_file(path, aliases: true)
+        rescue ArgumentError
+          YAML.load_file(path)
+        end
+        HashWithIndifferentAccess.new(config[env])
+      end
     end
 end

--- a/lib/webpacker/env.rb
+++ b/lib/webpacker/env.rb
@@ -27,7 +27,11 @@ class Webpacker::Env
 
     def available_environments
       if config_path.exist?
-        YAML.load(config_path.read).keys
+        begin
+          YAML.load_file(config_path.to_s, aliases: true)
+        rescue ArgumentError
+          YAML.load_file(config_path.to_s)
+        end
       else
         [].freeze
       end


### PR DESCRIPTION
Psych 4 load in safe mode by default: https://github.com/ruby/psych/pull/487

So aliases need to be explicitly allowed.

cc @tenderlove 