### PR TITLE
Readme: Clarify that a tsconfig.json is not relevant to @babel/preset-typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,12 @@ yarn add coffeescript coffee-loader
 yarn add typescript @babel/preset-typescript
 ```
 
+Babel won’t perform any type-checking on TypeScript code. To optionally use type-checking run:
+
+```bash
+yarn add fork-ts-checker-webpack-plugin
+```
+
 Add tsconfig.json
 
 ```json
@@ -368,12 +374,6 @@ Add tsconfig.json
   "exclude": ["**/*.spec.ts", "node_modules", "vendor", "public"],
   "compileOnSave": false
 }
-```
-
-Babel won’t perform any type-checking on TypeScript code. To optionally use type-checking run:
-
-```bash
-yarn add fork-ts-checker-webpack-plugin
 ```
 
 Then modify the webpack config to use it as a plugin:


### PR DESCRIPTION
This clarification should streamline the debugging process should a developer encounter a typical typescript error, like `ReferenceError: 'exports' is undefined` while using Webpacker