### PR TITLE
Remove success message on webpacker:install

### DIFF
--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -68,9 +68,7 @@ if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR > 1
   say "policy.connect_src :self, :https, \"http://localhost:3035\", \"ws://localhost:3035\" if Rails.env.development?", :yellow
 end
 
-if results.all?
-  say "Webpacker successfully installed 🎉 🍰", :green
-else
+unless results.all?
   say "Webpacker installation failed 😭 See above for details.", :red
   exit 1
 end


### PR DESCRIPTION
Currently, the last line of output when running `rails new` is
"Webpacker successfully installed" which is somewhat confusing if you
don't read all of the intermediate output from that command. After
proposing https://github.com/rails/rails/pull/42546 to add a clear
success message to the end of `rails new`, @rafaelfranca and others
recommended removing the success message from webpacker to be more in
line the Unix philosophy of not saying anything when things go well.