### PR TITLE
update upgrading guide to suggest webpack-dev-server@3

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ You can run following commands to upgrade Webpacker to the latest stable version
 bundle update webpacker
 rails webpacker:binstubs
 yarn upgrade @rails/webpacker --latest
-yarn upgrade webpack-dev-server --latest
+yarn upgrade webpack-dev-server@^3
 
 # Or to install the latest release (including pre-releases)
 yarn add @rails/webpacker@next


### PR DESCRIPTION
As per https://github.com/rails/webpacker/pull/3121

updating webpack-dev-server will result in version 4 which causes breakage that is hard to debug. Update readme to only update webpack-dev-server within version 3 to prevent developers from having to debug the issue with webpack-cli/serve