### PR TITLE
Add troubleshooting section about CDN URL gotcha

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -188,3 +188,21 @@ module.exports = merge(webpackConfig, {
   ],
 })
 ```
+
+## Wrong CDN src from javascript_pack_tag
+
+If your deployment doesn't rebuild assets between environments (such as when
+using Heroku's Pipeline promote feature). You might find that your production
+application is using your staging `config.asset_host` URL when using
+`javascript_pack_tag`.
+
+This can be fixed by setting the environment variable `WEBPACKER_ASSET_HOST` to
+an empty string where your assets are compiled. On Heroku this is done under
+*Settings* -> *Config Vars*.
+
+This way webpacker won't hard-code the CDN URL into the manifest file used by
+`javascript_pack_tag`, but instead fetch the CDN at runtime, resolving the
+issue.
+
+See [this issue](https://github.com/rails/webpacker/issues/3005) for more
+details.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -193,15 +193,15 @@ module.exports = merge(webpackConfig, {
 
 If your deployment doesn't rebuild assets between environments (such as when
 using Heroku's Pipeline promote feature). You might find that your production
-application is using your staging `config.asset_host` URL when using
+application is using your staging `config.asset_host` host when using
 `javascript_pack_tag`.
 
 This can be fixed by setting the environment variable `WEBPACKER_ASSET_HOST` to
 an empty string where your assets are compiled. On Heroku this is done under
 *Settings* -> *Config Vars*.
 
-This way webpacker won't hard-code the CDN URL into the manifest file used by
-`javascript_pack_tag`, but instead fetch the CDN at runtime, resolving the
+This way webpacker won't hard-code the CDN host into the manifest file used by
+`javascript_pack_tag`, but instead fetch the CDN host at runtime, resolving the
 issue.
 
 See [this issue](https://github.com/rails/webpacker/issues/3005) for more


### PR DESCRIPTION
This PR adds a new section to the troubleshooting document explaining a gotcha where the javascript asset file can be incorrectly linked when `config.asset_host` is configured with different URLs in different environments and assets are not re-compiled between those environments.

As the new section explains this is common on Heroku where the user is encouraged to use their pipeline promote feature that does not re-compile assets between apps.

A common pattern is to use one app as a staging environment to evaluate builds. Upon acceptance, the staging app is “promoted” to the production environment. If `WEBPACKER_ASSET_HOST` is not set to an empty value in the staging application that application’s CDN URL will be compiled into the manifest.json file and reused in the production application.

This issue can be tricky to detect as there might be no immediate error. The file probably still exists as it’s used by staging. When the staging environment later is re-deployed with new finger-printed assets the CDN will eventually remove the asset files that production is still dependent on.

All credit to @willcosgrove who provided this solution in https://github.com/rails/webpacker/issues/3005.