### PR TITLE
Allow liveReload to be configurable in dev server

### DIFF
--- a/lib/install/config/webpacker.yml
+++ b/lib/install/config/webpacker.yml
@@ -26,6 +26,8 @@ development:
     port: 3035
     # Hot Module Replacement updates modules while the application is running without a full reload
     hmr: false
+    # Defaults to the inverse of hmr. Uncomment to manually set this.
+    # live_reload: true
     client:
       # Should we show a full-screen overlay in the browser when there are compiler errors or warnings?
       overlay: true

--- a/package/environments/development.js
+++ b/package/environments/development.js
@@ -12,6 +12,11 @@ let devConfig = {
 }
 
 if (runningWebpackDevServer) {
+  let liveReload = !devServer.hmr
+  if (devServer.live_reload !== undefined) {
+    liveReload = devServer.live_reload
+  }
+
   const devServerConfig = {
     devMiddleware: {
       publicPath
@@ -22,7 +27,7 @@ if (runningWebpackDevServer) {
     port: devServer.port,
     https: devServer.https,
     hot: devServer.hmr,
-    liveReload: !devServer.hmr,
+    liveReload,
     historyApiFallback: { disableDotRule: true },
     headers: devServer.headers,
     static: {


### PR DESCRIPTION
By default, liveReload for the `webpack_dev_server` config is the inverse of the hmr setting. There may be a usecase where one may want to control both values manually.

This allows liveReload to be configurable through `webpacker.yml` via the `live_reload` option. If not set, then the default of the inverse of hmr is used.