### PR TITLE
Specify webpack-dev-server to be v3

### DIFF
--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -51,7 +51,7 @@ say "Installing webpack and webpack-cli as direct dependencies"
 run "yarn add webpack@#{webpack_version} webpack-cli@#{webpack_cli_version}"
 
 say "Installing dev server for live reloading"
-run "yarn add --dev webpack-dev-server"
+run "yarn add --dev webpack-dev-server@^3"
 
 if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR > 1
   say "You need to allow webpack-dev-server host as allowed origin for connect-src.", :yellow


### PR DESCRIPTION
Otherwise when using Webpacker v5, it will install [webpack-dev-server v4](https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md#400-2021-08-18) which then requires `@webpack-cli/serve` to also be installed to properly run `bin/webpack-dev-server`.

When using Webpacker v5 with Webpack v4 and trying to run `bin/webpack-dev-server`:

```shell
$ bin/webpack-dev-server
The command moved into a separate package: @webpack-cli/serve
Would you like to install serve? (That will run npm install -D @webpack-cli/serve) (yes/NO) :
```