### PR TITLE
Update webpack-dev-server config to work with version 4

### DIFF
--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -24,25 +24,21 @@ development:
     https: false
     host: localhost
     port: 3035
-    public: localhost:3035
     # Hot Module Replacement updates modules while the application is running without a full reload
     hmr: false
-    # Should we show a full-screen overlay in the browser when there are compiler errors or warnings?
-    overlay: true
+    client:
+      # Should we show a full-screen overlay in the browser when there are compiler errors or warnings?
+      overlay: true
     # Should we use gzip compression?
     compress: true
     # Note that apps that do not check the host are vulnerable to DNS rebinding attacks
-    disable_host_check: true
-    # This option lets the browser open with your local IP
-    use_local_ip: false
-    # When enabled, nothing except the initial startup information will be written to the console.
-    # This also means that errors or warnings from webpack are not visible.
-    quiet: false
+    allowed_hosts: "all"
     pretty: true
     headers:
       'Access-Control-Allow-Origin': '*'
-    watch_options:
-      ignored: '**/node_modules/**'
+    static:
+      watch:
+        ignored: '**/node_modules/**'
 
 test:
   <<: *default

--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -29,6 +29,11 @@ development:
     client:
       # Should we show a full-screen overlay in the browser when there are compiler errors or warnings?
       overlay: true
+      # May also be a string
+      # webSocketURL:
+      #  hostname: "0.0.0.0"
+      #  pathname: "/ws"
+      #  port: 8080
     # Should we use gzip compression?
     compress: true
     # Note that apps that do not check the host are vulnerable to DNS rebinding attacks

--- a/package/__tests__/development.js
+++ b/package/__tests__/development.js
@@ -23,7 +23,7 @@ describe('Development environment', () => {
         devServer: {
           host: 'localhost',
           port: 3035,
-          injectClient: false
+          hot: false
         }
       })
     })

--- a/package/environments/development.js
+++ b/package/environments/development.js
@@ -18,9 +18,29 @@ if (runningWebpackDevServer) {
     })
   }
 
-  let staticConfig = { publicPath: contentBase }
+  const devServerConfig = {
+    devMiddleware: {
+      publicPath
+    },
+    compress: devServer.compress,
+    allowedHosts: devServer.allowed_hosts,
+    host: devServer.host,
+    port: devServer.port,
+    https: devServer.https,
+    hot: devServer.hmr,
+    historyApiFallback: { disableDotRule: true },
+    headers: devServer.headers,
+    static: {
+      publicPath: contentBase
+    }
+  }
+
   if (devServer.static) {
-    staticConfig = { ...staticConfig, ...devServer.static }
+    devServerConfig.static = { ...devServerConfig.static, ...devServer.static }
+  }
+
+  if (devServer.client) {
+    devServerConfig.client = devServer.client
   }
 
   devConfig = merge(devConfig, {
@@ -31,23 +51,7 @@ if (runningWebpackDevServer) {
       modules: false,
       moduleTrace: false
     },
-    devServer: {
-      client: {
-        overlay: devServer.overlay
-      },
-      devMiddleware: {
-        publicPath
-      },
-      compress: devServer.compress,
-      allowedHosts: devServer.allowed_hosts,
-      host: devServer.host,
-      port: devServer.port,
-      https: devServer.https,
-      hot: devServer.hmr,
-      historyApiFallback: { disableDotRule: true },
-      headers: devServer.headers,
-      static: staticConfig
-    }
+    devServer: devServerConfig
   })
 }
 

--- a/package/environments/development.js
+++ b/package/environments/development.js
@@ -28,6 +28,7 @@ if (runningWebpackDevServer) {
     port: devServer.port,
     https: devServer.https,
     hot: devServer.hmr,
+    liveReload: !devServer.hmr,
     historyApiFallback: { disableDotRule: true },
     headers: devServer.headers,
     static: {

--- a/package/environments/development.js
+++ b/package/environments/development.js
@@ -18,34 +18,35 @@ if (runningWebpackDevServer) {
     })
   }
 
+  let staticConfig = { publicPath: contentBase }
+  if (devServer.static) {
+    staticConfig = { ...staticConfig, ...devServer.static }
+  }
+
   devConfig = merge(devConfig, {
+    stats: {
+      colors: true,
+      entrypoints: false,
+      errorDetails: true,
+      modules: false,
+      moduleTrace: false
+    },
     devServer: {
-      clientLogLevel: 'none',
+      client: {
+        overlay: devServer.overlay
+      },
+      devMiddleware: {
+        publicPath
+      },
       compress: devServer.compress,
-      quiet: devServer.quiet,
-      disableHostCheck: devServer.disable_host_check,
+      allowedHosts: devServer.allowed_hosts,
       host: devServer.host,
       port: devServer.port,
       https: devServer.https,
       hot: devServer.hmr,
-      contentBase,
-      inline: devServer.inline || devServer.hmr,
-      injectClient: devServer.hmr,
-      injectHot: devServer.hmr,
-      useLocalIp: devServer.use_local_ip,
-      public: devServer.public,
-      publicPath,
       historyApiFallback: { disableDotRule: true },
       headers: devServer.headers,
-      overlay: devServer.overlay,
-      stats: {
-        colors: true,
-        entrypoints: false,
-        errorDetails: true,
-        modules: false,
-        moduleTrace: false
-      },
-      watchOptions: devServer.watch_options
+      static: staticConfig
     }
   })
 }


### PR DESCRIPTION
`webpack-dev-server` 4 dropped very recently. With it came a very large set of breaking changes regarding the configuration.

This updates the dev server configurtation in `development.js` and the default `webpacker.yml` files to work with it.

I can at least confirm that using this against a relatively basic Rails app using version 4 with tailwind + turbo works as "expected."

The upgrade guide for going from webpacker 5 to 6 pretty much does a redo on the installation (including uninstalling and reinstalling the latest `webpack-dev-server`), so in theory those on the upgrade path would need to review and reimplement any custom config changes anyway for their `webpacker.yml` file?