### PR TITLE
CI: use caching for JavaScript workflows 

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -15,24 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          cache: yarn
 
       - name: Install yarn maybe
         run: which yarn || npm install -g yarn
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.node }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.node }}-yarn-
 
       - name: Install dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v2
         with:
@@ -22,8 +23,6 @@ jobs:
 
       - name: Install yarn maybe
         run: which yarn || npm install -g yarn
-
-      - uses: actions/checkout@v2
 
       - name: Install dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -15,25 +15,15 @@ jobs:
 
     steps:
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          cache: yarn
 
       - name: Install yarn maybe
         run: which yarn || npm install -g yarn
 
       - uses: actions/checkout@v2
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
 
       - name: Install dependencies
         run: yarn --frozen-lockfile


### PR DESCRIPTION
This PR adds caching to the `jest` & `js-lint` CI workflows.

- 🎡  enable `cache: yarn` as described  in [actions/setup-node docs](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies)
- 🔧  use `actions/setup-node@v2`
- 🔧 ordered checkout before Node installation in js-lint to avoid an issue
- 🧹  cleanup unused caching configuration
