### PR TITLE
Skip contenthash when not production

### DIFF
--- a/package/environments/__tests__/base.js
+++ b/package/environments/__tests__/base.js
@@ -29,9 +29,9 @@ describe('Base config', () => {
     })
 
     test('should return output', () => {
-      expect(baseConfig.output.filename).toEqual('js/[name]-[contenthash].js')
+      expect(baseConfig.output.filename).toEqual('js/[name].js')
       expect(baseConfig.output.chunkFilename).toEqual(
-        'js/[name]-[contenthash].chunk.js'
+        'js/[name].chunk.js'
       )
     })
 

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -77,12 +77,12 @@ const getPlugins = () => {
 
 // Don't use contentHash except for production for performance
 // https://webpack.js.org/guides/build-performance/#avoid-production-specific-tooling
-const filenameHash = isProduction ? '-[contenthash]' : '';
+const hash = isProduction ? '-[contenthash]' : ''
 module.exports = {
   mode: 'production',
   output: {
-    filename: `js/[name]${filenameHash}.js`,
-    chunkFilename: `js/[name]${filenameHash}.chunk.js`,
+    filename: `js/[name]${hash}.js`,
+    chunkFilename: `js/[name]${hash}.chunk.js`,
 
     // https://webpack.js.org/configuration/output/#outputhotupdatechunkfilename
     hotUpdateChunkFilename: 'js/[id].[fullhash].hot-update.js',

--- a/package/environments/base.js
+++ b/package/environments/base.js
@@ -8,6 +8,7 @@ const { sync: globSync } = require('glob')
 const WebpackAssetsManifest = require('webpack-assets-manifest')
 const webpack = require('webpack')
 const rules = require('../rules')
+const { isProduction } = require('../env')
 const config = require('../config')
 const { moduleExists } = require('../utils/helpers')
 
@@ -61,11 +62,12 @@ const getPlugins = () => {
   ]
 
   if (moduleExists('css-loader') && moduleExists('mini-css-extract-plugin')) {
+    const hash = isProduction ? '-[contenthash:8]' : ''
     const MiniCssExtractPlugin = require('mini-css-extract-plugin')
     plugins.push(
       new MiniCssExtractPlugin({
-        filename: 'css/[name]-[contenthash:8].css',
-        chunkFilename: 'css/[id]-[contenthash:8].css'
+        filename: `css/[name]${hash}.css`,
+        chunkFilename: `css/[id]${hash}.css`
       })
     )
   }
@@ -73,12 +75,17 @@ const getPlugins = () => {
   return plugins
 }
 
+// Don't use contentHash except for production for performance
+// https://webpack.js.org/guides/build-performance/#avoid-production-specific-tooling
+const filenameHash = isProduction ? '-[contenthash]' : '';
 module.exports = {
   mode: 'production',
   output: {
-    filename: 'js/[name]-[contenthash].js',
-    chunkFilename: 'js/[name]-[contenthash].chunk.js',
-    hotUpdateChunkFilename: 'js/[id]-[hash].hot-update.js',
+    filename: `js/[name]${filenameHash}.js`,
+    chunkFilename: `js/[name]${filenameHash}.chunk.js`,
+
+    // https://webpack.js.org/configuration/output/#outputhotupdatechunkfilename
+    hotUpdateChunkFilename: 'js/[id].[fullhash].hot-update.js',
     path: config.outputPath,
     publicPath: config.publicPath
   },


### PR DESCRIPTION
Per the webpack docs on better performance, the contenthash should be
skipped when not on production.

https://webpack.js.org/guides/build-performance/#avoid-production-specific-tooling