### PR TITLE
Run Jest with Node.js 16, drop Node.js 15

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [12.x, 14.x, 15.x]
+        node: [12.x, 14.x, 16.x]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
v16 is "Current", while v15 is already unsupported.

https://nodejs.org/en/about/releases/