### PR TITLE
Fix so webpacker:install does not require webpacker.yml pre-existing

### DIFF
--- a/lib/tasks/webpacker/install.rake
+++ b/lib/tasks/webpacker/install.rake
@@ -4,7 +4,8 @@ bin_path = ENV["BUNDLE_BIN"] || Rails.root.join("bin")
 namespace :webpacker do
   desc "Install Webpacker in this application"
   task install: [:check_node, :check_yarn] do |task|
-    @@webpacker_installing = true
+    Webpacker::Configuration.installing = true
+
     prefix = task.name.split(/#|webpacker:install/).first
 
     if Rails::VERSION::MAJOR >= 5

--- a/lib/tasks/webpacker/install.rake
+++ b/lib/tasks/webpacker/install.rake
@@ -4,6 +4,7 @@ bin_path = ENV["BUNDLE_BIN"] || Rails.root.join("bin")
 namespace :webpacker do
   desc "Install Webpacker in this application"
   task install: [:check_node, :check_yarn] do |task|
+    @@webpacker_installing = true
     prefix = task.name.split(/#|webpacker:install/).first
 
     if Rails::VERSION::MAJOR >= 5

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -80,10 +80,13 @@ class Webpacker::Configuration
       end
       config[env].deep_symbolize_keys
     rescue Errno::ENOENT => e
-      raise "Webpacker configuration file not found #{config_path}. " \
-            "Please run rails webpacker:install " \
-            "Error: #{e.message}"
-
+      if @@webpacker_installing
+        {}
+      else
+        raise "Webpacker configuration file not found #{config_path}. " \
+              "Please run rails webpacker:install " \
+              "Error: #{e.message}"
+      end
     rescue Psych::SyntaxError => e
       raise "YAML syntax error occurred while parsing #{config_path}. " \
             "Please note that YAML must be consistently indented using spaces. Tabs are not allowed. " \

--- a/lib/webpacker/configuration.rb
+++ b/lib/webpacker/configuration.rb
@@ -3,6 +3,10 @@ require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/hash/indifferent_access"
 
 class Webpacker::Configuration
+  class << self
+    attr_accessor :installing
+  end
+
   attr_reader :root_path, :config_path, :env
 
   def initialize(root_path:, config_path:, env:)
@@ -80,7 +84,7 @@ class Webpacker::Configuration
       end
       config[env].deep_symbolize_keys
     rescue Errno::ENOENT => e
-      if @@webpacker_installing
+      if self.class.installing
         {}
       else
         raise "Webpacker configuration file not found #{config_path}. " \


### PR DESCRIPTION
If you run ./bin/rails webpacker:install on a rails app with no
config/webpacker.yml, we get a crash with this error:

> Webpacker configuration file not found webpacker-v6/config/webpacker.yml.

> Please run rails webpacker:install Error: No such file or directory @
rb_check_realpath_internal - webpacker-v6/config/webpacker.yml

With this fix, allow the installer to run.

Problem solved with a global to indicate installing so that default
configuration is used rather than crashing because the yet to be
installed config/webpacker.yml is not yet installed.

Fixes this old, very confusing issue https://github.com/rails/webpacker/issues/940#issuecomment-757482835.
