### PR TITLE
Make connect_timeout work with DNS resolution

### DIFF
--- a/lib/webpacker/dev_server.rb
+++ b/lib/webpacker/dev_server.rb
@@ -13,7 +13,7 @@ class Webpacker::DevServer
 
   def running?
     if config.dev_server.present?
-      Socket.tcp(host, port, connect_timeout: connect_timeout).close
+      Timeout.timeout(connect_timeout) { Socket.tcp(host, port).close }
       true
     else
       false

--- a/lib/webpacker/dev_server_runner.rb
+++ b/lib/webpacker/dev_server_runner.rb
@@ -1,5 +1,6 @@
 require "shellwords"
 require "socket"
+require "timeout"
 require "webpacker/configuration"
 require "webpacker/dev_server"
 require "webpacker/runner"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require "minitest/autorun"
 require "rails"
 require "rails/test_help"
 require "byebug"
+require "ostruct"
 
 require_relative "test_app/config/environment"
 


### PR DESCRIPTION
Before it could timeout the connection process, but it still waits for DNS resolution, in some systems for a long time(e.g. on Alpine I see that connection timeouts only after 5 seconds). 
It's possible to interrupt the name resolution in ruby 3.3+, tested on 3.3.4 (related issue https://bugs.ruby-lang.org/issues/19965)


```
irb(main):029* Benchmark.measure do
irb(main):030*   begin
irb(main):031*     Socket.tcp('host', 8080, connect_timeout: 0.01).close
irb(main):032*   rescue
irb(main):033*     puts 'No connection'
irb(main):034*   end
irb(main):035> end
irb(main):036> 
No connection
=> 
#<Benchmark::Tms:0x00007ff9aa0b7128
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=5.006601492001209,
 @stime=0.00031999999999987594,
 @total=0.0014850000000001806,
 @utime=0.0011650000000003047>
```
```
irb(main):041* Benchmark.measure do
irb(main):042*   begin
irb(main):043*     Timeout.timeout(0.01) { Socket.tcp('host', 8080).close }
irb(main):044*   rescue
irb(main):045*     puts 'No connection'
irb(main):046*   end
irb(main):047> end
irb(main):048> 
No connection
=> 
#<Benchmark::Tms:0x00007ff9a9f27678
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=0.010416228004032746,
 @stime=0.000212000000000101,
 @total=0.0009450000000004177,
 @utime=0.0007330000000003167>
```