### PR TITLE
Support node LTS and future "Current" releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib/install/config/webpacker.yml"
   ],
   "engines": {
-    "node": ">= 12.13.0 || >=14",
+    "node": "^12.13.0 || ^14 || >=16",
     "yarn": ">=1 <4"
   },
   "dependencies": {


### PR DESCRIPTION
Drops support for Node.js 13 and 15.

https://nodejs.org/en/about/releases/