### PR TITLE
Add fast refresh to default babel if packages exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,9 @@ Webpacker out of the box supports JS and static assets (fonts, images etc.) comp
 
 ```bash
 yarn add react react-dom @babel/preset-react
+
+## add hmr ones only for development
+yarn add --dev @pmmmwh/react-refresh-webpack-plugin react-refresh
 ```
 
 ...if you are using typescript, update your `tsconfig.json`

--- a/package/babel/preset.js
+++ b/package/babel/preset.js
@@ -48,7 +48,10 @@ module.exports = function config(api) {
         moduleExists('babel-plugin-transform-react-remove-prop-types') && [
           'babel-plugin-transform-react-remove-prop-types',
           { removeImport: true }
-        ]
+        ],
+      moduleExists('react-refresh') && [
+        process.env.WEBPACK_SERVE && 'react-refresh/babel'
+      ]
     ].filter(Boolean)
   }
 }


### PR DESCRIPTION
With this change, it's extremely easy to make React work with HMR.

Here's a PR in my example project demonstrating the improvement:

https://github.com/shakacode/react_on_rails_tutorial_with_ssr_and_hmr_fast_refresh/pull/20