### PR TITLE
Remove unnecessary `implementation` option

### DIFF
--- a/package/rules/sass.js
+++ b/package/rules/sass.js
@@ -9,8 +9,7 @@ module.exports = canProcess('sass-loader', (resolvedPath) =>
     {
       loader: resolvedPath,
       options: {
-        sassOptions: { includePaths },
-        implementation: require('sass')
+        sassOptions: { includePaths }
       }
     }
   ])


### PR DESCRIPTION
The `implementaiton` option is unnecessary if it points to `sass`, as that's the default value anyway according to the [documentation](https://www.npmjs.com/package/sass-loader#implementation).

> Beware the situation when `node-sass` and `sass` were installed!
**By default the `sass-loader` prefers `sass`**. 

Removing this unnecessary option also allows to use `node-sass` if that's what developers want (e.g. because it's faster or because of existing codebase compatibility).