### PR TITLE
Improved output on webpack error

### DIFF
--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -89,7 +89,7 @@ class Webpacker::Compiler
         end
       else
         non_empty_streams = [stdout, stderr].delete_if(&:empty?)
-        logger.error "\nCOMPILATION FAILED:\n EXIT STATUS: #{status}\n OUTPUTS:\n#{non_empty_streams.join("\n\n")}"
+        logger.error "\nCOMPILATION FAILED:\nEXIT STATUS: #{status}\nOUTPUTS:\n#{non_empty_streams.join("\n\n")}"
       end
 
       status.success?

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -89,7 +89,7 @@ class Webpacker::Compiler
         end
       else
         non_empty_streams = [stdout, stderr].delete_if(&:empty?)
-        logger.error "Compilation failed:\nexit_status: #{status}\noutputs: #{non_empty_streams.join("\n\n")}"
+        logger.error "Compilation failed:\n ExitStatus: #{status}\n Outputs: #{non_empty_streams.join("\n\n")}"
       end
 
       status.success?

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -89,7 +89,7 @@ class Webpacker::Compiler
         end
       else
         non_empty_streams = [stdout, stderr].delete_if(&:empty?)
-        logger.error "Compilation failed:\n ExitStatus: #{status}\n Outputs: #{non_empty_streams.join("\n\n")}"
+        logger.error "\nCOMPILATION FAILED:\n EXIT STATUS: #{status}\n OUTPUTS:\n#{non_empty_streams.join("\n\n")}"
       end
 
       status.success?

--- a/lib/webpacker/compiler.rb
+++ b/lib/webpacker/compiler.rb
@@ -89,7 +89,7 @@ class Webpacker::Compiler
         end
       else
         non_empty_streams = [stdout, stderr].delete_if(&:empty?)
-        logger.error "Compilation failed:\n#{non_empty_streams.join("\n\n")}"
+        logger.error "Compilation failed:\nexit_status: #{status}\noutputs: #{non_empty_streams.join("\n\n")}"
       end
 
       status.success?


### PR DESCRIPTION
When webpack terminates with an error, the reason may not be clear from the stdout and stderr output alone.
For example, I could not understand the reason when webpack was killed. (See the `before` output below).
For this reason, when webpack fails, it outputs the status information in addition to the stdout and stderr output. Now, I can notice when webpack is killed. (See the `after` output below).

## output examples

### before:

```
** Execute webpacker:compile
Compiling...
Compilation failed:
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
```

### after:

```
** Execute webpacker:compile
Compiling...
Compilation failed:
 ExitStatus: pid 1064 SIGKILL (signal 9)
 Outputs: Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
```
