### PR TITLE
support stylesheet_pack_tag with HMR

### DIFF
--- a/lib/webpacker/helper.rb
+++ b/lib/webpacker/helper.rb
@@ -141,8 +141,6 @@ module Webpacker::Helper
   #   <%= stylesheet_pack_tag 'calendar' %>
   #   <%= stylesheet_pack_tag 'map' %>
   def stylesheet_pack_tag(*names, **options)
-    return "" if Webpacker.inlining_css?
-
     stylesheet_link_tag(*sources_from_manifest_entrypoints(names, type: :stylesheet), **options)
   end
 


### PR DESCRIPTION
Closes https://github.com/rails/webpacker/issues/3183

Webpack with HRM can work with styles that are imported from JS, but can't work with styles outside of JS scope
https://webpack.js.org/guides/hot-module-replacement/#hmr-with-stylesheets