### PR TITLE
Include style-loader for CSS integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ module.exports = merge(webpackConfig, {
 To enable CSS support in your application, add following packages:
 
 ```bash
-yarn add css-loader mini-css-extract-plugin css-minimizer-webpack-plugin
+yarn add css-loader style-loader mini-css-extract-plugin css-minimizer-webpack-plugin
 ```
 
 Optionally, add the `CSS` extension to webpack config for easy resolution.


### PR DESCRIPTION
PR #3031 added a dependency for `style-loader` when CSS is inlined here: https://github.com/rails/webpacker/blob/master/package/utils/get_style_rule.js#L16

The integration instructions for supporting CSS does not include that package for the `yarn add` so no one would know to include it until they try to run the dev server locally and are greeted with a missing package error.

```
ERROR in ./app/packs/entrypoints/application.js 8:0-33
Module not found: Error: Can't resolve 'style-loader' in '/path/to/webapp'
resolve 'style-loader' in '/path/to/webapp'
```

Adding the package with `yarn add` fixes the issue.

I added `style-loader` to the README under the CSS integration section.