### PR TITLE
Remove old configuration adding hashes for files

### DIFF
--- a/package/environments/__tests__/base.js
+++ b/package/environments/__tests__/base.js
@@ -39,12 +39,12 @@ describe('Base config', () => {
       const defaultRules = Object.keys(rules)
       const configRules = baseConfig.module.rules
 
-      expect(defaultRules.length).toEqual(3)
-      expect(configRules.length).toEqual(3)
+      expect(defaultRules.length).toEqual(4)
+      expect(configRules.length).toEqual(4)
     })
 
     test('should return default plugins', () => {
-      expect(baseConfig.plugins.length).toEqual(2)
+      expect(baseConfig.plugins.length).toEqual(3)
     })
 
     test('should return default resolveLoader', () => {

--- a/package/environments/__tests__/base.js
+++ b/package/environments/__tests__/base.js
@@ -39,12 +39,12 @@ describe('Base config', () => {
       const defaultRules = Object.keys(rules)
       const configRules = baseConfig.module.rules
 
-      expect(defaultRules.length).toEqual(4)
-      expect(configRules.length).toEqual(4)
+      expect(defaultRules.length).toEqual(3)
+      expect(configRules.length).toEqual(3)
     })
 
     test('should return default plugins', () => {
-      expect(baseConfig.plugins.length).toEqual(3)
+      expect(baseConfig.plugins.length).toEqual(2)
     })
 
     test('should return default resolveLoader', () => {

--- a/package/environments/development.js
+++ b/package/environments/development.js
@@ -12,12 +12,6 @@ let devConfig = {
 }
 
 if (runningWebpackDevServer) {
-  if (devServer.hmr) {
-    devConfig = merge(devConfig, {
-      output: { filename: '[name]-[hash].js' }
-    })
-  }
-
   const devServerConfig = {
     devMiddleware: {
       publicPath


### PR DESCRIPTION
Per all dependency updates, we don't need hashes on filenames when hot
reloading. Plus, this could be configured in base.js where other output
options are set.