### PR TITLE
Update CONTRIBUTING.md with the correct syntax for running a single test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,5 +48,5 @@ bundle exec rake test TEST=test/rake_tasks_test.rb
 #### 4.2 Run a single ruby test
 
 ```
-ruby -I test test/rake_tasks_test.rb -n test_rake_webpacker_install
+bundle exec ruby -I test test/rake_tasks_test.rb -n test_rake_webpacker_install
 ```


### PR DESCRIPTION
The ruby command in CONTRIBUTING.md  to run a single test needs to be rpefixed with `bundle exec`
