### PR TITLE
Raise a more accurate error when 'which_command' is not installed

### DIFF
--- a/lib/tasks/webpacker/check_node.rake
+++ b/lib/tasks/webpacker/check_node.rake
@@ -7,7 +7,7 @@ namespace :webpacker do
         which_command = 'where'
       else
         which_command = 'which'
-        raise Errno::ENOSYS if `rpm -qa | grep #{which_command}`.strip.empty?
+        raise Errno::ENOSYS if system("type which").nil?
       end
 
       raise Errno::ENOENT if `#{which_command} node || #{which_command} nodejs`.strip.empty?
@@ -36,7 +36,7 @@ namespace :webpacker do
       $stderr.puts "Exiting!"
       exit!
     rescue Errno::ENOSYS
-      $stderr.puts "'#{which_command}' is not installed. Please download and install '#{which_command}' by running the following command 'yum install #{which_command}'"
+      $stderr.puts "'#{which_command}' is not installed. Please download and install '#{which_command}'"
       $stderr.puts "Exiting!"
       exit!
     end

--- a/lib/tasks/webpacker/check_node.rake
+++ b/lib/tasks/webpacker/check_node.rake
@@ -3,7 +3,13 @@ namespace :webpacker do
   desc "Verifies if Node.js is installed"
   task :check_node do
     begin
-      which_command = Gem.win_platform? ? "where" : "which"
+      if Gem.win_platform?
+        which_command = 'where'
+      else
+        which_command = 'which'
+        raise Errno::ENOSYS if `rpm -qa | grep #{which_command}`.strip.empty?
+      end
+
       raise Errno::ENOENT if `#{which_command} node || #{which_command} nodejs`.strip.empty?
 
       node_version = `node -v || nodejs -v`.strip
@@ -27,6 +33,10 @@ namespace :webpacker do
       end
     rescue Errno::ENOENT
       $stderr.puts "Node.js not installed. Please download and install Node.js https://nodejs.org/en/download/"
+      $stderr.puts "Exiting!"
+      exit!
+    rescue Errno::ENOSYS
+      $stderr.puts "'#{which_command}' is not installed. Please download and install '#{which_command}' by running the following command 'yum install #{which_command}'"
       $stderr.puts "Exiting!"
       exit!
     end

--- a/lib/tasks/webpacker/check_node.rake
+++ b/lib/tasks/webpacker/check_node.rake
@@ -3,15 +3,6 @@ namespace :webpacker do
   desc "Verifies if Node.js is installed"
   task :check_node do
     begin
-      if Gem.win_platform?
-        which_command = 'where'
-      else
-        which_command = 'which'
-        raise Errno::ENOSYS if system("type which").nil?
-      end
-
-      raise Errno::ENOENT if `#{which_command} node || #{which_command} nodejs`.strip.empty?
-
       node_version = `node -v || nodejs -v`.strip
       raise Errno::ENOENT if node_version.blank?
 
@@ -33,10 +24,6 @@ namespace :webpacker do
       end
     rescue Errno::ENOENT
       $stderr.puts "Node.js not installed. Please download and install Node.js https://nodejs.org/en/download/"
-      $stderr.puts "Exiting!"
-      exit!
-    rescue Errno::ENOSYS
-      $stderr.puts "'#{which_command}' is not installed. Please download and install '#{which_command}'"
       $stderr.puts "Exiting!"
       exit!
     end


### PR DESCRIPTION
I have a custom Centos docker image with a ruby on rails project setup. I was getting the following **error** during the precompile task.

`bundle exec rails assets:precompile`

this is the error output:
```
.
.
.
I, [2021-12-21T17:28:19.287300 #1]  INFO -- : Writing /usr/local/project/public/assets/express/lib/application-98f164ad65010340ab481475a0137ee982cf4de44f0e4c6441263ebb2b676481.js.gz
sh: which: command not found
sh: which: command not found
Node.js not installed. Please download and install Node.js https://nodejs.org/en/download/
Exiting!

The command '/bin/sh -c PRECOMPILE_ASSETS_FLAG=true RAILS_GROUPS=assets bundle exec rake assets:precompile' returned a non-zero code: 1
```

The final message indicates that **Node.js** is not installed which is incorrect. Node is already installed and working, the problem here is my Centos image doesn't have the "**which**" command activated/installed.

According to the GNU error codes:  https://www.gnu.org/software/libc/manual/html_node/Error-Codes.html
The error `Errno::ENOSYS` will be more accurate for this sceneario.

> Macro: int ENOSYS
“Function not implemented.” This indicates that the function called is not implemented at all, either in the C library itself or in the operating system.
