### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -2,6 +2,9 @@ name: Jest specs
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   jest:
     name: Jest specs

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -2,6 +2,9 @@ name: JS lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   js-lint:
     name: JS Lint

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -2,6 +2,9 @@ name: Rubocop
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   rubocop:
     name: Rubocop

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -2,6 +2,9 @@ name: Ruby specs
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Ruby specs


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
