### PR TITLE
Remove node/yarn dependency from clobber and support windows

### DIFF
--- a/lib/tasks/webpacker/check_node.rake
+++ b/lib/tasks/webpacker/check_node.rake
@@ -3,7 +3,9 @@ namespace :webpacker do
   desc "Verifies if Node.js is installed"
   task :check_node do
     begin
-      raise Errno::ENOENT if `which node || which nodejs`.strip.empty?
+      which_command = Gem.win_platform? ? 'where' : 'which'
+      raise Errno::ENOENT if `#{which_command} node || #{which_command} nodejs`.strip.empty?
+
       node_version = `node -v || nodejs -v`.strip
       raise Errno::ENOENT if node_version.blank?
 

--- a/lib/tasks/webpacker/check_yarn.rake
+++ b/lib/tasks/webpacker/check_yarn.rake
@@ -3,7 +3,9 @@ namespace :webpacker do
   desc "Verifies if Yarn is installed"
   task :check_yarn do
     begin
-      raise Errno::ENOENT if `which yarn`.strip.empty?
+      which_command = Gem.win_platform? ? 'where' : 'which'
+      raise Errno::ENOENT if `#{which_command} yarn`.strip.empty?
+
       yarn_version = `yarn --version`.strip
       raise Errno::ENOENT if yarn_version.blank?
 

--- a/lib/tasks/webpacker/clobber.rake
+++ b/lib/tasks/webpacker/clobber.rake
@@ -2,7 +2,7 @@ require "webpacker/configuration"
 
 namespace :webpacker do
   desc "Remove the webpack compiled output directory"
-  task clobber: ["webpacker:verify_install", :environment] do
+  task clobber: ["webpacker:verify_config", :environment] do
     Webpacker.clobber
     $stdout.puts "Removed webpack output path directory #{Webpacker.config.public_output_path}"
   end

--- a/lib/tasks/webpacker/verify_config.rake
+++ b/lib/tasks/webpacker/verify_config.rake
@@ -1,0 +1,14 @@
+require "webpacker/configuration"
+
+namespace :webpacker do
+  desc "Verifies if the Webpacker config is present"
+  task :verify_config do
+    unless Webpacker.config.config_path.exist?
+      path = Webpacker.config.config_path.relative_path_from(Pathname.new(pwd)).to_s
+      $stderr.puts "Configuration #{path} file not found. \n"\
+           "Make sure webpacker:install is run successfully before " \
+           "running dependent tasks"
+      exit!
+    end
+  end
+end

--- a/lib/tasks/webpacker/verify_install.rake
+++ b/lib/tasks/webpacker/verify_install.rake
@@ -1,14 +1,4 @@
-require "webpacker/configuration"
-
 namespace :webpacker do
   desc "Verifies if Webpacker is installed"
-  task verify_install: [:check_node, :check_yarn, :check_binstubs] do
-    unless Webpacker.config.config_path.exist?
-      path = Webpacker.config.config_path.relative_path_from(Pathname.new(pwd)).to_s
-      $stderr.puts "Configuration #{path} file not found. \n"\
-           "Make sure webpacker:install is run successfully before " \
-           "running dependent tasks"
-      exit!
-    end
-  end
+  task verify_install: [:verify_config, :check_node, :check_yarn, :check_binstubs]
 end


### PR DESCRIPTION
This is a twofer, because I ran into one issue while trying to fix the other. 

The first issue fixed was introduced in #2943, which uses a platform specific shell command to determine if yarn/node are installed. This PR updates this change to use an equivelant windows command on windows platforms.

The second change removes the dependency on yarn and node when running webpacker:clobber, since neither of these are needed. This is fairly important because webpacker:clobber is implicitly called when assets:clobber is called, which you might call on a server that's not set up for development (and therefor missing node/yarn).

