### PR TITLE
CI: Simplify ruby.yml workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [14]
         ruby:
           - 2.7
           - "3.0"
@@ -39,14 +38,6 @@ jobs:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
       - uses: actions/checkout@v2
-
-      - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
-
-      - name: Install yarn maybe
-        run: which yarn || npm install -g yarn
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,9 +7,6 @@ jobs:
     name: Ruby specs
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' || matrix.experimental }}
-    env:
-      BUNDLE_JOBS: 4
-      BUNDLE_RETRY: 3
     strategy:
       fail-fast: false
       matrix:
@@ -38,14 +35,10 @@ jobs:
             gemfile: gemfiles/Gemfile-rails-edge
             experimental: true
 
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: /home/runner/bundle
-          key: bundle-use-ruby-${{ matrix.ruby }}-${{ matrix.gemfile }}-gems-${{ hashFiles(matrix.gemfile) }}-${{ hashFiles('**/*.gemspec') }}
-          restore-keys: |
-            bundle-use-ruby-${{ matrix.ruby }}-${{ matrix.gemfile }}-gems-
 
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1
@@ -58,13 +51,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
-      - name: Bundle install
-        run: |
-          gem install bundler -v 2.1.4
-          bundle config path /home/runner/bundle
-          bundle config --global gemfile ${{ matrix.gemfile }}
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true # Run "bundle install", and cache the result automatically.
 
       - name: Ruby specs
-        run: bundle exec rake test
+        run: bundle exec rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,23 +15,17 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: [14]
-        ruby: [
-          2.7,
-          3.0
-        ]
-        gemfile: [
-          "gemfiles/Gemfile-rails.5.2.x",
-          "gemfiles/Gemfile-rails.6.0.x",
-          "gemfiles/Gemfile-rails.6.1.x"
-        ]
+        ruby:
+          - 2.7
+          - "3.0"
+        gemfile:
+          - gemfiles/Gemfile-rails.5.2.x
+          - gemfiles/Gemfile-rails.6.0.x
+          - gemfiles/Gemfile-rails.6.1.x
         exclude:
-          - ruby: 2.4
-            gemfile: gemfiles/Gemfile-rails.6.0.x
-          - ruby: 2.4
-            gemfile: gemfiles/Gemfile-rails.6.1.x
           - ruby: 2.5
             gemfile: gemfiles/Gemfile-rails.6.1.x
-          - ruby: 3.0
+          - ruby: "3.0"
             gemfile: gemfiles/Gemfile-rails.5.2.x
         experimental: [false]
         include:
@@ -39,7 +33,7 @@ jobs:
             os: ubuntu-latest
             gemfile: gemfiles/Gemfile-rails-edge
             experimental: true
-          - ruby: 3.0
+          - ruby: "3.0"
             os: ubuntu-latest
             gemfile: gemfiles/Gemfile-rails-edge
             experimental: true


### PR DESCRIPTION
This PR simplifies the **CI Ruby Workflow**.

- 🛠️  Quote `3.0` to avoid risking this Float becoming the String "3" when interpolating.
- 🧹  Format YAML lists so the GitHub editing UI likes it.
- 🧹  Remove unused "exclude:" directive for Ruby v2.4 entries.
- 🧹 Remove unused Node.js.
- ✅  Use setup-ruby's `bundler-cache: true` to do the whole of the caching & install.