### PR TITLE
prettier-friendly package.json

### DIFF
--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -53,7 +53,9 @@ insert_into_file Rails.root.join("package.json").to_s, before: /\n}\n*$/ do
   <<~JSON.chomp
   ,
     "babel": {
-      "presets": ["./node_modules/@rails/webpacker/package/babel/preset.js"]
+      "presets": [
+        "./node_modules/@rails/webpacker/package/babel/preset.js"
+      ]
     },
     "browserslist": [
       "defaults"


### PR DESCRIPTION
fixes duplicate entries in `package.json`

e.g. ending up with things like:

```json
    "config/locales/*.yml": [
      "bin/sort-yaml"
    ]
  },
  "babel": {
    "presets": [
      "./node_modules/@rails/webpacker/package/babel/preset.js"
    ]
  },
  "browserslist": [
    "defaults"
  ],
  "resolutions": {
    "glob-parent": "5.1.2"
  },
  "babel": {
    "presets": ["./node_modules/@rails/webpacker/package/babel/preset.js"]
  },
  "browserslist": [
    "defaults"
  ]
}
```