### PR TITLE
Add Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+A bug is a crash or incorrect behavior. If you have a debugging or troubleshooting question, please open a discussion on the [Rails forum, category webpacker](https://discuss.rubyonrails.org/c/webpacker/10)
+
+Ruby version:
+Rails version:
+Webpacker version:
+
+Expected behavior:
+
+Actual behavior:
+
+Small, reproducible repo:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a report for a crash or unexpected behavior.
 title: ''
 labels: 'bug'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Bug report
+about: Create a request for new functionality
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+A feature request is describes a suggested improvement. If you have a debugging or troubleshooting question, please open a discussion on the [Rails forum, category webpacker](https://discuss.rubyonrails.org/c/webpacker/10)
+
+Ruby version:
+Rails version:
+Webpacker version:
+
+Desired behavior:
+
+Actual behavior:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ leaving Webpack responsible solely for app-like JavaScript, or it can be used ex
 
 **NOTE:** The master branch now hosts the code for v6.x.x. Please refer to [5-x-stable](https://github.com/rails/webpacker/tree/5-x-stable) branch for 5.x documentation.
 
+Pleaes see the [new rails/webpacker discussion forum](https://discuss.rubyonrails.org/c/webpacker/10) to discuss debugging and troubleshooting tips. Please open issues for bugs and feature requests.
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 


### PR DESCRIPTION
These can redirect support requests to https://discuss.rubyonrails.org/c/webpacker/10.

I also updated the README with this suggestion.