### PR TITLE
refactor(cli): drop unused @argv.delete

### DIFF
--- a/lib/webpacker/webpack_runner.rb
+++ b/lib/webpacker/webpack_runner.rb
@@ -28,7 +28,6 @@ module Webpacker
 
       if @argv.delete "--debug-webpacker"
         cmd = ["node", "--inspect-brk"] + cmd
-        @argv.delete "--debug-webpacker"
       end
 
       if @argv.delete "--trace-deprecation"


### PR DESCRIPTION
f0d2913de06a9ef73439aa8dfa74fef37c5ecb97 introduced the `#delete` two lines up, so now this is no longer needed.