### PR TITLE
Make Compiler#watched_files_digest thread safe.

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -53,11 +53,13 @@ class Webpacker::Compiler
 
     def watched_files_digest
       warn "Webpacker::Compiler.watched_paths has been deprecated. Set additional_paths in webpacker.yml instead." unless watched_paths.empty?
-      Dir.chdir File.expand_path(config.root_path) do
-        files = Dir[*default_watched_paths, *watched_paths].reject { |f| File.directory?(f) }
-        file_ids = files.sort.map { |f| "#{File.basename(f)}/#{Digest::SHA1.file(f).hexdigest}" }
-        Digest::SHA1.hexdigest(file_ids.join("/"))
+      root_path = File.expand_path(config.root_path)
+      expanded_paths = [*default_watched_paths, *watched_paths].map do |path|
+        File.join(root_path, path)
       end
+      files = Dir[*expanded_paths].reject { |f| File.directory?(f) }
+      file_ids = files.sort.map { |f| "#{File.basename(f)}/#{Digest::SHA1.file(f).hexdigest}" }
+      Digest::SHA1.hexdigest(file_ids.join("/"))
     end
 
     def record_compilation_digest


### PR DESCRIPTION
Removes Dir.chdir call which raises error if two threads both try to call it. Instead we manually expand the root path and join relative watch paths to it before calling Dir.

See https://github.com/rails/webpacker/pull/2788#issuecomment-863898053 for motivation.