### PR TITLE
Correct developing doc to use yalc

### DIFF
--- a/docs/developing_webpacker.md
+++ b/docs/developing_webpacker.md
@@ -11,10 +11,10 @@ Let's call the rails/webpacker directory `WEBPACKER_DIR` which has rails/webpack
 
 ## Changing the Package
 ### Setup with Yalc
-Use [`yalc`](https://github.com/wclr/yalc) unless you like yak shaving weird errors. 
-1. In `WEBPACKER_DIR`, run `yalc publish` 
-2. In `TEST_APP_DIR`, run `yarn link @rails/webpacker`
-   
+Use [`yalc`](https://github.com/wclr/yalc) unless you like yak shaving weird errors.
+1. In `WEBPACKER_DIR`, run `yalc publish`
+2. In `TEST_APP_DIR`, run `yalc link @rails/webpacker`
+
 ## Update the Package Code
 1. Make some JS change in WEBPACKER_DIR
 2. Run `yalc push` and your changes will be pushed to your `TEST_APP_DIR`'s node_modules.


### PR DESCRIPTION
The document outlining how to develope webpacker side-by-side with an app uses `yalc` to "build" and link the package to the test app's `node_modules`. It mentions using `yarn link` to link the packages together, however I have yet to get it to work.

```bash
$ yarn link @rails/webpacker
yarn link v1.22.5
error No registered package found called "@rails/webpacker".
info Visit https://yarnpkg.com/en/docs/cli/link for documentation about this command.
```

I am able to get it to work with `yalc link`, however.

```bash
$ yalc link @rails/webpacker
Package @rails/webpacker@6.0.0-rc.1 linked ==> /home/user/work/testapp/node_modules/@rails/webpacker
```

Unless I'm doing something very wrong with the other steps, I am running under the assumption that this was a mistype in the document and yalc is the correct command to use to link.

I updated the document accordingly.