### PR TITLE
helpers: support explicit webpacker instance

### DIFF
--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -13,8 +13,8 @@ module Webpacker::Helper
   # Example:
   #
   #   <%= asset_pack_path 'calendar.css' %> # => "/packs/calendar-1016838bab065ae1e122.css"
-  def asset_pack_path(name, **options)
-    path_to_asset(current_webpacker_instance.manifest.lookup!(name), options)
+  def asset_pack_path(name, webpacker: nil, **options)
+    path_to_asset(webpacker_instance(webpacker).manifest.lookup!(name), options)
   end
 
   # Computes the absolute path for a given Webpacker asset.
@@ -24,23 +24,23 @@ module Webpacker::Helper
   # Example:
   #
   #   <%= asset_pack_url 'calendar.css' %> # => "http://example.com/packs/calendar-1016838bab065ae1e122.css"
-  def asset_pack_url(name, **options)
-    url_to_asset(current_webpacker_instance.manifest.lookup!(name), options)
+  def asset_pack_url(name, webpacker: nil, **options)
+    url_to_asset(webpacker_instance(webpacker).manifest.lookup!(name), options)
   end
 
   # Computes the relative path for a given Webpacker image with the same automated processing as image_pack_tag.
   # Returns the relative path using manifest.json and passes it to path_to_asset helper.
   # This will use path_to_asset internally, so most of their behaviors will be the same.
-  def image_pack_path(name, **options)
-    resolve_path_to_image(name, **options)
+  def image_pack_path(name, webpacker: nil, **options)
+    resolve_path_to_image(name, webpacker: webpacker, **options)
   end
 
   # Computes the absolute path for a given Webpacker image with the same automated
   # processing as image_pack_tag. Returns the relative path using manifest.json
   # and passes it to path_to_asset helper. This will use path_to_asset internally,
   # so most of their behaviors will be the same.
-  def image_pack_url(name, **options)
-    resolve_path_to_image(name, **options.merge(protocol: :request))
+  def image_pack_url(name, webpacker: nil, **options)
+    resolve_path_to_image(name, webpacker: webpacker, **options.merge(protocol: :request))
   end
 
   # Creates an image tag that references the named pack file.
@@ -52,14 +52,14 @@ module Webpacker::Helper
   #
   #  <%= image_pack_tag 'picture.png', srcset: { 'picture-2x.png' => '2x' } %>
   #  <img srcset= "/packs/picture-2x-7cca48e6cae66ec07b8e.png 2x" src="/packs/picture-c38deda30895059837cf.png" >
-  def image_pack_tag(name, **options)
+  def image_pack_tag(name, webpacker: nil, **options)
     if options[:srcset] && !options[:srcset].is_a?(String)
       options[:srcset] = options[:srcset].map do |src_name, size|
-        "#{resolve_path_to_image(src_name)} #{size}"
+        "#{resolve_path_to_image(src_name, webpacker: webpacker)} #{size}"
       end.join(", ")
     end
 
-    image_tag(resolve_path_to_image(name), options)
+    image_tag(resolve_path_to_image(name, webpacker: webpacker), options)
   end
 
   # Creates a link tag for a favicon that references the named pack file.
@@ -68,8 +68,8 @@ module Webpacker::Helper
   #
   #  <%= favicon_pack_tag 'mb-icon.png', rel: 'apple-touch-icon', type: 'image/png' %>
   #  <link href="/packs/mb-icon-k344a6d59eef8632c9d1.png" rel="apple-touch-icon" type="image/png" />
-  def favicon_pack_tag(name, **options)
-    favicon_link_tag(resolve_path_to_image(name), options)
+  def favicon_pack_tag(name, webpacker: nil, **options)
+    favicon_link_tag(resolve_path_to_image(name, webpacker: webpacker), options)
   end
 
   # Creates script tags that reference the js chunks from entrypoints when using split chunks API,
@@ -95,8 +95,8 @@ module Webpacker::Helper
   #
   #   <%= javascript_pack_tag 'calendar' %>
   #   <%= javascript_pack_tag 'map' %>
-  def javascript_pack_tag(*names, **options)
-    javascript_include_tag(*sources_from_manifest_entrypoints(names, type: :javascript), **options)
+  def javascript_pack_tag(*names, webpacker: nil, **options)
+    javascript_include_tag(*sources_from_manifest_entrypoints(names, type: :javascript, webpacker: webpacker), **options)
   end
 
   # Creates a link tag, for preloading, that references a given Webpacker asset.
@@ -107,9 +107,9 @@ module Webpacker::Helper
   #
   #   <%= preload_pack_asset 'fonts/fa-regular-400.woff2' %> # =>
   #   <link rel="preload" href="/packs/fonts/fa-regular-400-944fb546bd7018b07190a32244f67dc9.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-  def preload_pack_asset(name, **options)
+  def preload_pack_asset(name, webpacker: nil, **options)
     if self.class.method_defined?(:preload_link_tag)
-      preload_link_tag(current_webpacker_instance.manifest.lookup!(name), options)
+      preload_link_tag(webpacker_instance(webpacker).manifest.lookup!(name), options)
     else
       raise "You need Rails >= 5.2 to use this tag."
     end
@@ -140,22 +140,27 @@ module Webpacker::Helper
   #
   #   <%= stylesheet_pack_tag 'calendar' %>
   #   <%= stylesheet_pack_tag 'map' %>
-  def stylesheet_pack_tag(*names, **options)
+  def stylesheet_pack_tag(*names, webpacker: nil, **options)
     return "" if Webpacker.inlining_css?
 
-    stylesheet_link_tag(*sources_from_manifest_entrypoints(names, type: :stylesheet), **options)
+    stylesheet_link_tag(*sources_from_manifest_entrypoints(names, type: :stylesheet, webpacker: webpacker), **options)
   end
 
   private
 
-    def sources_from_manifest_entrypoints(names, type:)
-      names.map { |name| current_webpacker_instance.manifest.lookup_pack_with_chunks!(name.to_s, type: type) }.flatten.uniq
+    def sources_from_manifest_entrypoints(names, webpacker: nil, type:)
+      names.map { |name| webpacker_instance(webpacker).manifest.lookup_pack_with_chunks!(name.to_s, type: type) }.flatten.uniq
     end
 
-    def resolve_path_to_image(name, **options)
+    def resolve_path_to_image(name, webpacker: nil, **options)
+      webpacker = webpacker_instance(webpacker)
       path = name.starts_with?("media/images/") ? name : "media/images/#{name}"
-      path_to_asset(current_webpacker_instance.manifest.lookup!(path), options)
+      path_to_asset(webpacker.manifest.lookup!(path), options)
     rescue
-      path_to_asset(current_webpacker_instance.manifest.lookup!(name), options)
+      path_to_asset(webpacker.manifest.lookup!(name), options)
+    end
+
+    def webpacker_instance(webpacker)
+      webpacker || current_webpacker_instance
     end
 end

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -1,10 +1,6 @@
 require "test_helper"
 
-class HelperTest < ActionView::TestCase
-  tests Webpacker::Helper
-
-  attr_reader :request
-
+module HelperTests
   def setup
     @request = Class.new do
       def send_early_hints(links) end
@@ -15,78 +11,78 @@ class HelperTest < ActionView::TestCase
   end
 
   def test_asset_pack_path
-    assert_equal "/packs/bootstrap-300631c4f0e0f9c865bc.js", asset_pack_path("bootstrap.js")
-    assert_equal "/packs/bootstrap-c38deda30895059837cf.css", asset_pack_path("bootstrap.css")
+    assert_equal "/#{@output_path}/bootstrap-300631c4f0e0f9c865bc.js", asset_pack_path("bootstrap.js", webpacker: @webpacker)
+    assert_equal "/#{@output_path}/bootstrap-c38deda30895059837cf.css", asset_pack_path("bootstrap.css", webpacker: @webpacker)
   end
 
   def test_asset_pack_url
-    assert_equal "https://example.com/packs/bootstrap-300631c4f0e0f9c865bc.js", asset_pack_url("bootstrap.js")
-    assert_equal "https://example.com/packs/bootstrap-c38deda30895059837cf.css", asset_pack_url("bootstrap.css")
+    assert_equal "https://example.com/#{@output_path}/bootstrap-300631c4f0e0f9c865bc.js", asset_pack_url("bootstrap.js", webpacker: @webpacker)
+    assert_equal "https://example.com/#{@output_path}/bootstrap-c38deda30895059837cf.css", asset_pack_url("bootstrap.css", webpacker: @webpacker)
   end
 
   def test_image_pack_path
-    assert_equal "/packs/application-k344a6d59eef8632c9d1.png", image_pack_path("application.png")
-    assert_equal "/packs/media/images/image-c38deda30895059837cf.jpg", image_pack_path("image.jpg")
-    assert_equal "/packs/media/images/image-c38deda30895059837cf.jpg", image_pack_path("media/images/image.jpg")
-    assert_equal "/packs/media/images/nested/image-c38deda30895059837cf.jpg", image_pack_path("nested/image.jpg")
-    assert_equal "/packs/media/images/nested/image-c38deda30895059837cf.jpg", image_pack_path("media/images/nested/image.jpg")
+    assert_equal "/#{@output_path}/application-k344a6d59eef8632c9d1.png", image_pack_path("application.png", webpacker: @webpacker)
+    assert_equal "/#{@output_path}/media/images/image-c38deda30895059837cf.jpg", image_pack_path("image.jpg", webpacker: @webpacker)
+    assert_equal "/#{@output_path}/media/images/image-c38deda30895059837cf.jpg", image_pack_path("media/images/image.jpg", webpacker: @webpacker)
+    assert_equal "/#{@output_path}/media/images/nested/image-c38deda30895059837cf.jpg", image_pack_path("nested/image.jpg", webpacker: @webpacker)
+    assert_equal "/#{@output_path}/media/images/nested/image-c38deda30895059837cf.jpg", image_pack_path("media/images/nested/image.jpg", webpacker: @webpacker)
   end
 
   def test_image_pack_url
-    assert_equal "https://example.com/packs/application-k344a6d59eef8632c9d1.png", image_pack_url("application.png")
-    assert_equal "https://example.com/packs/media/images/image-c38deda30895059837cf.jpg", image_pack_url("image.jpg")
-    assert_equal "https://example.com/packs/media/images/image-c38deda30895059837cf.jpg", image_pack_url("media/images/image.jpg")
-    assert_equal "https://example.com/packs/media/images/nested/image-c38deda30895059837cf.jpg", image_pack_url("nested/image.jpg")
-    assert_equal "https://example.com/packs/media/images/nested/image-c38deda30895059837cf.jpg", image_pack_url("media/images/nested/image.jpg")
+    assert_equal "https://example.com/#{@output_path}/application-k344a6d59eef8632c9d1.png", image_pack_url("application.png", webpacker: @webpacker)
+    assert_equal "https://example.com/#{@output_path}/media/images/image-c38deda30895059837cf.jpg", image_pack_url("image.jpg", webpacker: @webpacker)
+    assert_equal "https://example.com/#{@output_path}/media/images/image-c38deda30895059837cf.jpg", image_pack_url("media/images/image.jpg", webpacker: @webpacker)
+    assert_equal "https://example.com/#{@output_path}/media/images/nested/image-c38deda30895059837cf.jpg", image_pack_url("nested/image.jpg", webpacker: @webpacker)
+    assert_equal "https://example.com/#{@output_path}/media/images/nested/image-c38deda30895059837cf.jpg", image_pack_url("media/images/nested/image.jpg", webpacker: @webpacker)
   end
 
   def test_image_pack_tag
     assert_equal \
-      "<img alt=\"Edit Entry\" src=\"/packs/application-k344a6d59eef8632c9d1.png\" width=\"16\" height=\"10\" />",
-      image_pack_tag("application.png", size: "16x10", alt: "Edit Entry")
+      "<img alt=\"Edit Entry\" src=\"/#{@output_path}/application-k344a6d59eef8632c9d1.png\" width=\"16\" height=\"10\" />",
+      image_pack_tag("application.png", webpacker: @webpacker, size: "16x10", alt: "Edit Entry")
     assert_equal \
-      "<img alt=\"Edit Entry\" src=\"/packs/media/images/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />",
-      image_pack_tag("image.jpg", size: "16x10", alt: "Edit Entry")
+      "<img alt=\"Edit Entry\" src=\"/#{@output_path}/media/images/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />",
+      image_pack_tag("image.jpg", webpacker: @webpacker, size: "16x10", alt: "Edit Entry")
     assert_equal \
-      "<img alt=\"Edit Entry\" src=\"/packs/media/images/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />",
-      image_pack_tag("media/images/image.jpg", size: "16x10", alt: "Edit Entry")
+      "<img alt=\"Edit Entry\" src=\"/#{@output_path}/media/images/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />",
+      image_pack_tag("media/images/image.jpg", webpacker: @webpacker, size: "16x10", alt: "Edit Entry")
     assert_equal \
-      "<img alt=\"Edit Entry\" src=\"/packs/media/images/nested/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />",
-      image_pack_tag("nested/image.jpg", size: "16x10", alt: "Edit Entry")
+      "<img alt=\"Edit Entry\" src=\"/#{@output_path}/media/images/nested/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />",
+      image_pack_tag("nested/image.jpg", webpacker: @webpacker, size: "16x10", alt: "Edit Entry")
     assert_equal \
-      "<img alt=\"Edit Entry\" src=\"/packs/media/images/nested/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />",
-      image_pack_tag("media/images/nested/image.jpg", size: "16x10", alt: "Edit Entry")
+      "<img alt=\"Edit Entry\" src=\"/#{@output_path}/media/images/nested/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />",
+      image_pack_tag("media/images/nested/image.jpg", webpacker: @webpacker, size: "16x10", alt: "Edit Entry")
     assert_equal \
-      "<img srcset=\"/packs/media/images/image-2x-7cca48e6cae66ec07b8e.jpg 2x\" src=\"/packs/media/images/image-c38deda30895059837cf.jpg\" />",
-      image_pack_tag("media/images/image.jpg", srcset: { "media/images/image-2x.jpg" => "2x" })
+      "<img srcset=\"/#{@output_path}/media/images/image-2x-7cca48e6cae66ec07b8e.jpg 2x\" src=\"/#{@output_path}/media/images/image-c38deda30895059837cf.jpg\" />",
+      image_pack_tag("media/images/image.jpg", webpacker: @webpacker, srcset: { "media/images/image-2x.jpg" => "2x" })
   end
 
   def test_favicon_pack_tag
     assert_equal \
-      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/application-k344a6d59eef8632c9d1.png\" />",
-      favicon_pack_tag("application.png", rel: "apple-touch-icon", type: "image/png")
+      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/#{@output_path}/application-k344a6d59eef8632c9d1.png\" />",
+      favicon_pack_tag("application.png", webpacker: @webpacker, rel: "apple-touch-icon", type: "image/png")
     assert_equal \
-      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/media/images/mb-icon-c38deda30895059837cf.png\" />",
-      favicon_pack_tag("mb-icon.png", rel: "apple-touch-icon", type: "image/png")
+      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/#{@output_path}/media/images/mb-icon-c38deda30895059837cf.png\" />",
+      favicon_pack_tag("mb-icon.png", webpacker: @webpacker, rel: "apple-touch-icon", type: "image/png")
     assert_equal \
-      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/media/images/mb-icon-c38deda30895059837cf.png\" />",
-      favicon_pack_tag("media/images/mb-icon.png", rel: "apple-touch-icon", type: "image/png")
+      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/#{@output_path}/media/images/mb-icon-c38deda30895059837cf.png\" />",
+      favicon_pack_tag("media/images/mb-icon.png", webpacker: @webpacker, rel: "apple-touch-icon", type: "image/png")
     assert_equal \
-      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/media/images/nested/mb-icon-c38deda30895059837cf.png\" />",
-      favicon_pack_tag("nested/mb-icon.png", rel: "apple-touch-icon", type: "image/png")
+      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/#{@output_path}/media/images/nested/mb-icon-c38deda30895059837cf.png\" />",
+      favicon_pack_tag("nested/mb-icon.png", webpacker: @webpacker, rel: "apple-touch-icon", type: "image/png")
     assert_equal \
-      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/media/images/nested/mb-icon-c38deda30895059837cf.png\" />",
-      favicon_pack_tag("media/images/nested/mb-icon.png", rel: "apple-touch-icon", type: "image/png")
+      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/#{@output_path}/media/images/nested/mb-icon-c38deda30895059837cf.png\" />",
+      favicon_pack_tag("media/images/nested/mb-icon.png", webpacker: @webpacker, rel: "apple-touch-icon", type: "image/png")
   end
 
   def test_preload_pack_asset
     if self.class.method_defined?(:preload_link_tag)
       assert_equal \
-        %(<link rel="preload" href="/packs/fonts/fa-regular-400-944fb546bd7018b07190a32244f67dc9.woff2" as="font" type="font/woff2" crossorigin="anonymous">),
-        preload_pack_asset("fonts/fa-regular-400.woff2")
+        %(<link rel="preload" href="/#{@output_path}/fonts/fa-regular-400-944fb546bd7018b07190a32244f67dc9.woff2" as="font" type="font/woff2" crossorigin="anonymous">),
+        preload_pack_asset("fonts/fa-regular-400.woff2", webpacker: @webpacker)
     else
       error = assert_raises do
-        preload_pack_asset("fonts/fa-regular-400.woff2")
+        preload_pack_asset("fonts/fa-regular-400.woff2", webpacker: @webpacker)
       end
 
       assert_equal \
@@ -97,54 +93,80 @@ class HelperTest < ActionView::TestCase
 
   def test_javascript_pack_tag
     assert_equal \
-      %(<script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js"></script>\n) +
-        %(<script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js"></script>\n) +
-        %(<script src="/packs/application-k344a6d59eef8632c9d1.js"></script>\n) +
-        %(<script src="/packs/bootstrap-300631c4f0e0f9c865bc.js"></script>),
-      javascript_pack_tag("application", "bootstrap")
+      %(<script src="/#{@output_path}/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js"></script>\n) +
+        %(<script src="/#{@output_path}/vendors~application-e55f2aae30c07fb6d82a.chunk.js"></script>\n) +
+        %(<script src="/#{@output_path}/application-k344a6d59eef8632c9d1.js"></script>\n) +
+        %(<script src="/#{@output_path}/bootstrap-300631c4f0e0f9c865bc.js"></script>),
+      javascript_pack_tag("application", "bootstrap", webpacker: @webpacker)
   end
 
   def test_javascript_pack_tag_splat
     assert_equal \
-      %(<script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js" defer="defer"></script>\n) +
-        %(<script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js" defer="defer"></script>\n) +
-        %(<script src="/packs/application-k344a6d59eef8632c9d1.js" defer="defer"></script>),
-      javascript_pack_tag("application", defer: true)
+      %(<script src="/#{@output_path}/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js" defer="defer"></script>\n) +
+        %(<script src="/#{@output_path}/vendors~application-e55f2aae30c07fb6d82a.chunk.js" defer="defer"></script>\n) +
+        %(<script src="/#{@output_path}/application-k344a6d59eef8632c9d1.js" defer="defer"></script>),
+      javascript_pack_tag("application", webpacker: @webpacker, defer: true)
   end
 
   def test_javascript_pack_tag_symbol
     assert_equal \
-      %(<script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js"></script>\n) +
-        %(<script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js"></script>\n) +
-        %(<script src="/packs/application-k344a6d59eef8632c9d1.js"></script>),
-      javascript_pack_tag(:application)
+      %(<script src="/#{@output_path}/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js"></script>\n) +
+        %(<script src="/#{@output_path}/vendors~application-e55f2aae30c07fb6d82a.chunk.js"></script>\n) +
+        %(<script src="/#{@output_path}/application-k344a6d59eef8632c9d1.js"></script>),
+      javascript_pack_tag(:application, webpacker: @webpacker)
   end
 
   def application_stylesheet_chunks
-    %w[/packs/1-c20632e7baf2c81200d3.chunk.css /packs/application-k344a6d59eef8632c9d1.chunk.css]
+    %W[/#{@output_path}/1-c20632e7baf2c81200d3.chunk.css /#{@output_path}/application-k344a6d59eef8632c9d1.chunk.css]
   end
 
   def hello_stimulus_stylesheet_chunks
-    %w[/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css]
+    %W[/#{@output_path}/hello_stimulus-k344a6d59eef8632c9d1.chunk.css]
   end
 
   def test_stylesheet_pack_tag
     assert_equal \
       (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks)
         .map { |chunk| stylesheet_link_tag(chunk) }.join("\n"),
-      stylesheet_pack_tag("application", "hello_stimulus")
+      stylesheet_pack_tag("application", "hello_stimulus", webpacker: @webpacker)
   end
 
   def test_stylesheet_pack_tag_symbol
     assert_equal \
       (application_stylesheet_chunks + hello_stimulus_stylesheet_chunks)
         .map { |chunk| stylesheet_link_tag(chunk) }.join("\n"),
-      stylesheet_pack_tag(:application, :hello_stimulus)
+      stylesheet_pack_tag(:application, :hello_stimulus, webpacker: @webpacker)
   end
 
   def test_stylesheet_pack_tag_splat
     assert_equal \
       (application_stylesheet_chunks).map { |chunk| stylesheet_link_tag(chunk, media: "all") }.join("\n"),
-      stylesheet_pack_tag("application", media: "all")
+      stylesheet_pack_tag("application", webpacker: @webpacker, media: "all")
+  end
+end
+
+class HelperTest < ActionView::TestCase
+  tests Webpacker::Helper
+  include HelperTests
+
+  attr_reader :request
+
+  def setup
+    super
+    @webpacker = nil
+    @output_path = "packs"
+  end
+end
+
+class HelperTestWithExplicitWebpacker < ActionView::TestCase
+  tests Webpacker::Helper
+  include HelperTests
+
+  attr_reader :request
+
+  def setup
+    super
+    @webpacker = ::Webpacker::Instance.new config_path: Rails.root.join("config/webpacker_other_location.yml")
+    @output_path = "other-packs"
   end
 end

--- a/test/test_app/config/webpacker_other_location.yml
+++ b/test/test_app/config/webpacker_other_location.yml
@@ -4,7 +4,7 @@ default: &default
   source_path: app/packs
   source_entry_path: entrypoints
   public_root_path: public
-  public_output_path: packs
+  public_output_path: other-packs
   cache_path: tmp/cache/webpacker
   webpack_compile_output: false
 

--- a/test/test_app/public/other-packs/manifest.json
+++ b/test/test_app/public/other-packs/manifest.json
@@ -1,0 +1,50 @@
+{
+  "bootstrap.css": "/other-packs/bootstrap-c38deda30895059837cf.css",
+  "application.css": "/other-packs/application-dd6b1cd38bfa093df600.css",
+  "bootstrap.js": "/other-packs/bootstrap-300631c4f0e0f9c865bc.js",
+  "application.js": "/other-packs/application-k344a6d59eef8632c9d1.js",
+  "application.png": "/other-packs/application-k344a6d59eef8632c9d1.png",
+  "fonts/fa-regular-400.woff2": "/other-packs/fonts/fa-regular-400-944fb546bd7018b07190a32244f67dc9.woff2",
+  "media/images/image.jpg": "/other-packs/media/images/image-c38deda30895059837cf.jpg",
+  "media/images/image-2x.jpg": "/other-packs/media/images/image-2x-7cca48e6cae66ec07b8e.jpg",
+  "media/images/nested/image.jpg": "/other-packs/media/images/nested/image-c38deda30895059837cf.jpg",
+  "media/images/mb-icon.png": "/other-packs/media/images/mb-icon-c38deda30895059837cf.png",
+  "media/images/nested/mb-icon.png": "/other-packs/media/images/nested/mb-icon-c38deda30895059837cf.png",
+  "entrypoints": {
+    "application": {
+      "assets": {
+        "js": [
+          "/other-packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js",
+          "/other-packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js",
+          "/other-packs/application-k344a6d59eef8632c9d1.js"
+        ],
+        "css": [
+          "/other-packs/1-c20632e7baf2c81200d3.chunk.css",
+          "/other-packs/application-k344a6d59eef8632c9d1.chunk.css"
+        ]
+      }
+    },
+    "bootstrap": {
+      "assets": {
+        "js": [
+          "/other-packs/bootstrap-300631c4f0e0f9c865bc.js"
+        ]
+      }
+    },
+    "hello_stimulus": {
+      "assets": {
+        "css": [
+          "/other-packs/1-c20632e7baf2c81200d3.chunk.css",
+          "/other-packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css"
+        ]
+      }
+    },
+    "print/application": {
+      "assets": {
+        "css": [
+          "/other-packs/print/application-983b6c164a47f7ed49cd.css"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Currently the helpers use `current_webpacker_instance` to determine the webpacker instance. This provides the opportunity for e.g. engines to override the webpacker instance, but there's no supported way to use multiple webpacker instances for the common case where an engine view is rendered in a main app layout. Support this use-case and fix #2946 by adding another parameter to the helpers, providing the opportunity to explicitly pass the desired webpacker instance. If the instance isn't provided, then continue using `current_webpacker_instance`.