### PR TITLE
Using default custom path for files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@ environment.loaders.append('nodeModules', nodeModules)
 ```
 
 - If you have added `environment.loaders.delete('nodeModules')` to your `environment.js`, this must be removed or you will receive an error (`Item nodeModules not found`).
-- `extract_css` option was removed. Webpacker will generate a separate `application.css` file for the default `application` pack, as supported by multiple files per entry introduced in 5.0.0. [#2608](https://github.com/rails/webpacker/pull/2608). However, CSS will be inlined when the webpack-dev-server is used with `hmr: true`. JS package exports `inliningCss`. This is useful to enable HMR for React. 
+- `extract_css` option was removed. Webpacker will generate a separate `application.css` file for the default `application` pack, as supported by multiple files per entry introduced in 5.0.0. [#2608](https://github.com/rails/webpacker/pull/2608). However, CSS will be inlined when the webpack-dev-server is used with `hmr: true`. JS package exports `inliningCss`. This is useful to enable HMR for React.
 - Webpacker's wrapper to the `splitChunks()` API will now default `runtimeChunk: 'single'` which will help prevent potential issues when using multiple entry points per page [#2708](https://github.com/rails/webpacker/pull/2708).
 - Changes `@babel/preset-env` modules option to `'auto'` per recommendation in the Babel docs [#2709](https://github.com/rails/webpacker/pull/2709)
 - Adds experimental Yarn 2 support. Note you must manually set `nodeLinker: node-modules` in your `.yarnrc.yml`.
 - Fixes dev server issues [#2898](https://github.com/rails/webpacker/pull/2898)
+- Update static files path to from `media/` to `static/`.
 
 ### Breaking changes
 - Removed integration installers

--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -153,7 +153,7 @@ module Webpacker::Helper
     end
 
     def resolve_path_to_image(name, **options)
-      path = name.starts_with?("media/images/") ? name : "media/images/#{name}"
+      path = name.starts_with?("static/") ? name : "static/#{name}"
       path_to_asset(current_webpacker_instance.manifest.lookup!(path), options)
     rescue
       path_to_asset(current_webpacker_instance.manifest.lookup!(name), options)

--- a/package/rules/file.js
+++ b/package/rules/file.js
@@ -18,6 +18,6 @@ module.exports = {
   exclude: [/\.(js|mjs|jsx|ts|tsx)$/],
   type: 'asset/resource',
   generator: {
-    filename: 'media/images/[hash][ext][query]'
+    filename: 'static/[hash][ext][query]'
   }
 }

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -26,18 +26,18 @@ class HelperTest < ActionView::TestCase
 
   def test_image_pack_path
     assert_equal "/packs/application-k344a6d59eef8632c9d1.png", image_pack_path("application.png")
-    assert_equal "/packs/media/images/image-c38deda30895059837cf.jpg", image_pack_path("image.jpg")
-    assert_equal "/packs/media/images/image-c38deda30895059837cf.jpg", image_pack_path("media/images/image.jpg")
-    assert_equal "/packs/media/images/nested/image-c38deda30895059837cf.jpg", image_pack_path("nested/image.jpg")
-    assert_equal "/packs/media/images/nested/image-c38deda30895059837cf.jpg", image_pack_path("media/images/nested/image.jpg")
+    assert_equal "/packs/static/image-c38deda30895059837cf.jpg", image_pack_path("image.jpg")
+    assert_equal "/packs/static/image-c38deda30895059837cf.jpg", image_pack_path("static/image.jpg")
+    assert_equal "/packs/static/nested/image-c38deda30895059837cf.jpg", image_pack_path("nested/image.jpg")
+    assert_equal "/packs/static/nested/image-c38deda30895059837cf.jpg", image_pack_path("static/nested/image.jpg")
   end
 
   def test_image_pack_url
     assert_equal "https://example.com/packs/application-k344a6d59eef8632c9d1.png", image_pack_url("application.png")
-    assert_equal "https://example.com/packs/media/images/image-c38deda30895059837cf.jpg", image_pack_url("image.jpg")
-    assert_equal "https://example.com/packs/media/images/image-c38deda30895059837cf.jpg", image_pack_url("media/images/image.jpg")
-    assert_equal "https://example.com/packs/media/images/nested/image-c38deda30895059837cf.jpg", image_pack_url("nested/image.jpg")
-    assert_equal "https://example.com/packs/media/images/nested/image-c38deda30895059837cf.jpg", image_pack_url("media/images/nested/image.jpg")
+    assert_equal "https://example.com/packs/static/image-c38deda30895059837cf.jpg", image_pack_url("image.jpg")
+    assert_equal "https://example.com/packs/static/image-c38deda30895059837cf.jpg", image_pack_url("static/image.jpg")
+    assert_equal "https://example.com/packs/static/nested/image-c38deda30895059837cf.jpg", image_pack_url("nested/image.jpg")
+    assert_equal "https://example.com/packs/static/nested/image-c38deda30895059837cf.jpg", image_pack_url("static/nested/image.jpg")
   end
 
   def test_image_pack_tag
@@ -45,20 +45,20 @@ class HelperTest < ActionView::TestCase
       "<img alt=\"Edit Entry\" src=\"/packs/application-k344a6d59eef8632c9d1.png\" width=\"16\" height=\"10\" />",
       image_pack_tag("application.png", size: "16x10", alt: "Edit Entry")
     assert_equal \
-      "<img alt=\"Edit Entry\" src=\"/packs/media/images/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />",
+      "<img alt=\"Edit Entry\" src=\"/packs/static/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />",
       image_pack_tag("image.jpg", size: "16x10", alt: "Edit Entry")
     assert_equal \
-      "<img alt=\"Edit Entry\" src=\"/packs/media/images/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />",
-      image_pack_tag("media/images/image.jpg", size: "16x10", alt: "Edit Entry")
+      "<img alt=\"Edit Entry\" src=\"/packs/static/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />",
+      image_pack_tag("static/image.jpg", size: "16x10", alt: "Edit Entry")
     assert_equal \
-      "<img alt=\"Edit Entry\" src=\"/packs/media/images/nested/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />",
+      "<img alt=\"Edit Entry\" src=\"/packs/static/nested/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />",
       image_pack_tag("nested/image.jpg", size: "16x10", alt: "Edit Entry")
     assert_equal \
-      "<img alt=\"Edit Entry\" src=\"/packs/media/images/nested/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />",
-      image_pack_tag("media/images/nested/image.jpg", size: "16x10", alt: "Edit Entry")
+      "<img alt=\"Edit Entry\" src=\"/packs/static/nested/image-c38deda30895059837cf.jpg\" width=\"16\" height=\"10\" />",
+      image_pack_tag("static/nested/image.jpg", size: "16x10", alt: "Edit Entry")
     assert_equal \
-      "<img srcset=\"/packs/media/images/image-2x-7cca48e6cae66ec07b8e.jpg 2x\" src=\"/packs/media/images/image-c38deda30895059837cf.jpg\" />",
-      image_pack_tag("media/images/image.jpg", srcset: { "media/images/image-2x.jpg" => "2x" })
+      "<img srcset=\"/packs/static/image-2x-7cca48e6cae66ec07b8e.jpg 2x\" src=\"/packs/static/image-c38deda30895059837cf.jpg\" />",
+      image_pack_tag("static/image.jpg", srcset: { "static/image-2x.jpg" => "2x" })
   end
 
   def test_favicon_pack_tag
@@ -66,17 +66,17 @@ class HelperTest < ActionView::TestCase
       "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/application-k344a6d59eef8632c9d1.png\" />",
       favicon_pack_tag("application.png", rel: "apple-touch-icon", type: "image/png")
     assert_equal \
-      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/media/images/mb-icon-c38deda30895059837cf.png\" />",
+      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/static/mb-icon-c38deda30895059837cf.png\" />",
       favicon_pack_tag("mb-icon.png", rel: "apple-touch-icon", type: "image/png")
     assert_equal \
-      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/media/images/mb-icon-c38deda30895059837cf.png\" />",
-      favicon_pack_tag("media/images/mb-icon.png", rel: "apple-touch-icon", type: "image/png")
+      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/static/mb-icon-c38deda30895059837cf.png\" />",
+      favicon_pack_tag("static/mb-icon.png", rel: "apple-touch-icon", type: "image/png")
     assert_equal \
-      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/media/images/nested/mb-icon-c38deda30895059837cf.png\" />",
+      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/static/nested/mb-icon-c38deda30895059837cf.png\" />",
       favicon_pack_tag("nested/mb-icon.png", rel: "apple-touch-icon", type: "image/png")
     assert_equal \
-      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/media/images/nested/mb-icon-c38deda30895059837cf.png\" />",
-      favicon_pack_tag("media/images/nested/mb-icon.png", rel: "apple-touch-icon", type: "image/png")
+      "<link rel=\"apple-touch-icon\" type=\"image/png\" href=\"/packs/static/nested/mb-icon-c38deda30895059837cf.png\" />",
+      favicon_pack_tag("static/nested/mb-icon.png", rel: "apple-touch-icon", type: "image/png")
   end
 
   def test_preload_pack_asset

--- a/test/test_app/public/packs/manifest.json
+++ b/test/test_app/public/packs/manifest.json
@@ -5,11 +5,11 @@
   "application.js": "/packs/application-k344a6d59eef8632c9d1.js",
   "application.png": "/packs/application-k344a6d59eef8632c9d1.png",
   "fonts/fa-regular-400.woff2": "/packs/fonts/fa-regular-400-944fb546bd7018b07190a32244f67dc9.woff2",
-  "media/images/image.jpg": "/packs/media/images/image-c38deda30895059837cf.jpg",
-  "media/images/image-2x.jpg": "/packs/media/images/image-2x-7cca48e6cae66ec07b8e.jpg",
-  "media/images/nested/image.jpg": "/packs/media/images/nested/image-c38deda30895059837cf.jpg",
-  "media/images/mb-icon.png": "/packs/media/images/mb-icon-c38deda30895059837cf.png",
-  "media/images/nested/mb-icon.png": "/packs/media/images/nested/mb-icon-c38deda30895059837cf.png",
+  "static/image.jpg": "/packs/static/image-c38deda30895059837cf.jpg",
+  "static/image-2x.jpg": "/packs/static/image-2x-7cca48e6cae66ec07b8e.jpg",
+  "static/nested/image.jpg": "/packs/static/nested/image-c38deda30895059837cf.jpg",
+  "static/mb-icon.png": "/packs/static/mb-icon-c38deda30895059837cf.png",
+  "static/nested/mb-icon.png": "/packs/static/nested/mb-icon-c38deda30895059837cf.png",
   "entrypoints": {
     "application": {
       "assets": {


### PR DESCRIPTION
Using https://webpack.js.org/guides/asset-modules/#custom-output-filename

It also fixes fonts that were extracted in `media/images`.