### PR TITLE
Reverts the Env#available_environments to return an array of supported environments

### DIFF
--- a/lib/webpacker/env.rb
+++ b/lib/webpacker/env.rb
@@ -31,7 +31,7 @@ class Webpacker::Env
           YAML.load_file(config_path.to_s, aliases: true)
         rescue ArgumentError
           YAML.load_file(config_path.to_s)
-        end
+        end.keys
       else
         [].freeze
       end


### PR DESCRIPTION

From v5.3.0 to v5.4.0 the implementation of Env#available_environments was changed and it now returns the full config hash and not just an array of environments (except when the file doesn't exist then it inconsistently returns a hash). This looks like it was an oversight and would also need to be applied to the v6 branch.

see https://github.com/rails/webpacker/commit/f8dbc91c9442e43529da8e08e5ac486d62c398cd#diff-0f66fa9a40636ce71d4a2b0a98de9dff3ba6ea6c21f5deca80fcde1191c614f6