### PR TITLE
Fixed README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Note, the default of "defer" for the `javascript_pack_tag`. You can override tha
 
 #### Server-Side Rendering (SSR)
 
-Note, if you are using server-side rendering of JavaScript with dynamic code-spliting, as is often done with extensions to Webpacker, like [React on Rails](https://github.com/shakacode/react_on_rails), your JavaScript should create the link prefetch HTML tags that you will use, so you won't need to use to `asset_pack_path` in those circumstances.
+Note, if you are using server-side rendering of JavaScript with dynamic code-splitting, as is often done with extensions to Webpacker, like [React on Rails](https://github.com/shakacode/react_on_rails), your JavaScript should create the link prefetch HTML tags that you will use, so you won't need to use to `asset_pack_path` in those circumstances.
 
 **Note:** In order for your styles or static assets files to be available in your view, you would need to link them in your "pack" or entry file. Otherwise, Webpack won't know to package up those files.
 


### PR DESCRIPTION
"spliting" to "splitting"