### PR TITLE
Backport #3250 to 5-x-stable branch

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -109,6 +109,9 @@ Layout/TrailingWhitespace:
 Style/RedundantPercentQ:
   Enabled: true
 
+Lint/DeprecatedClassMethods:
+  Enabled: true
+
 # Align `end` with the matching keyword or starting expression except for
 # assignments, where it should be aligned with the LHS.
 Layout/EndAlignment:

--- a/lib/install/template.rb
+++ b/lib/install/template.rb
@@ -13,7 +13,7 @@ copy_file "#{__dir__}/config/babel.config.js", "babel.config.js"
 say "Copying .browserslistrc to app root directory"
 copy_file "#{__dir__}/config/.browserslistrc", ".browserslistrc"
 
-if Dir.exists?(Webpacker.config.source_path)
+if Dir.exist?(Webpacker.config.source_path)
   say "The JavaScript app source directory already exists"
 else
   say "Creating JavaScript app source directory"
@@ -22,7 +22,7 @@ end
 
 apply "#{__dir__}/binstubs.rb"
 
-if File.exists?(".gitignore")
+if File.exist?(".gitignore")
   append_to_file ".gitignore" do
     "\n"                   +
     "/public/packs\n"      +


### PR DESCRIPTION
Currently released stable version of webpacker (5.4.3) does not work on the newest stable Ruby (3.2.0) because webpacker 5.4.3 includes `Dir.exists?` and `File.exists?` that were removed in Ruby 3.2.

Hence, the current situation is that Rails 6.1 users cannot upgrade to Ruby 3.2 because there's no webpacker that supports that versions stack. We could solve this situation by backporting a single commit from #3250.

Please consider merging this and cutting the version 5.4.4 release from 5-x-stable branch. Then probably people would stop complaining to the Ruby-core on the Ruby BTS about this error from webpacker... https://bugs.ruby-lang.org/issues/19352

Closes #3299