### PR TITLE
Remove setting RAILS_ENV from RACK_ENV, NODE_ENV defaults RAILS_ENV

### DIFF
--- a/lib/install/bin/webpack
+++ b/lib/install/bin/webpack
@@ -6,7 +6,7 @@ require "webpacker"
 require "webpacker/webpack_runner"
 
 ENV["RAILS_ENV"] ||= "development"
-ENV["NODE_ENV"]  ||= "development"
+ENV["NODE_ENV"]  ||= ENV["RAILS_ENV"]
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", Pathname.new(__FILE__).realpath)
 
 APP_ROOT = File.expand_path("..", __dir__)

--- a/lib/install/bin/webpack
+++ b/lib/install/bin/webpack
@@ -5,7 +5,7 @@ require "bundler/setup"
 require "webpacker"
 require "webpacker/webpack_runner"
 
-ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
+ENV["RAILS_ENV"] ||= "development"
 ENV["NODE_ENV"]  ||= "development"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", Pathname.new(__FILE__).realpath)
 

--- a/lib/install/bin/webpack-dev-server
+++ b/lib/install/bin/webpack-dev-server
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
+ENV["RAILS_ENV"] ||= "development"
 ENV["NODE_ENV"]  ||= "development"
 
 require "pathname"

--- a/lib/install/bin/webpack-dev-server
+++ b/lib/install/bin/webpack-dev-server
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 ENV["RAILS_ENV"] ||= "development"
-ENV["NODE_ENV"]  ||= "development"
+ENV["NODE_ENV"]  ||= ENV["RAILS_ENV"]
 
 require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",

--- a/test/test_app/bin/webpack
+++ b/test/test_app/bin/webpack
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
+ENV["RAILS_ENV"] ||= "development"
 ENV["NODE_ENV"] ||= ENV["RAILS_ENV"]
 
 require "pathname"

--- a/test/test_app/bin/webpack-dev-server
+++ b/test/test_app/bin/webpack-dev-server
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
+ENV["RAILS_ENV"] ||= "development"
 ENV["NODE_ENV"] ||= ENV["RAILS_ENV"]
 
 require "pathname"


### PR DESCRIPTION
* Fixes https://github.com/rails/webpacker/issues/3200
* NODE_ENV will default to RAILS_ENV which is a reasonable default.

Per https://nodejs.dev/learn/nodejs-the-difference-between-development-and-production

Generally, the only value that matters for NODE_ENV is production. 

~Given the old code, I suspect that many people ran `rake assets:precompile` and had the NODE_ENV incorrectly set to 'development' for production builds.~

Actually, for running the rake task to build, https://github.com/rails/webpacker/blob/master/lib/tasks/webpacker/compile.rake#L23 sets the NODE_ENV to production if not set.

