### PR TITLE
Specify webpack-dev-server to be v3

### DIFF
--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -43,7 +43,7 @@ else
 end
 
 say "Installing dev server for live reloading"
-run "yarn add --dev webpack-dev-server"
+run "yarn add --dev webpack-dev-server@^3"
 
 if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR > 1
   say "You need to allow webpack-dev-server host as allowed origin for connect-src.", :yellow


### PR DESCRIPTION
same as https://github.com/rails/webpacker/pull/3121. when using Webpacker v4, it will install webpack-dev-server@4.8.1 which then requires `@webpack-cli/serve` to also be installed to properly run `bin/webpack-dev-server`.