### PR TITLE
Suppress RuboCop offense to fix broken build

### DIFF
--- a/lib/webpacker/manifest.rb
+++ b/lib/webpacker/manifest.rb
@@ -105,7 +105,7 @@ class Webpacker::Manifest
     def missing_file_from_manifest_error(bundle_name)
       <<-MSG
 Webpacker can't find #{bundle_name} in #{config.public_manifest_path}. Possible causes:
-1. You forgot to install node packages (try `yarn install`) or are running an incompatible version of Node 
+1. You forgot to install node packages (try `yarn install`) or are running an incompatible version of Node
 2. Your app has code with a non-standard extension (like a `.jsx` file) but the extension is not in the `extensions` config in `config/webpacker.yml`
 3. You have set compile: false (see `config/webpacker.yml`) for this environment
    (unless you are using the `webpack -w` or the webpack-dev-server, in which case maybe you aren't running the dev server in the background?)


### PR DESCRIPTION
Follow up to https://github.com/rails/webpacker/pull/3232.

This PR suppresses the following RuboCop offense.

```console
% bundle exec rubocop
(snip)

lib/webpacker/manifest.rb:108:107: C: [Correctable]
Layout/TrailingWhitespace: Trailing whitespace detected.
1. You forgot to install node packages (try `yarn install`) or are
running an incompatible version of Node
                                       ^

64 files inspected, 1 offense detected, 1 offense auto-correctable
Error: Process completed with exit code 1.
```

https://github.com/rails/webpacker/runs/4651343194