### PR TITLE
Separate svg loader from file loader and add a custom generator

### DIFF
--- a/package/environments/__tests__/base.js
+++ b/package/environments/__tests__/base.js
@@ -8,6 +8,7 @@ const { chdirTestApp, chdirCwd } = require('../../utils/helpers')
 chdirTestApp()
 
 const { resolve } = require('path')
+
 const rules = require('../../rules')
 const baseConfig = require('../base')
 
@@ -39,8 +40,8 @@ describe('Base config', () => {
       const defaultRules = Object.keys(rules)
       const configRules = baseConfig.module.rules
 
-      expect(defaultRules.length).toEqual(3)
-      expect(configRules.length).toEqual(3)
+      expect(defaultRules.length).toEqual(4)
+      expect(configRules.length).toEqual(4)
     })
 
     test('should return default plugins', () => {

--- a/package/rules/file.js
+++ b/package/rules/file.js
@@ -12,8 +12,7 @@ module.exports = {
     /\.otf$/,
     /\.ttf$/,
     /\.woff$/,
-    /\.woff2$/,
-    /\.svg$/
+    /\.woff2$/
   ],
   exclude: [/\.(js|mjs|jsx|ts|tsx)$/],
   type: 'asset/resource',

--- a/package/rules/index.js
+++ b/package/rules/index.js
@@ -4,6 +4,7 @@
 const rules = {
   raw: require('./raw'),
   file: require('./file'),
+  svg: require('./svg'),
   css: require('./css'),
   sass: require('./sass'),
   babel: require('./babel'),

--- a/package/rules/svg.js
+++ b/package/rules/svg.js
@@ -1,0 +1,16 @@
+module.exports = {
+  test: /\.svg/,
+  type: 'asset/inline',
+  generator: {
+    dataUrl: content => {
+      content = content.toString();
+      
+      if (require.resolve("mini-svg-data-uri")) {
+        const svgToMiniDataURI = require('mini-svg-data-uri');
+        content = svgToMiniDataURI(content)
+      }
+
+      return content;
+    }
+  }
+}


### PR DESCRIPTION
Looks like you get rid off svg loader on `https://github.com/rails/webpacker/pull/2830`, I think its a good idea to keep loading it separately since svg files could be manipulated differently than other assets files. Also it would probably be better to add the `svg` files inlined thus we can get rid of some `HTTP` requests.