### PR TITLE
Docs: v6 upgrade: fix instructions re: React

### DIFF
--- a/docs/v6_upgrade.md
+++ b/docs/v6_upgrade.md
@@ -61,6 +61,9 @@ Example going to a specific (beta) version:
   ]
 }
 ```
+
+React users should specify `webpacker/package/babel/preset-react.js` instead.
+
 12. Remove `postcss.config.js` if you don't use `PostCSS`.
 13. `extensions` was removed from the `webpacker.yml` file. Move custom extensions to your configuration by merging an object like this. For more details, see docs for [Webpack Configuration](https://github.com/rails/webpacker/blob/master/README.md#webpack-configuration)
 


### PR DESCRIPTION
Without this fix, if a React user followed the instructions, they'd get an error from Babel about JSX being unsupported.