### PR TITLE
Use `exist?` instead of deprecated `exists?`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -110,6 +110,9 @@ Layout/TrailingWhitespace:
 Style/RedundantPercentQ:
   Enabled: true
 
+Lint/DeprecatedClassMethods:
+  Enabled: true
+
 # Align `end` with the matching keyword or starting expression except for
 # assignments, where it should be aligned with the LHS.
 Layout/EndAlignment:

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -5,7 +5,7 @@ copy_file "#{__dir__}/package.json", "package.json"
 say "Copying webpack core config"
 directory "#{__dir__}/config/webpack", "config/webpack"
 
-if Dir.exists?(Webpacker.config.source_path)
+if Dir.exist?(Webpacker.config.source_path)
   say "The packs app source directory already exists"
 else
   say "Creating packs app source directory"
@@ -16,7 +16,7 @@ end
 apply "#{__dir__}/binstubs.rb"
 
 git_ignore_path = Rails.root.join(".gitignore")
-if File.exists?(git_ignore_path)
+if File.exist?(git_ignore_path)
   append_to_file git_ignore_path do
     "\n"                   +
     "/public/packs\n"      +


### PR DESCRIPTION
`Dir.exists?` and `File.exists? were removed by https://github.com/ruby/ruby/pull/5352.
It will be the following error in Ruby 3.2.

```console
% ruby -ve 'File.exists?("foo.rb")'
ruby 3.2.0dev (2021-12-28T15:22:18Z master 39b3aa4fb3) [x86_64-darwin19]
-e:1:in `<main>': undefined method `exists?' for File:Class (NoMethodError)

File.exists?("foo.rb")
    ^^^^^^^^
Did you mean?  exist?
```

And this PR enables `Lint/DeprecatedClassMethods` cop to detect these deprecated methods.