### PR TITLE
Add config option to disable healthcheck

### DIFF
--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -37,6 +37,9 @@ development:
     compress: true
     # Note that apps that do not check the host are vulnerable to DNS rebinding attacks
     disable_host_check: true
+    # When this option is true, the rails proxy will assume that the dev server is always running.
+    # Otherwise, it will check connectivity by opening a test connection before every request.
+    disable_health_check: false
     # This option lets the browser open with your local IP
     use_local_ip: false
     # When enabled, nothing except the initial startup information will be written to the console.
@@ -44,9 +47,9 @@ development:
     quiet: false
     pretty: false
     headers:
-      'Access-Control-Allow-Origin': '*'
+      "Access-Control-Allow-Origin": "*"
     watch_options:
-      ignored: '**/node_modules/**'
+      ignored: "**/node_modules/**"
 
 test:
   <<: *default

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -47,9 +47,9 @@ development:
     quiet: false
     pretty: false
     headers:
-      "Access-Control-Allow-Origin": "*"
+      'Access-Control-Allow-Origin': '*'
     watch_options:
-      ignored: "**/node_modules/**"
+      ignored: '**/node_modules/**'
 
 test:
   <<: *default

--- a/lib/webpacker/dev_server.rb
+++ b/lib/webpacker/dev_server.rb
@@ -1,5 +1,5 @@
 class Webpacker::DevServer
-  DEFAULT_ENV_PREFIX = "WEBPACKER_DEV_SERVER".freeze
+  DEFAULT_ENV_PREFIX = 'WEBPACKER_DEV_SERVER'.freeze
 
   # Configure dev server connection timeout (in seconds), default: 0.01
   # Webpacker.dev_server.connect_timeout = 1
@@ -13,12 +13,14 @@ class Webpacker::DevServer
 
   def running?
     if config.dev_server.present?
-      Socket.tcp(host, port, connect_timeout: connect_timeout).close
+      unless config.dev_server.disable_health_check
+        Socket.tcp(host, port, connect_timeout: connect_timeout).close
+      end
       true
     else
       false
     end
-  rescue
+  rescue StandardError
     false
   end
 
@@ -32,7 +34,7 @@ class Webpacker::DevServer
 
   def https?
     case fetch(:https)
-    when true, "true", Hash
+    when true, 'true', Hash
       true
     else
       false
@@ -40,7 +42,7 @@ class Webpacker::DevServer
   end
 
   def protocol
-    https? ? "https" : "http"
+    https? ? 'https' : 'http'
   end
 
   def host_with_port
@@ -56,11 +58,13 @@ class Webpacker::DevServer
   end
 
   private
-    def fetch(key)
-      ENV["#{env_prefix}_#{key.upcase}"] || config.dev_server.fetch(key, defaults[key])
-    end
 
-    def defaults
-      config.send(:defaults)[:dev_server] || {}
-    end
+  def fetch(key)
+    ENV["#{env_prefix}_#{key.upcase}"] ||
+      config.dev_server.fetch(key, defaults[key])
+  end
+
+  def defaults
+    config.send(:defaults)[:dev_server] || {}
+  end
 end

--- a/lib/webpacker/dev_server.rb
+++ b/lib/webpacker/dev_server.rb
@@ -1,5 +1,5 @@
 class Webpacker::DevServer
-  DEFAULT_ENV_PREFIX = 'WEBPACKER_DEV_SERVER'.freeze
+  DEFAULT_ENV_PREFIX = "WEBPACKER_DEV_SERVER".freeze
 
   # Configure dev server connection timeout (in seconds), default: 0.01
   # Webpacker.dev_server.connect_timeout = 1
@@ -16,11 +16,12 @@ class Webpacker::DevServer
       unless config.dev_server.disable_health_check
         Socket.tcp(host, port, connect_timeout: connect_timeout).close
       end
+
       true
     else
       false
     end
-  rescue StandardError
+  rescue
     false
   end
 
@@ -34,7 +35,7 @@ class Webpacker::DevServer
 
   def https?
     case fetch(:https)
-    when true, 'true', Hash
+    when true, "true", Hash
       true
     else
       false
@@ -42,7 +43,7 @@ class Webpacker::DevServer
   end
 
   def protocol
-    https? ? 'https' : 'http'
+    https? ? "https" : "http"
   end
 
   def host_with_port
@@ -58,13 +59,11 @@ class Webpacker::DevServer
   end
 
   private
+    def fetch(key)
+      ENV["#{env_prefix}_#{key.upcase}"] || config.dev_server.fetch(key, defaults[key])
+    end
 
-  def fetch(key)
-    ENV["#{env_prefix}_#{key.upcase}"] ||
-      config.dev_server.fetch(key, defaults[key])
-  end
-
-  def defaults
-    config.send(:defaults)[:dev_server] || {}
-  end
+    def defaults
+      config.send(:defaults)[:dev_server] || {}
+    end
 end


### PR DESCRIPTION
It appears that the rails proxy middleware is opening a dummy TCP connection to the webpack-dev-server upon every request, in order to test that it is still running. I think for many purposes this will be unneccessary, and we can introduce a configuration option to disable this behaviour. Removing this extra connection may reduce load and response times when using the webpack-dev-server, especially when working with large projects.