### PR TITLE
Remove loose: true to support Stimulus 3.x

### DIFF
--- a/package/babel/preset.js
+++ b/package/babel/preset.js
@@ -25,7 +25,6 @@ module.exports = function config(api) {
           corejs: '3.8',
           modules: 'auto',
           bugfixes: true,
-          loose: true,
           exclude: ['transform-typeof-symbol']
         }
       ],


### PR DESCRIPTION
This fixes an issue with the babel preset which prevents Stimulus 3.x from working.

See #3153 for more information about the issue and the proposed fix.