### PR TITLE
fix babel.config.js for babel v7.22.0

### DIFF
--- a/lib/install/config/babel.config.js
+++ b/lib/install/config/babel.config.js
@@ -42,25 +42,25 @@ module.exports = function(api) {
       isTestEnv && 'babel-plugin-dynamic-import-node',
       '@babel/plugin-transform-destructuring',
       [
-        '@babel/plugin-proposal-class-properties',
+        '@babel/plugin-transform-class-properties',
         {
           loose: true
         }
       ],
       [
-        '@babel/plugin-proposal-object-rest-spread',
+        '@babel/plugin-transform-object-rest-spread',
         {
           useBuiltIns: true
         }
       ],
       [
-        '@babel/plugin-proposal-private-methods',
+        '@babel/plugin-transform-private-methods',
         {
           loose: true
         }
       ],
       [
-        '@babel/plugin-proposal-private-property-in-object',
+        '@babel/plugin-transform-private-property-in-object',
         {
           loose: true
         }


### PR DESCRIPTION
With the [update to babel v7.22.0 on May 26, 2023](https://github.com/babel/babel/blob/main/CHANGELOG.md#v7220-2023-05-26), several `-proposal-` plugins were changed to `-transform-`.

This caused a difference between the webpacker's babel.config.js copied when executing webpacker:install and the package name installed by yarn, which caused WebPacker to raise a ManifestError when displaying the view file in rails 6.x.
(You can see this problem by creating a new rails 6 app, installing webpacker, creating a controller and view file, and accessing the page.)

This commit is to keep up with the latest version of babel and resolve the above problem.