### PR TITLE
GitHub workflow

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Install yarn
-        run: npm install -g yarn
+      - name: Install yarn maybe
+        run: which yarn || sudo npm install -g yarn
 
       - uses: actions/checkout@v2
       - name: Get yarn cache directory path

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -3,7 +3,7 @@ name: Jest specs
 on: [push, pull_request]
 
 jobs:
-  build:
+  jest:
     name: Jest specs
     strategy:
       matrix:
@@ -13,6 +13,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Install yarn
+        run: npm install -g yarn
+
       - uses: actions/checkout@v2
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -3,7 +3,7 @@ name: JS lint
 on: [push, pull_request]
 
 jobs:
-  build:
+  js-lint:
     name: JS Lint
 
     strategy:
@@ -14,6 +14,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Install yarn
+        run: npm install -g yarn
+
       - uses: actions/checkout@v2
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Install yarn
-        run: npm install -g yarn
+      - name: Install yarn maybe
+        run: which yarn || sudo npm install -g yarn
 
       - uses: actions/checkout@v2
       - name: Get yarn cache directory path

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -3,7 +3,7 @@ name: Rubocop
 on: [push, pull_request]
 
 jobs:
-  build:
+  rubocop:
     name: Rubocop
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -55,8 +55,8 @@ jobs:
           restore-keys: |
             bundle-use-ruby-${{ matrix.ruby }}-${{ matrix.gemfile }}-gems-
 
-      - name: Install yarn
-        run: npm install -g yarn
+      - name: Install yarn maybe
+        run: which yarn || sudo npm install -g yarn
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,7 +3,7 @@ name: Ruby specs
 on: [push, pull_request]
 
 jobs:
-  build:
+  test:
     name: Ruby specs
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' || matrix.experimental }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,23 +23,20 @@ jobs:
         ]
         gemfile: [
           "gemfiles/Gemfile-rails.5.2.x",
-          "gemfiles/Gemfile-rails.6.0.x"
+          "gemfiles/Gemfile-rails.6.0.x",
+          "gemfiles/Gemfile-rails.6.1.x"
         ]
         exclude:
-          - ruby: "2.4"
+          - ruby: 2.4
             gemfile: gemfiles/Gemfile-rails.6.0.x
-          - ruby: "3.0"
+          - ruby: 2.4
+            gemfile: gemfiles/Gemfile-rails.6.1.x
+          - ruby: 2.5
+            gemfile: gemfiles/Gemfile-rails.6.1.x
+          - ruby: 3.0
             gemfile: gemfiles/Gemfile-rails.5.2.x
         experimental: [false]
         include:
-          - ruby: 2.5
-            os: ubuntu-latest
-            gemfile: gemfiles/Gemfile-rails-edge
-            experimental: true
-          - ruby: 2.6
-            os: ubuntu-latest
-            gemfile: gemfiles/Gemfile-rails-edge
-            experimental: true
           - ruby: 2.7
             os: ubuntu-latest
             gemfile: gemfiles/Gemfile-rails-edge
@@ -57,6 +54,9 @@ jobs:
           key: bundle-use-ruby-${{ matrix.ruby }}-${{ matrix.gemfile }}-gems-${{ hashFiles(matrix.gemfile) }}-${{ hashFiles('**/*.gemspec') }}
           restore-keys: |
             bundle-use-ruby-${{ matrix.ruby }}-${{ matrix.gemfile }}-gems-
+
+      - name: Install yarn
+        run: npm install -g yarn
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - "lib/install/templates/**"
     - "vendor/**/*"
     - "node_modules/**/*"
+    - "_actions/**/*"
 
 # Prefer &&/|| over and/or.
 Style/AndOr:

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -1,1 +1,1 @@
-lib/install/config/webpacker.yml
+../lib/install/config/webpacker.yml

--- a/gemfiles/Gemfile-rails.6.1.x
+++ b/gemfiles/Gemfile-rails.6.1.x
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec path: "../"
 
-gem "rails", github: "rails/rails", branch: "main"
+gem "rails", '~>6.1.0'
 gem "arel", github: "rails/arel"
 gem "rake", ">= 11.1"
 gem "rack-proxy", require: false

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -120,26 +120,31 @@ class HelperTest < ActionView::TestCase
       javascript_pack_tag(:application)
   end
 
+  def application_stylesheet_chunks
+    %w[/packs/1-c20632e7baf2c81200d3.chunk.css /packs/application-k344a6d59eef8632c9d1.chunk.css]
+  end
+
+  def hello_stimulus_stylesheet_chunks
+    %w[/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css]
+  end
+
   def test_stylesheet_pack_tag
     assert_equal \
-      %(<link rel="stylesheet" media="screen" href="/packs/1-c20632e7baf2c81200d3.chunk.css" />\n) +
-        %(<link rel="stylesheet" media="screen" href="/packs/application-k344a6d59eef8632c9d1.chunk.css" />\n) +
-        %(<link rel="stylesheet" media="screen" href="/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css" />),
+      (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks)
+        .map { |chunk| stylesheet_link_tag(chunk) }.join("\n"),
       stylesheet_pack_tag("application", "hello_stimulus")
   end
 
   def test_stylesheet_pack_tag_symbol
     assert_equal \
-      %(<link rel="stylesheet" media="screen" href="/packs/1-c20632e7baf2c81200d3.chunk.css" />\n) +
-        %(<link rel="stylesheet" media="screen" href="/packs/application-k344a6d59eef8632c9d1.chunk.css" />\n) +
-        %(<link rel="stylesheet" media="screen" href="/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css" />),
+      (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks)
+        .map { |chunk| stylesheet_link_tag(chunk) }.join("\n"),
       stylesheet_pack_tag(:application, :hello_stimulus)
   end
 
   def test_stylesheet_pack_tag_splat
     assert_equal \
-      %(<link rel="stylesheet" media="all" href="/packs/1-c20632e7baf2c81200d3.chunk.css" />\n) +
-        %(<link rel="stylesheet" media="all" href="/packs/application-k344a6d59eef8632c9d1.chunk.css" />),
+      (application_stylesheet_chunks).map { |chunk| stylesheet_link_tag(chunk, media: "all") }.join("\n"),
       stylesheet_pack_tag("application", media: "all")
   end
 end


### PR DESCRIPTION
Hi, @gauravtiwari.

While working on my previous pull request #3015  I found that the GitHub workflow definitions are bit outdated, and I think that they are not failing now only because dependencies are cached (the edge rails have no master branch for a while). So I made few changes:
- added Gemfile-rails.6.1.x 
- updated Gemfile-rails-edge to point to the "main" branch
- renamed job names to be able to specify what job to run, when you run it locally with the [act](https://github.com/nektos/act) tool.
- added "_actions/**/*" to rubocop exclusions (this one for the act tool too)
- fixed "test/helper_test.rb" to pass with rails 7. It failed because stylesheet_link_tag is changed the[ order of the tag attributes](https://github.com/rails/rails/commit/1280620767c6ce45576b893a8073d44590f4511c#diff-f853a033bebad270e4cda42cb5e80ea21d85933023e115856b03230a6255818cL171). Also, the "media=screen" attribute will be [disabled in the default rails 7 configuration](https://github.com/rails/rails/commit/1280620767c6ce45576b893a8073d44590f4511c#diff-9f26e965e7e2a6842bd6ea755924a621038bc9dd8d63cfa6b34092aa32ede02cR207). 
