### PR TITLE
Fixes #3208 Rake tasks don't show log out put

### DIFF
--- a/lib/webpacker.rb
+++ b/lib/webpacker.rb
@@ -24,7 +24,7 @@ module Webpacker
 
   def ensure_log_goes_to_stdout
     old_logger = Webpacker.logger
-    Webpacker.logger = ActiveSupport::Logger.new(STDOUT)
+    Webpacker.logger = Logger.new(STDOUT)
     yield
   ensure
     Webpacker.logger = old_logger


### PR DESCRIPTION
https://github.com/rails/webpacker/issues/3208

* you have to assign `Logger.new(STDOUT)` instead of `ActiveSupport::Logger.new(STDOUT)` to `Webpacker.logger`