### PR TITLE
Fix missing "yarn add postcss" in PostCSS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ then add the relevant pre-processors:
 #### Postcss
 
 ```bash
-yarn add postcss-loader
+yarn add postcss postcss-loader
 ```
 
 Optionally add these two plugins if they are required in your `postcss.config.js`:


### PR DESCRIPTION
The other instructions e.g. `yarn add sass sass-loader` include the main package in the command i.e. `sass`

For the PostCSS instructions this is missing, but it looks like the main package `postcss` is necessary.