### PR TITLE
Binstub checker message is misleading

### DIFF
--- a/lib/tasks/webpacker/check_binstubs.rake
+++ b/lib/tasks/webpacker/check_binstubs.rake
@@ -2,7 +2,7 @@ namespace :webpacker do
   desc "Verifies that bin/webpacker is present"
   task :check_binstubs do
     unless File.exist?(Rails.root.join("bin/webpacker"))
-      $stderr.puts "webpack binstub not found.\n"\
+      $stderr.puts "webpacker binstub not found.\n"\
            "Have you run rails webpacker:install ?\n"\
            "Make sure the bin directory and bin/webpacker are not included in .gitignore\n"\
            "Exiting!"


### PR DESCRIPTION
While it's looking for a file with name `webpacker` it still reports a file with name `webpack`.